### PR TITLE
ci: pin actions to Node 24 versions before deadline

### DIFF
--- a/.github/workflows/docs-generate.yml
+++ b/.github/workflows/docs-generate.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: ⎔ Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25"
       - name: 📝 Generate reference Markdown

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: ⎔ Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25"
       - name: ⬇️ Resolve modules

--- a/.github/workflows/parser-survey.yml
+++ b/.github/workflows/parser-survey.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⤵️ Check out the calling repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: target
           # The calling repo's contents are treated as untrusted data (only
@@ -36,14 +36,14 @@ jobs:
           persist-credentials: false
 
       - name: ⤵️ Check out zsh-lint
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: z-shell/zsh-lint
           ref: ${{ inputs['zsh-lint-ref'] }}
           path: zsh-lint
 
       - name: ⎔ Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Verify semantic tag
         run: |
           tag="${GITHUB_REF_NAME}"

--- a/.github/workflows/wiki-docs-sync.yml
+++ b/.github/workflows/wiki-docs-sync.yml
@@ -37,13 +37,13 @@ jobs:
 
       - name: ⤵️ Check out zsh-lint
         if: steps.token.outputs.present == 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: zsh-lint
 
       - name: ⤵️ Check out wiki (next)
         if: steps.token.outputs.present == 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: z-shell/wiki
           ref: next
@@ -53,9 +53,12 @@ jobs:
 
       - name: ⎔ Set up Go
         if: steps.token.outputs.present == 'true'
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25"
+          # zsh-lint is checked out under ./zsh-lint, so point the build cache
+          # at its go.sum instead of the (nonexistent) workspace-root one.
+          cache-dependency-path: zsh-lint/go.sum
 
       - name: 📝 Generate and inject reference
         if: steps.token.outputs.present == 'true'
@@ -68,7 +71,7 @@ jobs:
 
       - name: 🔀 Open or update sync PR
         if: steps.token.outputs.present == 'true'
-        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.WIKI_SYNC_TOKEN }}
           path: wiki

--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -35,7 +35,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: "Set matrix output"
         id: set-matrix
         run: |
@@ -50,7 +50,7 @@ jobs:
       matrix: ${{ fromJSON(needs.zsh-matrix.outputs.matrix) }}
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: "⚡ Install dependencies"
         run: sudo apt update && sudo apt-get install -y zsh && touch ~/.zshrc
       - name: "⚡ zsh -n: ${{ matrix.file }}"


### PR DESCRIPTION
## Summary

GitHub forces Node 20 actions onto the Node 24 runtime starting **2026-06-02**
(flagged as annotations on the recent `wiki-docs-sync` run). Bump all pinned
actions to their current Node 24-native releases, full-SHA pinned and verified
against upstream release tags:

| Action | Was | Now |
| --- | --- | --- |
| `actions/checkout` | v4 (`34e1148`) | **v6.0.2** (`de0fac2`) |
| `actions/setup-go` | v5 (`40f1582`) | **v6.4.0** (`4a36011`) |
| `peter-evans/create-pull-request` | v7.0.11 (`22a9089`) | **v8.1.1** (`5f6978f`) |

`create-pull-request` v8 is a runtime-only major bump (no input/behavior
changes per its release notes).

Also:
- Fix two `zsh-n.yml` `checkout` pins that already used the v6 SHA but carried a
  stale `# v4` comment.
- Set `cache-dependency-path: zsh-lint/go.sum` on the wiki-sync `setup-go` step
  (the repo is checked out under `./zsh-lint`, so the default workspace-root
  `go.sum` lookup missed and emitted a cache warning).

## Test plan

- [x] All pins point at SHAs that resolve to the named release tags
- [ ] Trunk (actionlint) passes on this PR