### PR TITLE
ci(wiki-sync): use GitHub App token for signed sync commits

### DIFF
--- a/.github/workflows/wiki-docs-sync.yml
+++ b/.github/workflows/wiki-docs-sync.yml
@@ -23,45 +23,58 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - name: 🔑 Check for sync token
-        id: token
+      # The wiki's next branch enforces required signed commits, so the sync
+      # must commit as a GitHub App bot (PAT-authored commits cannot be signed
+      # by create-pull-request). Provision a GitHub App with Contents:write +
+      # Pull requests:write on z-shell/wiki, install it there, and set the
+      # WIKI_SYNC_APP_ID and WIKI_SYNC_APP_PRIVATE_KEY repository secrets.
+      - name: 🔑 Check for sync app credentials
+        id: app
         env:
-          WIKI_SYNC_TOKEN: ${{ secrets.WIKI_SYNC_TOKEN }}
+          WIKI_SYNC_APP_ID: ${{ secrets.WIKI_SYNC_APP_ID }}
         run: |
-          if [ -n "$WIKI_SYNC_TOKEN" ]; then
+          if [ -n "$WIKI_SYNC_APP_ID" ]; then
             echo "present=true" >> "$GITHUB_OUTPUT"
           else
             echo "present=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::WIKI_SYNC_TOKEN not set; skipping wiki docs sync."
+            echo "::notice::WIKI_SYNC_APP_ID not set; skipping wiki docs sync."
           fi
 
+      - name: 🪪 Mint wiki app token
+        id: app-token
+        if: steps.app.outputs.present == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.WIKI_SYNC_APP_ID }}
+          private-key: ${{ secrets.WIKI_SYNC_APP_PRIVATE_KEY }}
+          owner: z-shell
+          repositories: wiki
+
       - name: ⤵️ Check out zsh-lint
-        if: steps.token.outputs.present == 'true'
+        if: steps.app.outputs.present == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: zsh-lint
 
       - name: ⤵️ Check out wiki (next)
-        if: steps.token.outputs.present == 'true'
+        if: steps.app.outputs.present == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: z-shell/wiki
           ref: next
           path: wiki
-          token: ${{ secrets.WIKI_SYNC_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
 
       - name: ⎔ Set up Go
-        if: steps.token.outputs.present == 'true'
+        if: steps.app.outputs.present == 'true'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25"
-          # zsh-lint is checked out under ./zsh-lint, so point the build cache
-          # at its go.sum instead of the (nonexistent) workspace-root one.
           cache-dependency-path: zsh-lint/go.sum
 
       - name: 📝 Generate and inject reference
-        if: steps.token.outputs.present == 'true'
+        if: steps.app.outputs.present == 'true'
         working-directory: zsh-lint
         run: |
           go tool gomarkdoc --output "$RUNNER_TEMP/ref.md" ./cmd/zsh-lint ./internal/survey
@@ -70,14 +83,14 @@ jobs:
             -mdx ../wiki/ecosystem/plugins/zsh_lint.mdx
 
       - name: 🔀 Open or update sync PR
-        if: steps.token.outputs.present == 'true'
+        if: steps.app.outputs.present == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.WIKI_SYNC_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           path: wiki
-          # Create commits via the GitHub API so they are signed/verified. The
-          # wiki's next branch requires signed commits, so an unsigned bot commit
-          # cannot be merged without an admin override.
+          # The app token lets create-pull-request sign commits as the app bot
+          # (commit signature verification for bots), satisfying the wiki next
+          # branch's required-signatures rule.
           sign-commits: true
           base: next
           branch: docs-sync/zsh-lint


### PR DESCRIPTION
## Why

The wiki `next` branch enforces `required_signatures`. The docs-sync used a fine-grained PAT, and `peter-evans/create-pull-request` **cannot sign PAT-authored commits** (only bot/App tokens), so sync PRs were stuck `BLOCKED` and needed admin overrides (wiki #756/#758/#760).

## What

Authenticate via a **GitHub App installation token** (`actions/create-github-app-token`, scoped to `z-shell/wiki`). `create-pull-request` then signs commits as the app bot → **verified** → satisfies the rule, so sync PRs merge normally.

The job is gated on `WIKI_SYNC_APP_ID`, so it **skips cleanly** until the app is provisioned (no breakage in the meantime).

## Required setup (maintainer)

1. Create a GitHub App (org `z-shell`) with repo permissions **Contents: write** and **Pull requests: write**.
2. Install it on **`z-shell/wiki`**.
3. Add repository secrets to **`z-shell/zsh-lint`**:
   - `WIKI_SYNC_APP_ID` — the App's ID
   - `WIKI_SYNC_APP_PRIVATE_KEY` — the App's private key (PEM)
4. The old `WIKI_SYNC_TOKEN` secret is no longer used and can be removed.

Once set, a `workflow_dispatch` run will open a **signed** sync PR that merges without override.

Complements wiki#759 (duplicate Trunk Check context fix, #757).