### PR TITLE
feat(diag): renderer-agnostic diagnostics model (#18)

### DIFF
--- a/internal/diag/diag.go
+++ b/internal/diag/diag.go
@@ -1,0 +1,75 @@
+// Package diag defines the analyzer's in-memory diagnostic model: the stable
+// types that rules, suppressions, and output renderers all share.
+//
+// The package imports nothing outside the standard library. That keeps the
+// model both renderer-agnostic (text/JSON formatting lives elsewhere and reuses
+// these types) and parser-agnostic (the front end can be swapped — see issue
+// #17 — with the syntax.Pos → diag.Position adapter living at the parser
+// boundary, not here).
+package diag
+
+// Severity is the advisory level of a diagnostic. Values are ordered
+// Info < Warning < Error so callers can threshold on them (for example, fail a
+// run at Warning or above).
+type Severity int
+
+const (
+	// Info is advisory output that does not indicate a problem.
+	Info Severity = iota
+	// Warning flags a likely issue that does not block.
+	Warning
+	// Error flags a problem that should fail a run.
+	Error
+)
+
+// String returns the lowercase name of the severity, or "unknown" for a value
+// outside the defined vocabulary.
+func (s Severity) String() string {
+	switch s {
+	case Info:
+		return "info"
+	case Warning:
+		return "warning"
+	case Error:
+		return "error"
+	default:
+		return "unknown"
+	}
+}
+
+// Position is a single point in a source file. Line and Col are 1-based; Col
+// counts bytes from the start of the line, matching the parser front end.
+// Offset is the 0-based byte offset from the start of the file. A zero Line
+// means the position is unknown.
+type Position struct {
+	Line   uint
+	Col    uint
+	Offset uint
+}
+
+// Valid reports whether the position refers to a real location, i.e. its Line
+// is set.
+func (p Position) Valid() bool {
+	return p.Line > 0
+}
+
+// Range is a half-open source span [Start, End): Start is the first covered
+// position and End is the position just past the last covered byte.
+type Range struct {
+	Start Position
+	End   Position
+}
+
+// RuleID is a stable, greppable identifier for the rule that produced a
+// diagnostic (for example "ZL0001").
+type RuleID string
+
+// Diagnostic is one analyzer finding. It is self-contained: it carries its own
+// file path so a renderer needs no external lookup to report it.
+type Diagnostic struct {
+	Path     string
+	Range    Range
+	Severity Severity
+	Rule     RuleID
+	Message  string
+}

--- a/internal/diag/diag_test.go
+++ b/internal/diag/diag_test.go
@@ -1,0 +1,83 @@
+package diag
+
+import "testing"
+
+func TestSeverityString(t *testing.T) {
+	tests := []struct {
+		name string
+		sev  Severity
+		want string
+	}{
+		{"info", Info, "info"},
+		{"warning", Warning, "warning"},
+		{"error", Error, "error"},
+		{"unknown", Severity(99), "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.sev.String(); got != tt.want {
+				t.Errorf("Severity(%d).String() = %q, want %q", tt.sev, got, tt.want)
+			}
+		})
+	}
+}
+
+// The severity vocabulary is ordered so callers can compare levels
+// (e.g. "fail the build at Warning or above"). Lock the ordering.
+func TestSeverityOrdering(t *testing.T) {
+	if !(Info < Warning && Warning < Error) {
+		t.Fatalf("severity ordering broken: want Info(%d) < Warning(%d) < Error(%d)",
+			Info, Warning, Error)
+	}
+}
+
+func TestPositionValid(t *testing.T) {
+	tests := []struct {
+		name string
+		pos  Position
+		want bool
+	}{
+		{"first line is valid", Position{Line: 1, Col: 1, Offset: 0}, true},
+		{"zero value is invalid", Position{}, false},
+		{"offset without line is invalid", Position{Offset: 42}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.pos.Valid(); got != tt.want {
+				t.Errorf("Position%+v.Valid() = %v, want %v", tt.pos, got, tt.want)
+			}
+		})
+	}
+}
+
+// A Diagnostic is a plain value: every field is set by the producer and read
+// back by a renderer with no external lookup. This proves the model is usable
+// and self-contained (no parser or renderer dependency).
+func TestDiagnosticValue(t *testing.T) {
+	d := Diagnostic{
+		Path:     "plugin.zsh",
+		Range:    Range{Start: Position{Line: 3, Col: 5, Offset: 40}, End: Position{Line: 3, Col: 9, Offset: 44}},
+		Severity: Warning,
+		Rule:     RuleID("ZL0001"),
+		Message:  "example finding",
+	}
+
+	if d.Path != "plugin.zsh" {
+		t.Errorf("Path = %q, want %q", d.Path, "plugin.zsh")
+	}
+	if d.Severity != Warning {
+		t.Errorf("Severity = %v, want %v", d.Severity, Warning)
+	}
+	if d.Rule != RuleID("ZL0001") {
+		t.Errorf("Rule = %q, want %q", d.Rule, "ZL0001")
+	}
+	if d.Message != "example finding" {
+		t.Errorf("Message = %q, want %q", d.Message, "example finding")
+	}
+	if !d.Range.Start.Valid() || !d.Range.End.Valid() {
+		t.Errorf("Range endpoints should be valid, got %+v", d.Range)
+	}
+	if d.Range.Start.Offset != 40 || d.Range.End.Offset != 44 {
+		t.Errorf("Range offsets = %d..%d, want 40..44", d.Range.Start.Offset, d.Range.End.Offset)
+	}
+}


### PR DESCRIPTION
Implements **#18** (epic: ZSH-3) — the core in-memory diagnostic model that later rules, suppressions, and output renderers will share.

## What

New `internal/diag` package, standard-library-only:

- `Severity` — explicit ordered vocabulary `Info < Warning < Error`, with `String()` and an `unknown` fallback.
- `Position` — 1-based `Line`/`Col`, 0-based `Offset`, `Valid()` helper.
- `Range` — half-open span `[Start, End)`.
- `RuleID` — stable greppable rule identifier.
- `Diagnostic` — self-contained finding (`Path`, `Range`, `Severity`, `Rule`, `Message`).

## Acceptance criteria (#18)

- [x] Focused internal diagnostics package exists.
- [x] Represents stable rule ID, severity, message, source range.
- [x] Severity vocabulary explicit and tested (incl. ordering + unknown fallback).
- [x] Renderer-agnostic — imports nothing outside stdlib, so it's also parser-agnostic (the `syntax.Pos → diag.Position` adapter will live at the parser boundary, supporting the front-end swap in #17).

## Deliberately out of scope (YAGNI / tracked elsewhere)

- No `Diagnostic.String()` / text / JSON rendering — renderers are later work; the model must not prejudge output format.
- No `syntax.Pos → diag.Position` adapter — lands with the first rule wiring.
- No `Off`/`None` severity / suppression — #19.
- No `Diagnostics` collection + deterministic sort — natural next step once a runner needs ordered output.

## Verification

`go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l` all clean. New `diag` tests pass; existing `parse`/`survey`/`wikidoc` suites unaffected.

Design spec: `management/superpowers/specs/2026-05-29-zsh-lint-diagnostics-model-design.md` (workspace).

---

### Epic (ZSH-3) status note

While picking this up I reconciled the tracker against GitHub. For maintainer visibility:

- **#5** (skeleton) — CLOSED (PR #26).
- **Legacy demotion** (epic remaining item 1) — DONE via PR #27.
- **Parser-survey CLI + reusable workflow** — DONE (PR #27).
- **code→wiki docs-sync pipeline** — DONE end-to-end (producer #29/#30/#34; wiki #753/#755; sync PR #756 merged).
- **#18 diagnostics model** — this PR.
- Remaining: #8/#17 (corpus eval + parser ADR), #7/#19/#20 (rule schema / suppression / output contract), #11–#16 (parser gaps). Cosmetic follow-up: #33 (generated H1s invert wiki TOC).