### PR TITLE
Promote next: sign docs-sync commits

### DIFF
--- a/.github/workflows/wiki-docs-sync.yml
+++ b/.github/workflows/wiki-docs-sync.yml
@@ -75,6 +75,10 @@ jobs:
         with:
           token: ${{ secrets.WIKI_SYNC_TOKEN }}
           path: wiki
+          # Create commits via the GitHub API so they are signed/verified. The
+          # wiki's next branch requires signed commits, so an unsigned bot commit
+          # cannot be merged without an admin override.
+          sign-commits: true
           base: next
           branch: docs-sync/zsh-lint
           title: "docs(zsh-lint): sync generated reference"


### PR DESCRIPTION
Promotes the wiki-docs-sync sign-commits fix (#45) to main so the workflow (run on main / via workflow_dispatch from the default branch) produces verified commits that satisfy the wiki next branch's required_signatures ruleset.