### PR TITLE
docs(rules): first-wave rule policy, documentation schema, and proposal form

### DIFF
--- a/.github/ISSUE_TEMPLATE/rule-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/rule-proposal.yml
@@ -1,0 +1,95 @@
+name: Rule proposal
+description: Propose a new semantic-analysis rule per docs/project/rule-policy.md
+title: "Rule proposal: <category>/<rule-name>"
+labels:
+  - rule-proposal
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Proposals are evaluated against the first-wave rule policy
+        (`docs/project/rule-policy.md`). All fields below are required by
+        that policy — proposals without corpus evidence or a
+        false-positive analysis are deferred, not reviewed.
+  - type: input
+    id: rule-id
+    attributes:
+      label: Rule ID
+      description: "Stable `category/rule-name` slug (categories: quoting, security, style, compat, plugin)."
+      placeholder: quoting/unquoted-array-subscript
+    validations:
+      required: true
+  - type: input
+    id: rule-name
+    attributes:
+      label: Rule name
+      description: Human-readable name returned by `Name()`.
+      placeholder: Unquoted array subscript expansion
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One sentence — what the rule reports.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why this matters
+      description: The failure mode, with the Zsh-manual section (zshexpn, zshparam, zshmisc, zshoptions) or Plugin Standard reference that explains the behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: corpus-evidence
+    attributes:
+      label: Corpus evidence
+      description: File/line citations from the survey corpus (docs/project/corpus.md) or a linked real-world Z-Shell repository where the pattern occurs.
+    validations:
+      required: true
+  - type: textarea
+    id: examples
+    attributes:
+      label: Bad / Good examples
+      description: At least one minimal flagged snippet and its fix.
+      value: |
+        ```zsh
+        # Bad
+
+        # Good
+        ```
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Proposed severity
+      options:
+        - error
+        - warning
+        - info
+        - hint
+    validations:
+      required: true
+  - type: textarea
+    id: severity-justification
+    attributes:
+      label: Severity justification
+      description: One line, per the severity mapping in the rule policy. Note `error` requires zero known legitimate uses in the corpus.
+    validations:
+      required: true
+  - type: textarea
+    id: false-positives
+    attributes:
+      label: False-positive analysis
+      description: Enumerate known legitimate uses of the pattern. For each, state whether the rule stays silent, downgrades severity, or relies on suppression (#19).
+    validations:
+      required: true
+  - type: textarea
+    id: parser-dependencies
+    attributes:
+      label: Parser dependencies
+      description: Open parser gaps (#11, #12, #13, #15, #16, #53) that mask the target construct, if any. Rules blocked by a gap are deferred until the gap is resolved.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/rule-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/rule-proposal.yml
@@ -93,3 +93,11 @@ body:
       description: Open parser gaps (#11, #12, #13, #15, #16, #53) that mask the target construct, if any. Rules blocked by a gap are deferred until the gap is resolved.
     validations:
       required: false
+  - type: textarea
+    id: suppression
+    attributes:
+      label: Suppression
+      description: How an intentional finding is silenced, per the shared suppression contract (#19). Until that contract lands, write `pending #19` — rules may not document ad-hoc escape hatches.
+      value: pending #19
+    validations:
+      required: true

--- a/docs/project/rule-policy.md
+++ b/docs/project/rule-policy.md
@@ -1,0 +1,103 @@
+# First-Wave Rule Policy
+
+Tracking issue: [#7](https://github.com/z-shell/zsh-lint/issues/7).
+
+How the first wave of 15–25 semantic rules is selected, what evidence a rule
+must provide before it ships, and what every shipped rule must document.
+Five rules predate this policy (`quoting/unquoted-var`, `security/eval`,
+`style/backquotes`, `style/function-decl`, `style/prefer-double-brackets`);
+they are grandfathered but must gain the documentation schema below before
+the first tagged release.
+
+## Selection criteria
+
+A rule candidate qualifies for the first wave only if all of these hold:
+
+1. **Corpus evidence.** The pattern the rule diagnoses occurs in the survey
+   corpus (`docs/project/corpus.md`) or in a linked real-world Z-Shell
+   repository. Cite files and lines in the proposal. Rules invented from
+   intuition wait for a later wave.
+2. **Manual grounding.** The behavior the rule warns about is explainable
+   from the Zsh manual (`zshexpn`, `zshparam`, `zshmisc`, `zshoptions`) or
+   the Z-Shell Plugin Standard. The proposal names the section.
+3. **Parseable today.** The rule must be implementable on AST shapes the
+   current front end produces. Patterns masked by open parser gaps
+   (#11, #12, #13, #15, #16, #53) are deferred until the gap is resolved —
+   a rule that can never see its target construct is untestable.
+4. **Actionable message.** The diagnostic must tell the user what to do,
+   not only what is wrong. If no safe rewrite exists, the rule must say why
+   the pattern is risky.
+5. **Bounded false positives.** The proposal must enumerate the known
+   legitimate uses of the pattern and state, for each, whether the rule
+   stays silent, downgrades severity, or relies on suppression (#19).
+
+## Rule IDs and categories
+
+Rule IDs are stable `category/rule-name` slugs (lowercase, hyphenated).
+First-wave categories:
+
+| Category   | Scope                                                                   |
+| ---------- | ----------------------------------------------------------------------- |
+| `quoting`  | Word splitting, globbing, and expansion quoting hazards.                |
+| `security` | Patterns that can execute or expand untrusted input.                    |
+| `style`    | Modern-Zsh idiom preferences with no behavior change.                   |
+| `compat`   | Constructs that behave differently across Zsh versions/emulation modes. |
+| `plugin`   | Z-Shell Plugin Standard conformance (ZERO idiom, unload, fpath).        |
+
+New categories require updating this table in the same PR that ships the
+first rule using them. A rule ID, once released, is never reused or renamed
+— deprecate and introduce a new ID instead.
+
+## Severity mapping
+
+Severities follow the LSP scale implemented in `internal/diag`:
+
+| Severity  | Use for                                                          |
+| --------- | ---------------------------------------------------------------- |
+| `error`   | Code that is broken or will misbehave at runtime in plain Zsh.   |
+| `warning` | Likely-bug patterns with realistic false-positive potential.     |
+| `info`    | Risky-but-sometimes-intentional patterns (e.g. `security/eval`). |
+| `hint`    | Style and idiom preferences.                                     |
+
+A first-wave rule may not ship at `error` unless its false-positive section
+demonstrates zero known legitimate uses in the corpus.
+
+## Documentation schema
+
+Every shipped rule must provide, in its proposal issue and in the generated
+reference docs (Go doc comment on the rule type):
+
+- **ID** — the `category/rule-name` slug returned by `ID()`.
+- **Name** — the human-readable name returned by `Name()`.
+- **Summary** — one sentence: what the rule reports.
+- **Why** — the failure mode, with the Zsh-manual or Plugin Standard
+  reference.
+- **Bad / Good** — at least one minimal flagged snippet and its fix.
+- **Severity** — with a one-line justification per the mapping above.
+- **False positives** — known legitimate uses and how the rule treats them.
+- **Suppression** — how to silence an intentional finding. Until #19 lands,
+  write `pending #19`; rules may not document ad-hoc escape hatches.
+- **Corpus evidence** — file/line citations from the survey corpus.
+
+## Shipping checklist
+
+A rule PR is mergeable when:
+
+1. The proposal issue (rule-proposal template) is approved and linked.
+2. The implementation conforms to
+   `.github/instructions/go-ast-linting.instructions.md` (visitor pattern,
+   safe text extraction, table-driven tests).
+3. Table-driven tests cover the Bad and Good examples plus every documented
+   false-positive case.
+4. The rule is registered in `internal/rules.Default()` and the generated
+   reference docs are regenerated.
+5. Running the analyzer over the survey corpus produces no finding the
+   author cannot classify as true positive or documented false positive.
+
+## False-positive policy
+
+False positives are budgeted, not forbidden: a first-wave rule earns its
+severity by how well it characterizes them. When a user reports a false
+positive, the triage order is (1) narrow the rule, (2) downgrade severity,
+(3) document it as a suppression case — removing the rule is a last resort
+and requires a tracking issue explaining why narrowing failed.


### PR DESCRIPTION
## Summary

Implements #7 on top of the merged corpus foundation (#54).

- **`docs/project/rule-policy.md`**: selection criteria for the first 15–25 rules (corpus evidence, Zsh-manual grounding, parseability against open gaps #11/#12/#13/#15/#16/#53, actionable messages, bounded false positives); rule ID/category taxonomy (`quoting`, `security`, `style`, `compat`, `plugin`); LSP-aligned severity mapping with an `error` bar; per-rule documentation schema; shipping checklist; false-positive triage policy. The five existing rules are grandfathered but must adopt the schema before the first tagged release.
- **`.github/ISSUE_TEMPLATE/rule-proposal.yml`**: issue form mirroring the schema so proposals arrive with the required evidence. Suppression documentation is explicitly `pending #19` — no ad-hoc escape hatches.

## Verification

- YAML validated with js-yaml; both files prettier-formatted.
- Docs-only change; `go build ./... && go test ./...` unaffected.

Closes #7 acceptance criteria: proposal template exists, required evidence documented, false-positive handling explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)