### PR TITLE
fix(wikidoc): normalize generated markdown indentation

### DIFF
--- a/internal/wikidoc/wikidoc.go
+++ b/internal/wikidoc/wikidoc.go
@@ -34,10 +34,11 @@ var (
 //     <a name="..."></a>; any raw anchor tag is MDX-hostile, so all opening
 //     and closing <a> tags are stripped (inner text, if any, is preserved).
 //  3. Unwrap angle-bracketed link destinations (](<#Run>) → ](#Run)).
-//  4. Escape bare <, >, {, } on prose lines (not inside fenced or indented code).
-//  5. Demote generated headings by three levels so they nest under the wiki
+//  4. Normalize leading tabs to four spaces for Markdown indentation.
+//  5. Escape bare <, >, {, } on prose lines (not inside fenced or indented code).
+//  6. Demote generated headings by three levels so they nest under the wiki
 //     page's "### Reference" section.
-//  6. Rewrite top-level Go declaration fragment links to Docusaurus slugs, so
+//  7. Rewrite top-level Go declaration fragment links to Docusaurus slugs, so
 //     gomarkdoc fragment links like #Run resolve as #func-run.
 func Sanitize(md string) string {
 	// Step 1: remove HTML comments.
@@ -49,16 +50,32 @@ func Sanitize(md string) string {
 	// Step 3: unwrap angle-bracketed link destinations.
 	out = reAngleLink.ReplaceAllString(out, "]($1)")
 
-	// Step 4: escape bare MDX special chars on prose lines only.
+	// Step 4: use spaces for Markdown indentation and repository whitespace.
+	out = normalizeIndent(out)
+
+	// Step 5: escape bare MDX special chars on prose lines only.
 	out = escapeProse(out)
 
-	// Step 5: nest generated headings under the page's Reference section.
+	// Step 6: nest generated headings under the page's Reference section.
 	out = demoteHeadings(out)
 
-	// Step 6: target the slugs Docusaurus derives from declaration headings.
+	// Step 7: target the slugs Docusaurus derives from declaration headings.
 	out = rewriteAPIFragmentLinks(out)
 
 	return out
+}
+
+// normalizeIndent converts leading tabs to four spaces so generated Markdown
+// stays compatible with the wiki repository's whitespace policy.
+func normalizeIndent(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		tabs := len(line) - len(strings.TrimLeft(line, "\t"))
+		if tabs > 0 {
+			lines[i] = strings.Repeat("    ", tabs) + line[tabs:]
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 // demoteHeadings shifts generated Markdown headings down three levels. Markdown

--- a/internal/wikidoc/wikidoc_test.go
+++ b/internal/wikidoc/wikidoc_test.go
@@ -211,6 +211,17 @@ func TestSanitize_DemoteHeadings(t *testing.T) {
 	}
 }
 
+// TestSanitize_NormalizeIndent verifies generated Markdown code indentation
+// uses spaces so wiki whitespace checks accept newly generated lines.
+func TestSanitize_NormalizeIndent(t *testing.T) {
+	input := "\timport \"example.test/pkg\"\n\t\tdeep"
+	got := wikidoc.Sanitize(input)
+	want := "    import \"example.test/pkg\"\n        deep"
+	if got != want {
+		t.Errorf("Sanitize(%q) = %q; want %q", input, got, want)
+	}
+}
+
 // TestSanitize_EscapeProseChars verifies bare < > { } are escaped on prose lines.
 func TestSanitize_EscapeProseChars(t *testing.T) {
 	input := "usage <file.zsh> {x}"
@@ -221,13 +232,14 @@ func TestSanitize_EscapeProseChars(t *testing.T) {
 	}
 }
 
-// TestSanitize_IndentedCodeNotEscaped verifies tab-indented code lines are left verbatim.
+// TestSanitize_IndentedCodeNotEscaped verifies tab-indented code lines are
+// normalized to spaces without escaping their code contents.
 func TestSanitize_IndentedCodeNotEscaped(t *testing.T) {
-	// A tab-indented code line — must NOT be escaped.
 	input := "\tfunc F(a <T>) {}"
 	got := wikidoc.Sanitize(input)
-	if got != input {
-		t.Errorf("Sanitize should not escape tab-indented code; got: %q, want: %q", got, input)
+	want := "    func F(a <T>) {}"
+	if got != want {
+		t.Errorf("Sanitize should normalize but not escape tab-indented code; got: %q, want: %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- normalize leading tabs in gomarkdoc output to four-space Markdown indentation
- keep code contents unescaped while satisfying the wiki repository whitespace policy
- add regression coverage for generated import and code lines

## Validation
- `docker run --rm -v "$PWD:/src" -w /src golang:1.25 sh -c 'gofmt -l . && go build ./... && go vet ./... && go test ./...'`\n- regenerated the wiki Zsh Lint reference and verified `git diff --check`\n\nFollow-up discovered while validating z-shell/wiki#762.