### PR TITLE
fix(wikidoc): doubled error prefix; document survey Run output

### DIFF
--- a/cmd/wikidoc/main.go
+++ b/cmd/wikidoc/main.go
@@ -49,7 +49,9 @@ func main() {
 
 	result, err := wikidoc.Inject(string(page), sanitized, *startMarker, *endMarker)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "wikidoc: %v\n", err)
+		// Inject already prefixes its errors with "wikidoc:"; print as-is to
+		// avoid a doubled "wikidoc: wikidoc: ..." prefix.
+		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
 

--- a/internal/survey/survey.go
+++ b/internal/survey/survey.go
@@ -17,6 +17,11 @@ import (
 )
 
 // Run parses each file in names, writing per-file status and a summary to w.
+//
+// Each file produces either an "OK   <path>" line or a "FAIL <path>" line
+// followed by a greppable "<path>:<line>:<col>: <message>" diagnostic. A final
+// summary line reports the total number of files surveyed, ok, and failed.
+//
 // It returns a process exit code: 0 if every file parsed, 1 otherwise.
 func Run(names []string, w io.Writer) int {
 	var failed int


### PR DESCRIPTION
## Summary

- **Fix doubled `wikidoc:` prefix** — the `wikidoc` CLI wrapped `Inject`'s
  already-prefixed errors, producing `wikidoc: wikidoc: ...`. Addresses the
  Copilot review comment on the promotion PR #34.
- **Document `survey.Run`'s output format** — spell out the OK/FAIL line shapes,
  the greppable diagnostic, and the summary line so the generated wiki reference
  is precise. No behavior change.

The doc-comment change also serves as the first real content delta for the
`wiki-docs-sync` pipeline once this reaches `main`.

## Test plan

- [x] `go build/vet/test`