### PR TITLE
fix(wikidoc): reject empty markers; restore root README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,9 @@ hand-edit the generated region there. Regenerate locally with:
 
     go tool gomarkdoc --output ref.md ./cmd/zsh-lint ./internal/survey
 
-`docs/README.md` is a thin landing page that points to the wiki.
+The root `README.md` is a minimal signpost for the GitHub landing page;
+`docs/README.md` holds the repo-local pointers and contributor quickstart. Both
+point at the wiki as the canonical reading surface.
 
 ## Build & test
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Zsh Lint
+
+A Go-based semantic analyzer for Zsh (reboot in progress, see
+[#5](https://github.com/z-shell/zsh-lint/issues/5)). It currently operates as a
+parser-survey tool; no lint rules yet.
+
+📖 **Canonical docs live on the Z-Shell Wiki:**
+**[wiki.zshell.dev — Zsh Lint](https://wiki.zshell.dev/ecosystem/plugins/zsh_lint)**
+
+For repo-local pointers and the contributor quickstart, see
+[`docs/README.md`](docs/README.md).
+
+## License
+
+Copyright (c) 2021 Z-Shell Community. Licensed under the GPL-3.0 License.

--- a/internal/wikidoc/wikidoc.go
+++ b/internal/wikidoc/wikidoc.go
@@ -91,9 +91,17 @@ func escapeLine(line string) string {
 // block, surrounded by blank lines, and returns the result. The markers
 // themselves are preserved. The end marker is searched for only after the start
 // marker, so an unrelated occurrence of the end-marker token earlier in the
-// document is ignored. Returns an error (prefixed "wikidoc:") if the start
-// marker is missing, or if no end marker is found after the start marker.
+// document is ignored. Returns an error (prefixed "wikidoc:") if either marker
+// is empty, if the start marker is missing, or if no end marker is found after
+// the start marker.
+//
+// Empty markers are rejected explicitly: strings.Index(s, "") returns 0, so an
+// empty marker would otherwise silently anchor at the start of the document and
+// corrupt the target file rather than failing loudly.
 func Inject(mdx, block, startMarker, endMarker string) (string, error) {
+	if startMarker == "" || endMarker == "" {
+		return "", fmt.Errorf("wikidoc: start and end markers must be non-empty")
+	}
 	startIdx := strings.Index(mdx, startMarker)
 	if startIdx < 0 {
 		return "", fmt.Errorf("wikidoc: start marker %q not found", startMarker)

--- a/internal/wikidoc/wikidoc_test.go
+++ b/internal/wikidoc/wikidoc_test.go
@@ -107,6 +107,33 @@ func TestInject_EndMarkerTokenAlsoBeforeStart(t *testing.T) {
 	}
 }
 
+// TestInject_EmptyMarkers verifies that empty start/end markers are rejected
+// rather than silently anchoring at index 0 (strings.Index(s, "") == 0).
+func TestInject_EmptyMarkers(t *testing.T) {
+	const start = "{/* zsh-lint:generated:start */}"
+	const end = "{/* zsh-lint:generated:end */}"
+	mdx := "# Title\n\n" + start + "\nOLD\n" + end + "\n"
+	cases := []struct {
+		name       string
+		start, end string
+	}{
+		{"empty start", "", end},
+		{"empty end", start, ""},
+		{"both empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := wikidoc.Inject(mdx, "NEW", tc.start, tc.end)
+			if err == nil {
+				t.Fatal("Inject should return error for empty marker")
+			}
+			if !strings.HasPrefix(err.Error(), "wikidoc:") {
+				t.Errorf("error should be prefixed 'wikidoc:'; got: %v", err)
+			}
+		})
+	}
+}
+
 // TestSanitize_RemoveHTMLComment verifies that the gomarkdoc-generated header comment
 // is stripped and surrounding content is preserved.
 func TestSanitize_RemoveHTMLComment(t *testing.T) {


### PR DESCRIPTION
## Summary

Incremental follow-up to the docs-sync pipeline (#30), addressing the three
Copilot review threads that were raised after that PR merged into `next`.

- **`Inject` rejects empty markers.** `strings.Index(s, "")` returns `0`, so an
  empty `-start`/`-end` marker would have silently anchored injection at the
  start of the target `.mdx` and corrupted it. `Inject` now returns
  `wikidoc: start and end markers must be non-empty`. Added table-driven test
  coverage (`TestInject_EmptyMarkers`).
- **Restore a minimal root `README.md`** as a GitHub landing-page signpost that
  points at the canonical wiki page and `docs/README.md` (without it the repo
  landing page and Go pkg/search entry points surfaced nothing).
- **AGENTS.md** now describes both README surfaces.

Supersedes the stale duplicate PR #31, whose branch
(`feature-zsh5-docs-sync`) had diverged from `next` after #30 merged.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...`
- [x] `TestInject_EmptyMarkers` covers empty start / empty end / both empty