### PR TITLE
ci(release): add tag-driven GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+---
+name: Release
+
+on:
+  push:
+    tags: ["v*.*.*"]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: github.repository == 'z-shell/zsh-lint'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Verify semantic tag
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Expected a semantic version tag like v1.2.3, got '${tag}'"
+            exit 1
+          fi
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          if ! gh release view "$tag" >/dev/null 2>&1; then
+            gh release create "$tag" --title "$tag" --generate-notes
+          fi


### PR DESCRIPTION
## Summary
Implements ADR-0007 (release & publication flow) for `zsh-lint`. As a Zsh plugin consumed from source, it has no build artifact — so pushing a `vX.Y.Z` tag creates a GitHub release with auto-generated notes.

Follows the `zunit` tag-driven pattern: SHA-pinned checkout, `contents: write`, `concurrency` with `cancel-in-progress: false`, semantic-tag validation via `GITHUB_REF_NAME` (no untrusted interpolation). Idempotent (skips if the release already exists).

Closes zsh-lint#21. Companion: z-shell/.github#430 (ADR-0007).

## Test plan
- [ ] Trunk / zsh-n green on this PR
- [ ] On a future `vX.Y.Z` tag push: release is created with generated notes