### PR TITLE
ci(wiki-sync): sign generated commits for required-signatures

### DIFF
--- a/.github/workflows/wiki-docs-sync.yml
+++ b/.github/workflows/wiki-docs-sync.yml
@@ -75,6 +75,10 @@ jobs:
         with:
           token: ${{ secrets.WIKI_SYNC_TOKEN }}
           path: wiki
+          # Create commits via the GitHub API so they are signed/verified. The
+          # wiki's next branch requires signed commits, so an unsigned bot commit
+          # cannot be merged without an admin override.
+          sign-commits: true
           base: next
           branch: docs-sync/zsh-lint
           title: "docs(zsh-lint): sync generated reference"


### PR DESCRIPTION
The wiki `next` branch enforces a `required_signatures` ruleset. The docs-sync workflow's `peter-evans/create-pull-request` step produced **unsigned** bot commits, so sync PRs (e.g. wiki #756, #758) were stuck `BLOCKED` and needed admin override.

Set `sign-commits: true` so commits are created via the GitHub API and arrive **verified**, letting sync PRs merge normally.

Complements the wiki-side fix (z-shell/wiki#759, the duplicate "Trunk Check" context, #757).