### PR TITLE
feat(corpus): land corpus inventory, survey report, gap fixtures, and workflow docs

### DIFF
--- a/docs/project/2026-06-12-survey.md
+++ b/docs/project/2026-06-12-survey.md
@@ -45,21 +45,21 @@ zunit/build.zsh:16:22: a command can only contain words and redirects; encounter
 
 ## Gap mapping
 
-| File | Failing construct | Diagnostic family | Tracking issue |
-| --- | --- | --- | --- |
-| `z-a-meta-plugins/functions/.za-meta-plugins-before-load-handler:7` | `${=${options[xtrace]:#off}:+-o xtrace}` | expansion flag `${=...}` | [#11](https://github.com/z-shell/zsh-lint/issues/11) |
-| `src/public/zsh/init.zsh:79` | `${(f@)$(...)}` | expansion flags | [#11](https://github.com/z-shell/zsh-lint/issues/11) |
-| `zsh-fancy-completions/functions/.expand-or-complete-with-dots:10` | `${(%)WAITING_DOTS}` | expansion flags | [#11](https://github.com/z-shell/zsh-lint/issues/11) |
-| `zsh-fancy-completions/lib/completion.zsh:76` | `${(s.:.)LS_COLORS}` | expansion flags | [#11](https://github.com/z-shell/zsh-lint/issues/11) |
-| `zd/docker/utils.zsh:26` | `${+_comps}` | `${+name}` operator | [#11](https://github.com/z-shell/zsh-lint/issues/11) ("related operators") |
-| `zd/docker/zshrc:19` | `${+functions[...]}` | `${+name}` operator | [#11](https://github.com/z-shell/zsh-lint/issues/11) |
-| `zsh-fancy-completions/functions/.man_glob:8` | `${+manpath}` | `${+name}` operator | [#11](https://github.com/z-shell/zsh-lint/issues/11) |
-| `zsh-fancy-completions/lib/state.zsh:13` | `${+Plugins[ZF_COMPLETIONS]}` | `${+name}` operator | [#11](https://github.com/z-shell/zsh-lint/issues/11) |
-| `z-a-meta-plugins/z-a-meta-plugins.plugin.zsh:7` | ZERO idiom `${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}` | nested parameter expansion | [#53](https://github.com/z-shell/zsh-lint/issues/53) |
-| `zsh-eza/zsh-eza.plugin.zsh:8` | ZERO idiom (same) | nested parameter expansion | [#53](https://github.com/z-shell/zsh-lint/issues/53) |
-| `zsh-fancy-completions/zsh-fancy-completions.plugin.zsh:5` | ZERO idiom (same) | nested parameter expansion | [#53](https://github.com/z-shell/zsh-lint/issues/53) |
-| `zsh-fancy-completions/functions/.completion-prediction:6` | `zle-line-init() { predict-on }` — `}` without preceding terminator | statement separation / brace termination | [#12](https://github.com/z-shell/zsh-lint/issues/12) |
-| `zunit/build.zsh:16` | `src/**/(^zunit).zsh` | filename-generation pattern | [#16](https://github.com/z-shell/zsh-lint/issues/16) |
+| File                                                                | Failing construct                                                   | Diagnostic family                        | Tracking issue                                                             |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------- | ---------------------------------------- | -------------------------------------------------------------------------- |
+| `z-a-meta-plugins/functions/.za-meta-plugins-before-load-handler:7` | `${=${options[xtrace]:#off}:+-o xtrace}`                            | expansion flag `${=...}`                 | [#11](https://github.com/z-shell/zsh-lint/issues/11)                       |
+| `src/public/zsh/init.zsh:79`                                        | `${(f@)$(...)}`                                                     | expansion flags                          | [#11](https://github.com/z-shell/zsh-lint/issues/11)                       |
+| `zsh-fancy-completions/functions/.expand-or-complete-with-dots:10`  | `${(%)WAITING_DOTS}`                                                | expansion flags                          | [#11](https://github.com/z-shell/zsh-lint/issues/11)                       |
+| `zsh-fancy-completions/lib/completion.zsh:76`                       | `${(s.:.)LS_COLORS}`                                                | expansion flags                          | [#11](https://github.com/z-shell/zsh-lint/issues/11)                       |
+| `zd/docker/utils.zsh:26`                                            | `${+_comps}`                                                        | `${+name}` operator                      | [#11](https://github.com/z-shell/zsh-lint/issues/11) ("related operators") |
+| `zd/docker/zshrc:19`                                                | `${+functions[...]}`                                                | `${+name}` operator                      | [#11](https://github.com/z-shell/zsh-lint/issues/11)                       |
+| `zsh-fancy-completions/functions/.man_glob:8`                       | `${+manpath}`                                                       | `${+name}` operator                      | [#11](https://github.com/z-shell/zsh-lint/issues/11)                       |
+| `zsh-fancy-completions/lib/state.zsh:13`                            | `${+Plugins[ZF_COMPLETIONS]}`                                       | `${+name}` operator                      | [#11](https://github.com/z-shell/zsh-lint/issues/11)                       |
+| `z-a-meta-plugins/z-a-meta-plugins.plugin.zsh:7`                    | ZERO idiom `${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}`             | nested parameter expansion               | [#53](https://github.com/z-shell/zsh-lint/issues/53)                       |
+| `zsh-eza/zsh-eza.plugin.zsh:8`                                      | ZERO idiom (same)                                                   | nested parameter expansion               | [#53](https://github.com/z-shell/zsh-lint/issues/53)                       |
+| `zsh-fancy-completions/zsh-fancy-completions.plugin.zsh:5`          | ZERO idiom (same)                                                   | nested parameter expansion               | [#53](https://github.com/z-shell/zsh-lint/issues/53)                       |
+| `zsh-fancy-completions/functions/.completion-prediction:6`          | `zle-line-init() { predict-on }` — `}` without preceding terminator | statement separation / brace termination | [#12](https://github.com/z-shell/zsh-lint/issues/12)                       |
+| `zunit/build.zsh:16`                                                | `src/**/(^zunit).zsh`                                               | filename-generation pattern              | [#16](https://github.com/z-shell/zsh-lint/issues/16)                       |
 
 ## Notes
 
@@ -76,6 +76,6 @@ zunit/build.zsh:16:22: a command can only contain words and redirects; encounter
   not front-end drift.
 - No reverse-subscript (`[(I)...]`, [#15](https://github.com/z-shell/zsh-lint/issues/15))
   or multi-name-loop ([#13](https://github.com/z-shell/zsh-lint/issues/13))
-  failures surfaced as the *first* error in any file in this run; earlier
+  failures surfaced as the _first_ error in any file in this run; earlier
   errors mask later constructs, so those issues stay open with their original
   observed examples.

--- a/docs/project/2026-06-12-survey.md
+++ b/docs/project/2026-06-12-survey.md
@@ -1,0 +1,81 @@
+# Survey Run — 2026-06-12
+
+- Front end: `mvdan.cc/sh/v3` v3.13.1 (`syntax.LangBash`)
+- Corpus: `docs/project/corpus.md` (this commit) — 19 files across 6 repositories
+- Command: see `docs/project/corpus.md`, "Running the survey"
+
+## Results
+
+```text
+FAIL z-a-meta-plugins/functions/.za-meta-plugins-before-load-handler
+z-a-meta-plugins/functions/.za-meta-plugins-before-load-handler:7:26: invalid parameter name
+OK   z-a-meta-plugins/functions/.za-meta-plugins-meta-cmd
+OK   z-a-meta-plugins/functions/.za-meta-plugins-meta-cmd-help-handler
+FAIL z-a-meta-plugins/z-a-meta-plugins.plugin.zsh
+z-a-meta-plugins/z-a-meta-plugins.plugin.zsh:7:14: nested parameter expansions are a zsh feature; tried parsing as bash
+FAIL src/public/zsh/init.zsh
+src/public/zsh/init.zsh:79:18: parameter expansion flags are a zsh feature; tried parsing as bash
+FAIL zd/docker/utils.zsh
+zd/docker/utils.zsh:26:6: `${+foo}` is a zsh feature; tried parsing as bash
+OK   zd/docker/zshenv
+FAIL zd/docker/zshrc
+zd/docker/zshrc:19:4: `${+foo}` is a zsh feature; tried parsing as bash
+FAIL zsh-eza/zsh-eza.plugin.zsh
+zsh-eza/zsh-eza.plugin.zsh:8:14: nested parameter expansions are a zsh feature; tried parsing as bash
+OK   zsh-fancy-completions/functions/.complete_menu
+FAIL zsh-fancy-completions/functions/.completion-prediction
+zsh-fancy-completions/functions/.completion-prediction:6:17: reached EOF without matching `{` with `}`
+FAIL zsh-fancy-completions/functions/.expand-or-complete-with-dots
+zsh-fancy-completions/functions/.expand-or-complete-with-dots:10:28: parameter expansion flags are a zsh feature; tried parsing as bash
+OK   zsh-fancy-completions/functions/.force_rehash
+FAIL zsh-fancy-completions/functions/.man_glob
+zsh-fancy-completions/functions/.man_glob:8:9: `${+foo}` is a zsh feature; tried parsing as bash
+OK   zsh-fancy-completions/lib/compatibility.zsh
+FAIL zsh-fancy-completions/lib/completion.zsh
+zsh-fancy-completions/lib/completion.zsh:76:45: parameter expansion flags are a zsh feature; tried parsing as bash
+FAIL zsh-fancy-completions/lib/state.zsh
+zsh-fancy-completions/lib/state.zsh:13:32: `${+foo}` is a zsh feature; tried parsing as bash
+FAIL zsh-fancy-completions/zsh-fancy-completions.plugin.zsh
+zsh-fancy-completions/zsh-fancy-completions.plugin.zsh:5:14: nested parameter expansions are a zsh feature; tried parsing as bash
+FAIL zunit/build.zsh
+zunit/build.zsh:16:22: a command can only contain words and redirects; encountered `(`
+
+19 file(s) surveyed, 6 ok, 13 failed
+```
+
+## Gap mapping
+
+| File | Failing construct | Diagnostic family | Tracking issue |
+| --- | --- | --- | --- |
+| `z-a-meta-plugins/functions/.za-meta-plugins-before-load-handler:7` | `${=${options[xtrace]:#off}:+-o xtrace}` | expansion flag `${=...}` | [#11](https://github.com/z-shell/zsh-lint/issues/11) |
+| `src/public/zsh/init.zsh:79` | `${(f@)$(...)}` | expansion flags | [#11](https://github.com/z-shell/zsh-lint/issues/11) |
+| `zsh-fancy-completions/functions/.expand-or-complete-with-dots:10` | `${(%)WAITING_DOTS}` | expansion flags | [#11](https://github.com/z-shell/zsh-lint/issues/11) |
+| `zsh-fancy-completions/lib/completion.zsh:76` | `${(s.:.)LS_COLORS}` | expansion flags | [#11](https://github.com/z-shell/zsh-lint/issues/11) |
+| `zd/docker/utils.zsh:26` | `${+_comps}` | `${+name}` operator | [#11](https://github.com/z-shell/zsh-lint/issues/11) ("related operators") |
+| `zd/docker/zshrc:19` | `${+functions[...]}` | `${+name}` operator | [#11](https://github.com/z-shell/zsh-lint/issues/11) |
+| `zsh-fancy-completions/functions/.man_glob:8` | `${+manpath}` | `${+name}` operator | [#11](https://github.com/z-shell/zsh-lint/issues/11) |
+| `zsh-fancy-completions/lib/state.zsh:13` | `${+Plugins[ZF_COMPLETIONS]}` | `${+name}` operator | [#11](https://github.com/z-shell/zsh-lint/issues/11) |
+| `z-a-meta-plugins/z-a-meta-plugins.plugin.zsh:7` | ZERO idiom `${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}` | nested parameter expansion | NEW — file dedicated issue |
+| `zsh-eza/zsh-eza.plugin.zsh:8` | ZERO idiom (same) | nested parameter expansion | NEW (same issue) |
+| `zsh-fancy-completions/zsh-fancy-completions.plugin.zsh:5` | ZERO idiom (same) | nested parameter expansion | NEW (same issue) |
+| `zsh-fancy-completions/functions/.completion-prediction:6` | `zle-line-init() { predict-on }` — `}` without preceding terminator | statement separation / brace termination | [#12](https://github.com/z-shell/zsh-lint/issues/12) |
+| `zunit/build.zsh:16` | `src/**/(^zunit).zsh` | filename-generation pattern | [#16](https://github.com/z-shell/zsh-lint/issues/16) |
+
+## Notes
+
+- The ZERO-handling idiom (Z-Shell Plugin Standard) fails in **every plugin
+  entry file** in the corpus. Per the minimization guidance in
+  [#15](https://github.com/z-shell/zsh-lint/issues/15)/[#16](https://github.com/z-shell/zsh-lint/issues/16),
+  nested parameter expansion is its own language feature and gets a dedicated
+  issue rather than being grouped under #11.
+- Compared with the 16-file survey referenced in
+  [#17](https://github.com/z-shell/zsh-lint/issues/17) (7 ok / 9 failed),
+  this run covers 19 files (6 ok / 13 failed). `zd/docker/utils.zsh` and
+  `zunit/build.zsh` previously parsed but now fail; both files have changed
+  since (modeline and content updates), so the regressions are corpus drift,
+  not front-end drift.
+- No reverse-subscript (`[(I)...]`, [#15](https://github.com/z-shell/zsh-lint/issues/15))
+  or multi-name-loop ([#13](https://github.com/z-shell/zsh-lint/issues/13))
+  failures surfaced as the *first* error in any file in this run; earlier
+  errors mask later constructs, so those issues stay open with their original
+  observed examples.

--- a/docs/project/2026-06-12-survey.md
+++ b/docs/project/2026-06-12-survey.md
@@ -55,9 +55,9 @@ zunit/build.zsh:16:22: a command can only contain words and redirects; encounter
 | `zd/docker/zshrc:19` | `${+functions[...]}` | `${+name}` operator | [#11](https://github.com/z-shell/zsh-lint/issues/11) |
 | `zsh-fancy-completions/functions/.man_glob:8` | `${+manpath}` | `${+name}` operator | [#11](https://github.com/z-shell/zsh-lint/issues/11) |
 | `zsh-fancy-completions/lib/state.zsh:13` | `${+Plugins[ZF_COMPLETIONS]}` | `${+name}` operator | [#11](https://github.com/z-shell/zsh-lint/issues/11) |
-| `z-a-meta-plugins/z-a-meta-plugins.plugin.zsh:7` | ZERO idiom `${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}` | nested parameter expansion | NEW — file dedicated issue |
-| `zsh-eza/zsh-eza.plugin.zsh:8` | ZERO idiom (same) | nested parameter expansion | NEW (same issue) |
-| `zsh-fancy-completions/zsh-fancy-completions.plugin.zsh:5` | ZERO idiom (same) | nested parameter expansion | NEW (same issue) |
+| `z-a-meta-plugins/z-a-meta-plugins.plugin.zsh:7` | ZERO idiom `${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}` | nested parameter expansion | [#53](https://github.com/z-shell/zsh-lint/issues/53) |
+| `zsh-eza/zsh-eza.plugin.zsh:8` | ZERO idiom (same) | nested parameter expansion | [#53](https://github.com/z-shell/zsh-lint/issues/53) |
+| `zsh-fancy-completions/zsh-fancy-completions.plugin.zsh:5` | ZERO idiom (same) | nested parameter expansion | [#53](https://github.com/z-shell/zsh-lint/issues/53) |
 | `zsh-fancy-completions/functions/.completion-prediction:6` | `zle-line-init() { predict-on }` — `}` without preceding terminator | statement separation / brace termination | [#12](https://github.com/z-shell/zsh-lint/issues/12) |
 | `zunit/build.zsh:16` | `src/**/(^zunit).zsh` | filename-generation pattern | [#16](https://github.com/z-shell/zsh-lint/issues/16) |
 
@@ -66,8 +66,8 @@ zunit/build.zsh:16:22: a command can only contain words and redirects; encounter
 - The ZERO-handling idiom (Z-Shell Plugin Standard) fails in **every plugin
   entry file** in the corpus. Per the minimization guidance in
   [#15](https://github.com/z-shell/zsh-lint/issues/15)/[#16](https://github.com/z-shell/zsh-lint/issues/16),
-  nested parameter expansion is its own language feature and gets a dedicated
-  issue rather than being grouped under #11.
+  nested parameter expansion is its own language feature and is tracked in
+  [#53](https://github.com/z-shell/zsh-lint/issues/53) rather than being grouped under #11.
 - Compared with the 16-file survey referenced in
   [#17](https://github.com/z-shell/zsh-lint/issues/17) (7 ok / 9 failed),
   this run covers 19 files (6 ok / 13 failed). `zd/docker/utils.zsh` and

--- a/docs/project/corpus.md
+++ b/docs/project/corpus.md
@@ -1,0 +1,57 @@
+# Parser Evaluation Corpus
+
+Tracking issue: [#9](https://github.com/z-shell/zsh-lint/issues/9).
+
+This is the explicit, reproducible set of real Z-Shell sources used to
+evaluate the parser front end (`cmd/zsh-lint-survey`). Survey runs and
+parser-gap issues must reference corpus entries by repository and path so
+results stay comparable across runs and front ends
+([#17](https://github.com/z-shell/zsh-lint/issues/17)).
+
+## Layout assumption
+
+Entries are paths relative to a checkout root containing the listed
+repositories as sibling directories named after the repository. Set
+`CORPUS_ROOT` to that root and clone each repository under it, then run the
+survey command shown below.
+
+## Inventory
+
+| Repository | Files | Rationale |
+| --- | --- | --- |
+| `z-shell/src` | `public/zsh/init.zsh` | Zi loader; heaviest real-world Zsh (parameter-expansion flags, `always` blocks). |
+| `z-shell/zd` | `docker/utils.zsh`, `docker/zshrc`, `docker/zshenv` | CI bootstrap Zsh; mixes POSIX-ish and Zsh-native style. |
+| `z-shell/zunit` | `build.zsh` | Build script; representative tooling Zsh. |
+| `z-shell/z-a-meta-plugins` | `z-a-meta-plugins.plugin.zsh`, `functions/` (dot-prefixed handler functions) | Annex entry plus handler functions using the strict-emulation pattern. |
+| `z-shell/zsh-fancy-completions` | `zsh-fancy-completions.plugin.zsh`, `functions/`, `lib/` | Completion-style plugin; globbing, zstyle, and completion-discovery heavy. |
+| `z-shell/zsh-eza` | `zsh-eza.plugin.zsh` | Small, typical plugin entry file. |
+
+Inclusion rationale, per family: the corpus deliberately spans the loader
+(`src`), the CI environment (`zd`), test tooling (`zunit`), an annex
+(`z-a-meta-plugins`), and user-facing plugins (completions, eza) so parser
+gaps found here generalize across the organization's Zsh styles.
+
+## Running the survey
+
+From a `zsh-lint` checkout:
+
+    cd "$CORPUS_ROOT"
+    find src/public/zsh/init.zsh \
+         zd/docker/utils.zsh zd/docker/zshrc zd/docker/zshenv \
+         zunit/build.zsh \
+         z-a-meta-plugins/z-a-meta-plugins.plugin.zsh \
+         z-a-meta-plugins/functions \
+         zsh-fancy-completions/zsh-fancy-completions.plugin.zsh \
+         zsh-fancy-completions/functions \
+         zsh-fancy-completions/lib \
+         zsh-eza/zsh-eza.plugin.zsh \
+         -type f | sort | xargs go run <path-to-zsh-lint>/cmd/zsh-lint-survey
+
+Directory entries are passed through `find -type f`, which also picks up
+dot-prefixed function files (the `z-a-meta-plugins` handlers).
+
+## Changing the corpus
+
+Add or remove entries via a pull request to this file, including a rationale
+row. Survey reports under `docs/project/` record the corpus state they ran
+against, so older reports stay interpretable after the corpus changes.

--- a/docs/project/corpus.md
+++ b/docs/project/corpus.md
@@ -33,7 +33,8 @@ gaps found here generalize across the organization's Zsh styles.
 
 ## Running the survey
 
-From a `zsh-lint` checkout:
+Run from `$CORPUS_ROOT`, pointing `go run` at a local `zsh-lint` checkout
+(replace `<path-to-zsh-lint>` with its location):
 
     cd "$CORPUS_ROOT"
     find src/public/zsh/init.zsh \

--- a/docs/project/corpus.md
+++ b/docs/project/corpus.md
@@ -17,14 +17,14 @@ survey command shown below.
 
 ## Inventory
 
-| Repository | Files | Rationale |
-| --- | --- | --- |
-| `z-shell/src` | `public/zsh/init.zsh` | Zi loader; heaviest real-world Zsh (parameter-expansion flags, `always` blocks). |
-| `z-shell/zd` | `docker/utils.zsh`, `docker/zshrc`, `docker/zshenv` | CI bootstrap Zsh; mixes POSIX-ish and Zsh-native style. |
-| `z-shell/zunit` | `build.zsh` | Build script; representative tooling Zsh. |
-| `z-shell/z-a-meta-plugins` | `z-a-meta-plugins.plugin.zsh`, `functions/` (dot-prefixed handler functions) | Annex entry plus handler functions using the strict-emulation pattern. |
-| `z-shell/zsh-fancy-completions` | `zsh-fancy-completions.plugin.zsh`, `functions/`, `lib/` | Completion-style plugin; globbing, zstyle, and completion-discovery heavy. |
-| `z-shell/zsh-eza` | `zsh-eza.plugin.zsh` | Small, typical plugin entry file. |
+| Repository                      | Files                                                                        | Rationale                                                                        |
+| ------------------------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `z-shell/src`                   | `public/zsh/init.zsh`                                                        | Zi loader; heaviest real-world Zsh (parameter-expansion flags, `always` blocks). |
+| `z-shell/zd`                    | `docker/utils.zsh`, `docker/zshrc`, `docker/zshenv`                          | CI bootstrap Zsh; mixes POSIX-ish and Zsh-native style.                          |
+| `z-shell/zunit`                 | `build.zsh`                                                                  | Build script; representative tooling Zsh.                                        |
+| `z-shell/z-a-meta-plugins`      | `z-a-meta-plugins.plugin.zsh`, `functions/` (dot-prefixed handler functions) | Annex entry plus handler functions using the strict-emulation pattern.           |
+| `z-shell/zsh-fancy-completions` | `zsh-fancy-completions.plugin.zsh`, `functions/`, `lib/`                     | Completion-style plugin; globbing, zstyle, and completion-discovery heavy.       |
+| `z-shell/zsh-eza`               | `zsh-eza.plugin.zsh`                                                         | Small, typical plugin entry file.                                                |
 
 Inclusion rationale, per family: the corpus deliberately spans the loader
 (`src`), the CI environment (`zd`), test tooling (`zunit`), an annex

--- a/docs/project/parser-gap-workflow.md
+++ b/docs/project/parser-gap-workflow.md
@@ -45,7 +45,9 @@ Add the minimized script as
 `internal/survey/testdata/corpus/gap-<issue>-<slug>.zsh` with the standard
 Zsh modeline and a leading comment naming the issue.
 `TestMinimizedCorpus` (`internal/survey/corpus_test.go`) discovers fixtures
-by glob: `gap-*` must fail to parse, `ok-*` must parse. There is no fixture
+by scanning the corpus directory and enforces the naming contract:
+`gap-<issue>-<slug>.zsh` must fail to parse, `ok-<slug>.zsh` must parse, and
+any other name is rejected. There is no fixture
 count assertion — adding fixtures never requires test edits
 ([#14](https://github.com/z-shell/zsh-lint/issues/14)); only the small
 `requiredFixtures` baseline list is asserted by name.

--- a/docs/project/parser-gap-workflow.md
+++ b/docs/project/parser-gap-workflow.md
@@ -1,0 +1,60 @@
+# Parser-Gap Workflow
+
+Tracking issue: [#10](https://github.com/z-shell/zsh-lint/issues/10).
+
+How a parser failure found in real Z-Shell code becomes a tracked, minimized
+regression fixture.
+
+## 1. Capture
+
+Run the survey over the documented corpus (`docs/project/corpus.md`). Every
+`FAIL` line comes with a greppable `path:line:col: message` diagnostic.
+Record the run as `docs/project/YYYY-MM-DD-survey.md` with a gap-mapping
+table (see `2026-06-12-survey.md` for the format). Note that the survey
+reports only the *first* parse error per file — later constructs are masked
+until earlier gaps are fixed.
+
+## 2. Classify
+
+Check the Zsh manual (`man zshexpn`, `man zshparam`, `man zshmisc`) to name
+the language feature involved. One issue per language feature — split broad
+"file X fails" findings into narrower feature issues. Worked examples:
+[#11](https://github.com/z-shell/zsh-lint/issues/11) parameter-expansion
+flags and operators, [#13](https://github.com/z-shell/zsh-lint/issues/13)
+multi-name loops, [#15](https://github.com/z-shell/zsh-lint/issues/15)
+reverse subscripts, [#16](https://github.com/z-shell/zsh-lint/issues/16)
+filename-generation patterns,
+[#53](https://github.com/z-shell/zsh-lint/issues/53) nested parameter
+expansions. Label new issues `parser-gap` + `corpus`.
+
+## 3. Minimize
+
+Starting from the failing real file, delete everything unrelated until the
+smallest script that still reproduces the same parse error remains. Validate
+both directions:
+
+    go run ./cmd/zsh-lint-survey <file>   # must FAIL with the same family
+    zsh -n <file>                         # must pass — the gap is real Zsh
+
+A fixture that `zsh -n` rejects is a broken script, not a parser gap; never
+commit one.
+
+## 4. Promote to fixture
+
+Add the minimized script as
+`internal/survey/testdata/corpus/gap-<issue>-<slug>.zsh` with the standard
+Zsh modeline and a leading comment naming the issue.
+`TestMinimizedCorpus` (`internal/survey/corpus_test.go`) discovers fixtures
+by glob: `gap-*` must fail to parse, `ok-*` must parse. There is no fixture
+count assertion — adding fixtures never requires test edits
+([#14](https://github.com/z-shell/zsh-lint/issues/14)); only the small
+`requiredFixtures` baseline list is asserted by name.
+
+## 5. Close the loop
+
+When a front-end change (or a front-end swap,
+[#17](https://github.com/z-shell/zsh-lint/issues/17)) makes a `gap-*`
+fixture parse, the test fails loudly. Rename the fixture to `ok-<slug>.zsh`
+so it becomes permanent regression coverage, update `requiredFixtures`, and
+close the issue with a link to the survey run confirming the originating
+real file now parses.

--- a/docs/project/parser-gap-workflow.md
+++ b/docs/project/parser-gap-workflow.md
@@ -11,7 +11,7 @@ Run the survey over the documented corpus (`docs/project/corpus.md`). Every
 `FAIL` line comes with a greppable `path:line:col: message` diagnostic.
 Record the run as `docs/project/YYYY-MM-DD-survey.md` with a gap-mapping
 table (see `2026-06-12-survey.md` for the format). Note that the survey
-reports only the *first* parse error per file — later constructs are masked
+reports only the _first_ parse error per file — later constructs are masked
 until earlier gaps are fixed.
 
 ## 2. Classify

--- a/internal/survey/corpus_test.go
+++ b/internal/survey/corpus_test.go
@@ -1,0 +1,69 @@
+package survey
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/z-shell/zsh-lint/internal/parse"
+)
+
+// requiredFixtures is the minimal baseline that must always exist. It guards
+// against accidental deletion without asserting a brittle total count
+// (issue #14): new fixtures can be added freely without touching this test.
+var requiredFixtures = []string{
+	"gap-11-param-expansion-flags.zsh",
+	"gap-12-brace-termination.zsh",
+	"gap-13-multi-name-loop.zsh",
+	"gap-15-reverse-subscript.zsh",
+	"gap-16-glob-patterns.zsh",
+	"gap-53-nested-param-expansion.zsh",
+	"ok-baseline.zsh",
+}
+
+// TestMinimizedCorpus walks testdata/corpus and enforces the fixture naming
+// contract from docs/project/parser-gap-workflow.md: gap-<issue>-<slug>.zsh
+// must fail to parse (a known, tracked parser gap) and ok-<slug>.zsh must
+// parse. Fixtures are discovered by glob so the corpus can grow without test
+// edits.
+func TestMinimizedCorpus(t *testing.T) {
+	dir := filepath.Join("testdata", "corpus")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", dir, err)
+	}
+	seen := map[string]bool{}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".zsh") {
+			continue
+		}
+		seen[name] = true
+		path := filepath.Join(dir, name)
+		f, err := os.Open(path)
+		if err != nil {
+			t.Fatalf("opening %s: %v", path, err)
+		}
+		_, perr := parse.Parse(f, path)
+		f.Close()
+		switch {
+		case strings.HasPrefix(name, "gap-"):
+			if perr == nil {
+				t.Errorf("%s: parsed cleanly, but gap-* fixtures must fail; "+
+					"the parser gap may be fixed — promote to ok-* and close the issue", name)
+			}
+		case strings.HasPrefix(name, "ok-"):
+			if perr != nil {
+				t.Errorf("%s: failed to parse, but ok-* fixtures must parse: %v", name, perr)
+			}
+		default:
+			t.Errorf("%s: fixture name must start with gap- or ok-", name)
+		}
+	}
+	for _, want := range requiredFixtures {
+		if !seen[want] {
+			t.Errorf("required baseline fixture missing: %s", want)
+		}
+	}
+}

--- a/internal/survey/corpus_test.go
+++ b/internal/survey/corpus_test.go
@@ -3,6 +3,7 @@ package survey
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -22,11 +23,17 @@ var requiredFixtures = []string{
 	"ok-baseline.zsh",
 }
 
-// TestMinimizedCorpus walks testdata/corpus and enforces the fixture naming
-// contract from docs/project/parser-gap-workflow.md: gap-<issue>-<slug>.zsh
-// must fail to parse (a known, tracked parser gap) and ok-<slug>.zsh must
-// parse. Fixtures are discovered by glob so the corpus can grow without test
-// edits.
+// Fixture naming contract from docs/project/parser-gap-workflow.md:
+// gap-<issue>-<slug>.zsh must fail to parse (a known, tracked parser gap)
+// and ok-<slug>.zsh must parse.
+var (
+	gapName = regexp.MustCompile(`^gap-[0-9]+(-[a-z0-9]+)+\.zsh$`)
+	okName  = regexp.MustCompile(`^ok(-[a-z0-9]+)+\.zsh$`)
+)
+
+// TestMinimizedCorpus scans the testdata/corpus directory and enforces the
+// fixture naming contract above. Fixtures are discovered by listing the
+// directory so the corpus can grow without test edits.
 func TestMinimizedCorpus(t *testing.T) {
 	dir := filepath.Join("testdata", "corpus")
 	entries, err := os.ReadDir(dir)
@@ -48,17 +55,17 @@ func TestMinimizedCorpus(t *testing.T) {
 		_, perr := parse.Parse(f, path)
 		f.Close()
 		switch {
-		case strings.HasPrefix(name, "gap-"):
+		case gapName.MatchString(name):
 			if perr == nil {
 				t.Errorf("%s: parsed cleanly, but gap-* fixtures must fail; "+
 					"the parser gap may be fixed — promote to ok-* and close the issue", name)
 			}
-		case strings.HasPrefix(name, "ok-"):
+		case okName.MatchString(name):
 			if perr != nil {
 				t.Errorf("%s: failed to parse, but ok-* fixtures must parse: %v", name, perr)
 			}
 		default:
-			t.Errorf("%s: fixture name must start with gap- or ok-", name)
+			t.Errorf("%s: fixture name must match gap-<issue>-<slug>.zsh or ok-<slug>.zsh", name)
 		}
 	}
 	for _, want := range requiredFixtures {

--- a/internal/survey/testdata/corpus/gap-11-param-expansion-flags.zsh
+++ b/internal/survey/testdata/corpus/gap-11-param-expansion-flags.zsh
@@ -1,0 +1,6 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# Issue #11: Zsh parameter-expansion flags are not part of the Bash grammar.
+typeset -A opts
+opts=( verbose 1 )
+print -r -- ${(kv)opts}

--- a/internal/survey/testdata/corpus/gap-12-brace-termination.zsh
+++ b/internal/survey/testdata/corpus/gap-12-brace-termination.zsh
@@ -1,0 +1,5 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# Issue #12: Zsh allows `}` to close a brace body without a preceding
+# terminator; minimized from zsh-fancy-completions .completion-prediction.
+f() { print -r -- hi }

--- a/internal/survey/testdata/corpus/gap-13-multi-name-loop.zsh
+++ b/internal/survey/testdata/corpus/gap-13-multi-name-loop.zsh
@@ -1,0 +1,6 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# Issue #13: Zsh multi-name for loops are not part of the Bash grammar.
+for key value in a 1 b 2; do
+  print -r -- "$key=$value"
+done

--- a/internal/survey/testdata/corpus/gap-15-reverse-subscript.zsh
+++ b/internal/survey/testdata/corpus/gap-15-reverse-subscript.zsh
@@ -1,0 +1,5 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# Issue #15: reverse-subscript flags in parameter expansion; minimized from
+# zsh-fancy-completions lib/completion.zsh.
+print -r -- ${_comps[(I)-value-*]}

--- a/internal/survey/testdata/corpus/gap-16-glob-patterns.zsh
+++ b/internal/survey/testdata/corpus/gap-16-glob-patterns.zsh
@@ -1,0 +1,5 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# Issue #16: filename-generation patterns used in build/completion discovery;
+# minimized from zunit build.zsh.
+cat src/**/(^zunit).zsh

--- a/internal/survey/testdata/corpus/gap-53-nested-param-expansion.zsh
+++ b/internal/survey/testdata/corpus/gap-53-nested-param-expansion.zsh
@@ -1,0 +1,4 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# Issue #53: nested parameter expansions (Z-Shell Plugin Standard ZERO idiom).
+0="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"

--- a/internal/survey/testdata/corpus/ok-baseline.zsh
+++ b/internal/survey/testdata/corpus/ok-baseline.zsh
@@ -1,0 +1,5 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# Baseline: plain POSIX-compatible constructs the front end must always parse.
+say() { print -r -- "$1"; }
+for x in a b c; do say "$x"; done


### PR DESCRIPTION
## Summary

Lands the corpus/parser-gap foundation that the maintainer roadmap comments on #6 and #20 schedule ahead of rule-policy and output-contract work. It also reconciles a gap: comments on #10 and #8 reference `docs/project/` docs and a minimized fixture corpus that were never committed — this PR creates those artifacts for real.

- **`docs/project/corpus.md`** (#9): explicit, reproducible 19-file survey corpus across `src`, `zd`, `zunit`, `z-a-meta-plugins`, `zsh-fancy-completions`, `zsh-eza`, with per-family rationale and run instructions.
- **`docs/project/2026-06-12-survey.md`** (#8): fresh survey run — 6 ok / 13 failed — with every failure mapped to a tracking issue (#11, #12, #16, new #53).
- **`internal/survey/testdata/corpus/` + `TestMinimizedCorpus`** (#11 #12 #13 #15 #16 #53, closes #14): minimized gap fixtures, each verified valid Zsh (`zsh -n`) and failing the current frontend; glob-discovered test with a named required-baseline set instead of a brittle total-count assertion.
- **`docs/project/parser-gap-workflow.md`** (#10): capture → classify → minimize → promote → close-the-loop contributor workflow, linking the existing parser-gap issues as worked examples.

## Verification

- `go build ./... && go vet ./... && go test ./...` — all green.
- Every `gap-*` fixture passes `zsh -n` and fails `zsh-lint-survey`; `ok-*` fixtures parse.

Closes #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)