### PR TITLE
fix(analyzer): complete review follow-ups

### DIFF
--- a/.github/workflows/docs-generate.yml
+++ b/.github/workflows/docs-generate.yml
@@ -26,6 +26,6 @@ jobs:
         with:
           go-version: "1.25"
       - name: 📝 Generate reference Markdown
-        run: go tool gomarkdoc --output "$RUNNER_TEMP/ref.md" ./cmd/zsh-lint ./internal/survey
+        run: go tool gomarkdoc --output "$RUNNER_TEMP/ref.md" ./cmd/zsh-lint ./cmd/zsh-lint-survey ./internal/survey
       - name: ✅ Verify generation is non-empty
         run: test -s "$RUNNER_TEMP/ref.md"

--- a/.github/workflows/parser-survey.yml
+++ b/.github/workflows/parser-survey.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: 🏗 Build the survey binary
         working-directory: zsh-lint
-        run: go build -o "$RUNNER_TEMP/zsh-lint" ./cmd/zsh-lint
+        run: go build -o "$RUNNER_TEMP/zsh-lint-survey" ./cmd/zsh-lint-survey
 
       - name: 🔎 Survey Zsh files
         working-directory: target
@@ -67,7 +67,7 @@ jobs:
           fi
           echo "Surveying ${#files[@]} file(s)..."
           set +e
-          "$RUNNER_TEMP/zsh-lint" "${files[@]}"
+          "$RUNNER_TEMP/zsh-lint-survey" "${files[@]}"
           status=$?
           set -e
           if [ "$FAIL_ON_PARSE_ERROR" = "true" ]; then

--- a/.github/workflows/wiki-docs-sync.yml
+++ b/.github/workflows/wiki-docs-sync.yml
@@ -77,10 +77,10 @@ jobs:
         if: steps.app.outputs.present == 'true'
         working-directory: zsh-lint
         run: |
-          go tool gomarkdoc --output "$RUNNER_TEMP/ref.md" ./cmd/zsh-lint ./internal/survey
+          go tool gomarkdoc --output "$RUNNER_TEMP/ref.md" ./cmd/zsh-lint ./cmd/zsh-lint-survey ./internal/survey
           go run ./cmd/wikidoc \
             -in "$RUNNER_TEMP/ref.md" \
-            -mdx ../wiki/ecosystem/plugins/zsh_lint.mdx
+            -mdx ../wiki/community/04_zsh_lint/index.mdx
 
       - name: 🔀 Open or update sync PR
         if: steps.app.outputs.present == 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,18 +4,19 @@ This project follows the organization-wide [Z-Shell Organization Guidelines](htt
 
 ## What this is
 
-`zsh-lint` is being rebooted as a **Go-based semantic analyzer for Zsh** (see
+`zsh-lint` is a **Go-based semantic analyzer for Zsh** (see
 [#5](https://github.com/z-shell/zsh-lint/issues/5)). The active product is the
 Go code under `cmd/` and `internal/`; the parser front end uses
-[`mvdan/sh`](https://github.com/mvdan/sh). It currently operates as a
-**parser-survey** tool and implements no lint rules yet.
+[`mvdan/sh`](https://github.com/mvdan/sh). The CLI runs a default set of
+static-analysis rules and reports greppable diagnostics.
 
 The original interactive Zi/`.zshrc` plugin lives under `legacy/` and is **not**
 part of the active product surface.
 
 ## Layout
 
-- `cmd/zsh-lint/` — CLI entry point.
+- `cmd/zsh-lint/` — semantic-analyzer CLI entry point.
+- `cmd/zsh-lint-survey/` — parser-gap survey CLI entry point.
 - `internal/parse/` — parser front end (mvdan/sh, swappable).
 - `internal/survey/` — parser-survey core (greppable diagnostics + exit code).
 - `internal/wikidoc/`, `cmd/wikidoc/` — docs-sync tooling (not product code).
@@ -24,11 +25,11 @@ part of the active product surface.
 ## Documentation
 
 Canonical reader docs live on the **wiki**
-(`ecosystem/plugins/zsh_lint`), which is the single reading surface. Code-derived
+(`community/zsh_lint`), which is the single reading surface. Code-derived
 reference is generated from Go doc comments and synced into the wiki — do not
 hand-edit the generated region there. Regenerate locally with:
 
-    go tool gomarkdoc --output ref.md ./cmd/zsh-lint ./internal/survey
+    go tool gomarkdoc --output ref.md ./cmd/zsh-lint ./cmd/zsh-lint-survey ./internal/survey
 
 ## Writing Lint Rules
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Zsh Lint
 
-A Go-based semantic analyzer for Zsh (reboot in progress, see
-[#5](https://github.com/z-shell/zsh-lint/issues/5)). It currently operates as a
-parser-survey tool; no lint rules yet.
+A standalone Go-based semantic analyzer for Zsh (see
+[#5](https://github.com/z-shell/zsh-lint/issues/5)). It parses Zsh scripts and
+reports greppable static-analysis diagnostics.
 
 📖 **Canonical docs live on the Z-Shell Wiki:**
-**[wiki.zshell.dev — Zsh Lint](https://wiki.zshell.dev/ecosystem/plugins/zsh_lint)**
+**[wiki.zshell.dev — Zsh Lint](https://wiki.zshell.dev/community/zsh_lint)**
 
 For repo-local pointers and the contributor quickstart, see
 [`docs/README.md`](docs/README.md).

--- a/cmd/zsh-lint-survey/main.go
+++ b/cmd/zsh-lint-survey/main.go
@@ -1,0 +1,18 @@
+// Command zsh-lint-survey runs the parser front end across Zsh files and
+// reports parser gaps without evaluating static-analysis rules.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/z-shell/zsh-lint/internal/survey"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: zsh-lint-survey <file.zsh> [file.zsh ...]")
+		os.Exit(2)
+	}
+	os.Exit(survey.Run(os.Args[1:], os.Stdout))
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,23 +1,29 @@
 # Zsh Lint
 
-A Go-based semantic analyzer for Zsh (reboot in progress, see
-[#5](https://github.com/z-shell/zsh-lint/issues/5)). It currently operates as a
-parser-survey tool; no lint rules yet.
+A standalone Go-based semantic analyzer for Zsh (see
+[#5](https://github.com/z-shell/zsh-lint/issues/5)). It parses Zsh scripts and
+reports greppable static-analysis diagnostics.
 
 ## Documentation
 
 📖 **Canonical docs live on the Z-Shell Wiki:**
-**[wiki.zshell.dev — Zsh Lint](https://wiki.zshell.dev/ecosystem/plugins/zsh_lint)**
+**[wiki.zshell.dev — Zsh Lint](https://wiki.zshell.dev/community/zsh_lint)**
 
 The wiki is the single reading surface. The reference section there is generated
 from this repo's Go doc comments and kept in sync automatically — do not edit it
 by hand on the wiki.
 
+## Commands
+
+- `zsh-lint` runs the default static-analysis rules.
+- `zsh-lint-survey` reports parser gaps without evaluating lint rules. The
+  reusable `Parser Survey` workflow uses this command for corpus evaluation.
+
 ## For contributors
 
 ```sh
 go build ./... && go vet ./... && go test ./...
-go tool gomarkdoc --output ref.md ./cmd/zsh-lint ./internal/survey   # regenerate reference
+go tool gomarkdoc --output ref.md ./cmd/zsh-lint ./cmd/zsh-lint-survey ./internal/survey   # regenerate reference
 ```
 
 The legacy interactive Zi/`.zshrc` plugin is archived under [`../legacy/`](../legacy/).

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -18,19 +18,20 @@ func New(rules ...Rule) *Analyzer {
 	}
 }
 
-// Analyze runs the semantic analyzer on the parsed file.
-// Per ADR 0011, this runs in two passes: Scope Resolution, then Rule Evaluation.
+// Analyze runs the semantic analyzer on the parsed file. Rules that implement
+// ScopeAwareRule opt into a scope-resolution pass before rule evaluation.
 func (a *Analyzer) Analyze(file *parse.File, path string) diag.Diagnostics {
 	ctx := NewContext(file, path)
+	ast := file.AST()
 
-	// Pass 1: Scope Resolution (Indexer)
-	if ast := file.AST(); ast != nil {
+	// Pass 1: Scope Resolution (Indexer), only when a rule consumes it.
+	if ast != nil && needsScope(a.rules) {
 		ctx.Scope.Index(ast)
 	}
 
 	// Pass 2: Rule Evaluation (Linter)
 	// Traverse the AST and feed each node to the registered rules.
-	if ast := file.AST(); ast != nil {
+	if ast != nil {
 		syntax.Walk(ast, func(node syntax.Node) bool {
 			if node == nil {
 				return true
@@ -44,4 +45,13 @@ func (a *Analyzer) Analyze(file *parse.File, path string) diag.Diagnostics {
 
 	ctx.Diagnostics.Sort()
 	return ctx.Diagnostics
+}
+
+func needsScope(rules []Rule) bool {
+	for _, rule := range rules {
+		if aware, ok := rule.(ScopeAwareRule); ok && aware.NeedsScope() {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -24,6 +24,19 @@ func (r *dummyRule) Analyze(ctx *analyzer.Context, node syntax.Node) {
 	}
 }
 
+type scopeRule struct {
+	sawGlobal bool
+}
+
+func (r *scopeRule) ID() diag.RuleID { return "test/scope" }
+func (r *scopeRule) Name() string    { return "Scope Rule" }
+func (r *scopeRule) NeedsScope() bool {
+	return true
+}
+func (r *scopeRule) Analyze(ctx *analyzer.Context, _ syntax.Node) {
+	r.sawGlobal = ctx.Scope.IsDeclared("global_var", nil)
+}
+
 func TestAnalyzer(t *testing.T) {
 	code := "echo ok\nbadcmd fail\n"
 	file, err := parse.Parse(strings.NewReader(code), "test.zsh")
@@ -47,5 +60,19 @@ func TestAnalyzer(t *testing.T) {
 	}
 	if d.Range.Start.Line != 2 {
 		t.Errorf("expected line 2, got %d", d.Range.Start.Line)
+	}
+}
+
+func TestAnalyzerIndexesScopeForOptInRule(t *testing.T) {
+	file, err := parse.Parse(strings.NewReader("global_var=value\n"), "test.zsh")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	rule := &scopeRule{}
+	analyzer.New(rule).Analyze(file, "test.zsh")
+
+	if !rule.sawGlobal {
+		t.Fatal("scope-aware rule did not receive the declaration index")
 	}
 }

--- a/internal/analyzer/rule.go
+++ b/internal/analyzer/rule.go
@@ -14,3 +14,10 @@ type Rule interface {
 	// Analyze evaluates a syntax node and reports findings to the context.
 	Analyze(ctx *Context, node syntax.Node)
 }
+
+// ScopeAwareRule is implemented by rules that need the declaration index.
+// Most rules inspect syntax only, so the analyzer skips the indexing pass
+// unless at least one registered rule opts in.
+type ScopeAwareRule interface {
+	NeedsScope() bool
+}

--- a/internal/scope/index.go
+++ b/internal/scope/index.go
@@ -29,10 +29,7 @@ func (m *Map) Index(node syntax.Node) {
 			prev := m.currentFunc
 			m.currentFunc = x
 			if x.Body != nil {
-				syntax.Walk(x.Body, func(inner syntax.Node) bool {
-					m.Index(inner)
-					return false // We handle the descent manually to avoid double-walking
-				})
+				m.Index(x.Body)
 			}
 			m.currentFunc = prev
 			return false // We already walked the children
@@ -79,18 +76,12 @@ func (m *Map) Index(node syntax.Node) {
 			}
 			cmdName := extractLiteral(x.Args[0])
 
-			isExport := cmdName == "export"
-			isLocal := cmdName == "local" || cmdName == "typeset" || cmdName == "declare"
 			isAlias := cmdName == "alias"
 
-			if isExport || isLocal {
-				for _, arg := range x.Args[1:] {
-					// We only care if they are actually assignments e.g., local foo=bar
-					// mvdan/sh parses local foo=bar as a CallExpr with Assign elements in Args.
-					// Note: If they just do `local foo`, it's a Word.
-					m.processDeclArg(arg, isExport, isLocal)
-				}
-			} else if isAlias {
+			// Under the Bash parser variant, export/local/typeset/declare are
+			// DeclClause nodes handled above. CallExpr declaration handling
+			// would be unreachable here.
+			if isAlias {
 				for _, arg := range x.Args[1:] {
 					m.processAliasArg(arg)
 				}
@@ -113,36 +104,6 @@ func (m *Map) Index(node syntax.Node) {
 		}
 		return true
 	})
-}
-
-func (m *Map) processDeclArg(arg *syntax.Word, isExport, isLocal bool) {
-	// If it's an assignment like `foo=bar`
-	for _, part := range arg.Parts {
-		if lit, ok := part.(*syntax.Lit); ok {
-			// Naive extraction for `foo=bar` vs `foo`
-			// mvdan/sh might also hand this over as an explicit syntax.Assign inside the CallExpr
-			name := lit.Value
-			// if it has an =, split it (simplification for AST extraction)
-			for i, c := range lit.Value {
-				if c == '=' {
-					name = lit.Value[:i]
-					break
-				}
-			}
-			if name != "" {
-				sym := Symbol{
-					Name:     name,
-					Kind:     KindVariable,
-					Node:     arg,
-					Pos:      arg.Pos(),
-					Exported: isExport,
-					Local:    isLocal,
-				}
-				m.Add(sym)
-				break // Only care about the first literal which holds the var name
-			}
-		}
-	}
 }
 
 func (m *Map) processAliasArg(arg *syntax.Word) {

--- a/internal/wikidoc/wikidoc.go
+++ b/internal/wikidoc/wikidoc.go
@@ -22,6 +22,8 @@ var (
 	reHTMLComment = regexp.MustCompile(`(?s)<!--.*?-->`)
 	reHTMLAnchor  = regexp.MustCompile(`</?a\b[^>]*>`)
 	reAngleLink   = regexp.MustCompile(`\]\(<([^>\s]*)>\)`)
+	reHeading     = regexp.MustCompile(`(?m)^(#{1,6})([ \t]+)`)
+	reAPIHeading  = regexp.MustCompile(`(?m)^#{2,} (func|type|var|const) ([A-Za-z_][A-Za-z0-9_]*)\b.*$`)
 )
 
 // Sanitize transforms a gomarkdoc Markdown string into MDX-safe content by
@@ -33,6 +35,10 @@ var (
 //     and closing <a> tags are stripped (inner text, if any, is preserved).
 //  3. Unwrap angle-bracketed link destinations (](<#Run>) → ](#Run)).
 //  4. Escape bare <, >, {, } on prose lines (not inside fenced or indented code).
+//  5. Demote generated headings by three levels so they nest under the wiki
+//     page's "### Reference" section.
+//  6. Rewrite top-level Go declaration fragment links to Docusaurus slugs, so
+//     gomarkdoc fragment links like #Run resolve as #func-run.
 func Sanitize(md string) string {
 	// Step 1: remove HTML comments.
 	out := reHTMLComment.ReplaceAllString(md, "")
@@ -46,7 +52,34 @@ func Sanitize(md string) string {
 	// Step 4: escape bare MDX special chars on prose lines only.
 	out = escapeProse(out)
 
+	// Step 5: nest generated headings under the page's Reference section.
+	out = demoteHeadings(out)
+
+	// Step 6: target the slugs Docusaurus derives from declaration headings.
+	out = rewriteAPIFragmentLinks(out)
+
 	return out
+}
+
+// demoteHeadings shifts generated Markdown headings down three levels. Markdown
+// has only six heading levels, so deeper input is clamped at h6.
+func demoteHeadings(s string) string {
+	return reHeading.ReplaceAllStringFunc(s, func(heading string) string {
+		hashes := strings.IndexAny(heading, " \t")
+		level := min(hashes+3, 6)
+		return strings.Repeat("#", level) + heading[hashes:]
+	})
+}
+
+// rewriteAPIFragmentLinks rewrites gomarkdoc's top-level declaration links to
+// the slugs Docusaurus derives from headings such as "## func Run".
+func rewriteAPIFragmentLinks(s string) string {
+	for _, match := range reAPIHeading.FindAllStringSubmatch(s, -1) {
+		name := match[2]
+		slug := strings.ToLower(match[1] + "-" + name)
+		s = strings.ReplaceAll(s, "](#"+name+")", "](#"+slug+")")
+	}
+	return s
 }
 
 // escapeProse escapes bare <, >, {, } on non-code lines.

--- a/internal/wikidoc/wikidoc_test.go
+++ b/internal/wikidoc/wikidoc_test.go
@@ -189,6 +189,28 @@ func TestSanitize_UnwrapAngleBracketLinks(t *testing.T) {
 	}
 }
 
+// TestSanitize_RewriteDocusaurusHeadingID verifies gomarkdoc fragment links still
+// resolve after Docusaurus derives heading slugs from API declaration headings.
+func TestSanitize_RewriteDocusaurusHeadingID(t *testing.T) {
+	input := "[func Run](#Run)\n\n## func Run(names []string, w io.Writer) int"
+	got := wikidoc.Sanitize(input)
+	want := "[func Run](#func-run)\n\n##### func Run(names []string, w io.Writer) int"
+	if got != want {
+		t.Errorf("Sanitize(%q) = %q; want %q", input, got, want)
+	}
+}
+
+// TestSanitize_DemoteHeadings verifies generated headings nest beneath the
+// wiki page's h3 Reference section without producing invalid h7 headings.
+func TestSanitize_DemoteHeadings(t *testing.T) {
+	input := "# package\n\n## Index\n\n#### Deep"
+	got := wikidoc.Sanitize(input)
+	want := "#### package\n\n##### Index\n\n###### Deep"
+	if got != want {
+		t.Errorf("Sanitize(%q) = %q; want %q", input, got, want)
+	}
+}
+
 // TestSanitize_EscapeProseChars verifies bare < > { } are escaped on prose lines.
 func TestSanitize_EscapeProseChars(t *testing.T) {
 	input := "usage <file.zsh> {x}"

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -3,4 +3,5 @@
 These files are the original interactive Zi/`.zshrc` editor that predates the
 Go reboot ([#5](https://github.com/z-shell/zsh-lint/issues/5)). They are kept
 for history and are **not** part of the active product surface. The current
-product is the Go parser-survey tool under `cmd/` and `internal/`.
+product is the Go semantic analyzer under `cmd/zsh-lint`; the parser-gap survey
+is available separately under `cmd/zsh-lint-survey`.


### PR DESCRIPTION
## Summary
- gate scope indexing behind an opt-in rule capability and simplify function traversal
- expose parser survey as a dedicated `zsh-lint-survey` command
- retarget wiki docs sync and normalize generated heading hierarchy

## Validation
- `docker run --rm -v "$PWD:/src" -w /src golang:1.25 sh -c 'gofmt -l . && go build ./... && go vet ./... && go test ./...'`\n- smoke-tested `go run ./cmd/zsh-lint-survey internal/survey/testdata/ok.zsh`\n- smoke-tested `go run ./cmd/zsh-lint internal/survey/testdata/ok.zsh`\n\nCloses #33\nCloses #41\nCloses #42\nCloses #43