### PR TITLE
feat(reboot): bootstrap Go semantic-analyzer skeleton (#5)

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -1,0 +1,36 @@
+---
+name: Go CI
+
+on:
+  push:
+    branches: [main]
+    paths: ["**/*.go", "go.mod", "go.sum", ".github/workflows/go-ci.yml"]
+  pull_request:
+    paths: ["**/*.go", "go.mod", "go.sum", ".github/workflows/go-ci.yml"]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: ⎔ Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: "1.23"
+      - name: ⬇️ Download modules
+        run: go mod download
+      - name: 🔎 Vet
+        run: go vet ./...
+      - name: 🏗 Build
+        run: go build ./...
+      - name: 🧪 Test
+        run: go test ./...

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: ⎔ Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.23"
+          go-version: "1.25"
       - name: ⬇️ Resolve modules
         run: go mod tidy
       - name: 🔎 Vet

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -26,8 +26,8 @@ jobs:
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.23"
-      - name: ⬇️ Download modules
-        run: go mod download
+      - name: ⬇️ Resolve modules
+        run: go mod tidy
       - name: 🔎 Vet
         run: go vet ./...
       - name: 🏗 Build

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,10 @@ doc/zsdoc/data
 *.cmd
 .tmp_versions/
 modules.order
+
+# Go module files must be tracked (the broad *.mod* rule above would hide go.mod)
+!go.mod
+!go.sum
 Module.symvers
 Mkfile.old
 dkms.conf

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 A Zi-aware linter for Zsh configuration and scripting.
 
+> 🚧 **Reboot in progress.** `zsh-lint` is being rebooted as a **Go-based semantic
+> analyzer** for Zsh (see [#5](https://github.com/z-shell/zsh-lint/issues/5)). The
+> Go foundation lives under `cmd/` and `internal/`; the parser front end uses
+> [`mvdan/sh`](https://github.com/mvdan/sh). The legacy Zsh plugin
+> (`zsh-lint.plugin.zsh`, `functions/`) is still present and will be moved out of
+> the active product surface as the reboot progresses.
+
 ## 📖 Documentation
 
 The canonical documentation for `zsh-lint`, including installation and usage guides, has moved to the **Z-Shell Wiki**:

--- a/cmd/zsh-lint/main.go
+++ b/cmd/zsh-lint/main.go
@@ -1,0 +1,43 @@
+// Command zsh-lint is the entry point for the rebooted Zsh semantic analyzer.
+//
+// In the reboot's parser-evaluation phase (issues #5, #8) it parses each given
+// file with the mvdan/sh front end and reports parse success or the first error,
+// so real-world Zsh corpora can be surveyed for parser gaps. Rule diagnostics
+// (issue #18) build on this foundation.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/z-shell/zsh-lint/internal/parse"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: zsh-lint <file.zsh> [file.zsh ...]")
+		os.Exit(2)
+	}
+
+	exitCode := 0
+	for _, name := range os.Args[1:] {
+		if err := parseFile(name); err != nil {
+			fmt.Printf("FAIL %s: %v\n", name, err)
+			exitCode = 1
+			continue
+		}
+		fmt.Printf("OK   %s\n", name)
+	}
+	os.Exit(exitCode)
+}
+
+func parseFile(name string) error {
+	f, err := os.Open(name)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = parse.Parse(f, name)
+	return err
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/z-shell/zsh-lint
+
+go 1.23
+
+require mvdan.cc/sh/v3 v3.13.1

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/z-shell/zsh-lint
 
-go 1.23
+go 1.25.0
 
 require mvdan.cc/sh/v3 v3.13.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
+github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
+github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+mvdan.cc/sh/v3 v3.13.1 h1:DP3TfgZhDkT7lerUdnp6PTGKyxxzz6T+cOlY/xEvfWk=
+mvdan.cc/sh/v3 v3.13.1/go.mod h1:lXJ8SexMvEVcHCoDvAGLZgFJ9Wsm2sulmoNEXGhYZD0=

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -1,0 +1,26 @@
+// Package parse wraps the mvdan.cc/sh parser as the analyzer's front end.
+//
+// mvdan/sh has no dedicated Zsh dialect, so the reboot uses the Bash variant as
+// the closest available grammar and records Zsh-specific gaps from real code
+// (see issues #8, #11–#16). Isolating the front end here lets it be swapped
+// later (e.g. tree-sitter-zsh, issue #17) without touching callers.
+package parse
+
+import (
+	"io"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// File is the parsed syntax tree produced by the front end.
+type File = syntax.File
+
+// Parse parses a single Zsh/Bash source read from r, using name in error
+// messages. It returns the syntax tree or the first parse error.
+func Parse(r io.Reader, name string) (*File, error) {
+	parser := syntax.NewParser(
+		syntax.KeepComments(true),
+		syntax.Variant(syntax.LangBash),
+	)
+	return parser.Parse(r, name)
+}

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -12,15 +12,21 @@ import (
 	"mvdan.cc/sh/v3/syntax"
 )
 
-// File is the parsed syntax tree produced by the front end.
-type File = syntax.File
+// File is the parsed source produced by the front end.
+type File struct {
+	tree *syntax.File
+}
 
 // Parse parses a single Zsh/Bash source read from r, using name in error
-// messages. It returns the syntax tree or the first parse error.
+// messages. It returns the parsed source or the first parse error.
 func Parse(r io.Reader, name string) (*File, error) {
 	parser := syntax.NewParser(
 		syntax.KeepComments(true),
 		syntax.Variant(syntax.LangBash),
 	)
-	return parser.Parse(r, name)
+	tree, err := parser.Parse(r, name)
+	if err != nil {
+		return nil, err
+	}
+	return &File{tree: tree}, nil
 }

--- a/internal/parse/parse_test.go
+++ b/internal/parse/parse_test.go
@@ -1,0 +1,32 @@
+package parse
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestParseValid(t *testing.T) {
+	const src = "print -r -- hello\nfor x in a b c; do print -r -- \"$x\"; done\n"
+	if _, err := Parse(strings.NewReader(src), "valid.zsh"); err != nil {
+		t.Fatalf("expected a valid parse, got error: %v", err)
+	}
+}
+
+func TestParseError(t *testing.T) {
+	const src = "if true; then\n" // unterminated: missing `fi`
+	if _, err := Parse(strings.NewReader(src), "invalid.zsh"); err == nil {
+		t.Fatal("expected a parse error for an unterminated `if`, got nil")
+	}
+}
+
+func TestParseFixture(t *testing.T) {
+	f, err := os.Open("testdata/sample.zsh")
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer f.Close()
+	if _, err := Parse(f, "sample.zsh"); err != nil {
+		t.Fatalf("expected fixture to parse, got error: %v", err)
+	}
+}

--- a/internal/parse/testdata/sample.zsh
+++ b/internal/parse/testdata/sample.zsh
@@ -1,0 +1,7 @@
+#!/usr/bin/env zsh
+# Minimal fixture for the parser-evaluation harness.
+local name="world"
+print -r -- "hello, ${name}"
+for i in 1 2 3; do
+  print -r -- "count: ${i}"
+done


### PR DESCRIPTION
## Summary
First foundation step of the **zsh-lint reboot** (ZSH-3 / #5): a minimal, **additive** Go skeleton.

- `go.mod` / `go.sum` — module `github.com/z-shell/zsh-lint`, Go 1.25, `mvdan.cc/sh/v3 v3.13.1`.
- `internal/parse` — front end isolated behind `parse.Parse(...)` (mvdan/sh, Bash variant as the closest grammar; swappable later per #17). Fixtures + tests.
- `cmd/zsh-lint` — parser-evaluation harness: parse files, report OK/FAIL (feeds the #8 corpus survey).
- `.github/workflows/go-ci.yml` — `go vet` / build / test; SHA-pinned, permissions: `contents: read`, concurrency.
- README reboot banner.

Scope kept tight: the **legacy plugin stays in place**; moving it out of the product surface (the other half of #5) is a focused follow-up.

## Notes / caveats
- `mvdan.cc/sh/v3 v3.13.1` requires Go 1.25, so the module and CI now target Go 1.25.
- `parse.File` is intentionally opaque for now so callers do not depend directly on mvdan/sh AST types before the parser ADR.

## Test plan
- [x] `go mod tidy`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go run ./cmd/zsh-lint internal/parse/testdata/sample.zsh` → `OK`
- [ ] GitHub Actions green after latest push