### PR TITLE
feat(diag,cli): versioned machine-readable JSON output contract

### DIFF
--- a/cmd/zsh-lint/main.go
+++ b/cmd/zsh-lint/main.go
@@ -15,15 +15,22 @@ import (
 )
 
 func main() {
-	if len(os.Args) < 2 {
-		fmt.Fprintln(os.Stderr, "usage: zsh-lint <file.zsh> [file.zsh ...]")
+	args := os.Args[1:]
+	jsonOut := false
+	if len(args) > 0 && args[0] == "--format=json" {
+		jsonOut = true
+		args = args[1:]
+	}
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: zsh-lint [--format=json] <file.zsh> [file.zsh ...]")
 		os.Exit(2)
 	}
 
 	an := analyzer.New(rules.Default()...)
+	var all diag.Diagnostics
 	var exitNonZero bool
 
-	for _, name := range os.Args[1:] {
+	for _, name := range args {
 		f, err := os.Open(name)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s: %v\n", name, err)
@@ -35,8 +42,15 @@ func main() {
 		f.Close()
 
 		if err != nil {
-			fmt.Println(formatErr(name, err))
 			exitNonZero = true
+			if jsonOut {
+				// Parser failures share the diagnostics model under the
+				// reserved rule ID parse/error
+				// (docs/project/output-contract.md).
+				all = append(all, parseErrDiag(name, err))
+			} else {
+				fmt.Println(formatErr(name, err))
+			}
 			continue
 		}
 
@@ -47,6 +61,9 @@ func main() {
 				exitNonZero = true
 			}
 
+			if jsonOut {
+				continue
+			}
 			// Format similar to gcc/clang
 			if d.Range.IsValid() {
 				fmt.Printf("%s:%d:%d: [%s] %s\n", d.File, d.Range.Start.Line, d.Range.Start.Column, d.RuleID, d.Message)
@@ -54,11 +71,65 @@ func main() {
 				fmt.Printf("%s: [%s] %s\n", d.File, d.RuleID, d.Message)
 			}
 		}
+		if jsonOut {
+			all = append(all, diags...)
+		}
+	}
+
+	if jsonOut {
+		all.Sort()
+		if err := diag.WriteJSON(os.Stdout, len(args), all); err != nil {
+			fmt.Fprintf(os.Stderr, "zsh-lint: encoding JSON: %v\n", err)
+			os.Exit(2)
+		}
 	}
 
 	if exitNonZero {
 		os.Exit(1)
 	}
+}
+
+// parseErrDiag converts a parser/IO error into a parse/error diagnostic,
+// extracting the source position when the front end provides one.
+func parseErrDiag(name string, err error) diag.Diagnostic {
+	d := diag.Diagnostic{
+		RuleID:   "parse/error",
+		Severity: diag.Error,
+		File:     name,
+	}
+	var perr syntax.ParseError
+	if errors.As(err, &perr) {
+		d.Message = perr.Text
+		d.Range = posRange(perr.Pos)
+		return d
+	}
+	var lerr syntax.LangError
+	if errors.As(err, &lerr) {
+		// LangError.Error() embeds the position; the range carries it in the
+		// contract, so strip the prefix to keep the message position-free.
+		lerr.Filename = ""
+		msg := lerr.Error()
+		if lerr.Pos.IsValid() {
+			prefix := fmt.Sprintf("%d:%d: ", lerr.Pos.Line(), lerr.Pos.Col())
+			if len(msg) > len(prefix) && msg[:len(prefix)] == prefix {
+				msg = msg[len(prefix):]
+			}
+		}
+		d.Message = msg
+		d.Range = posRange(lerr.Pos)
+		return d
+	}
+	d.Message = err.Error()
+	return d
+}
+
+// posRange converts a parser position into a zero-width diagnostic range.
+func posRange(p syntax.Pos) diag.Range {
+	if !p.IsValid() {
+		return diag.Range{}
+	}
+	pos := diag.Position{Line: int(p.Line()), Column: int(p.Col()), Offset: int(p.Offset())}
+	return diag.Range{Start: pos, End: pos}
 }
 
 // formatErr renders a parser/IO error as a greppable `path:line:col: message`

--- a/docs/project/output-contract.md
+++ b/docs/project/output-contract.md
@@ -1,0 +1,85 @@
+# Machine-Readable Output Contract
+
+Tracking issue: [#20](https://github.com/z-shell/zsh-lint/issues/20).
+
+The stable transport format for diagnostics, for CI and editor consumers.
+Version 1 is implemented by `internal/diag.WriteJSON` and exposed by
+`zsh-lint --format=json`; the contract is covered by tests in
+`internal/diag/json_test.go`.
+
+## Versioning
+
+The envelope carries an integer `version` (currently `1`,
+`diag.JSONVersion`). Adding new optional members is allowed within a
+version; removing or changing the meaning of an existing member requires
+incrementing it. Consumers must reject versions they do not understand.
+
+## Envelope
+
+`zsh-lint --format=json <files...>` writes one JSON object to stdout,
+followed by a single newline:
+
+```json
+{
+  "version": 1,
+  "diagnostics": [
+    {
+      "rule": "quoting/unquoted-var",
+      "severity": "warning",
+      "message": "Variable expansion should be double-quoted",
+      "file": "lib/a.zsh",
+      "range": {
+        "start": { "line": 2, "column": 6, "offset": 13 },
+        "end": { "line": 2, "column": 8, "offset": 15 }
+      }
+    }
+  ],
+  "summary": {
+    "files": 1,
+    "diagnostics": 1,
+    "errors": 0,
+    "warnings": 1,
+    "infos": 0,
+    "hints": 0
+  }
+}
+```
+
+- `diagnostics` is always an array (empty, never `null`), sorted by the
+  deterministic order defined by `diag.Diagnostics.Sort` (file, range,
+  rule, severity, message) so output is reproducible across runs.
+- `severity` is one of `error`, `warning`, `info`, `hint` — the canonical
+  lowercase names from `internal/diag`, ordered per the LSP scale.
+- `rule` is the stable `category/rule-name` slug (rule policy,
+  `docs/project/rule-policy.md`).
+- `line` and `column` are 1-based; `offset` is a 0-based byte offset.
+  `range` is half-open: `[start, end)`.
+- An unpositioned diagnostic (whole-file or unknown location) omits the
+  `range` member entirely.
+- `summary.files` counts files inspected, independent of how many produced
+  findings.
+- Human-readable output is unchanged and remains the default; the flag is
+  opt-in.
+
+## Parser failures
+
+Parser failures and analyzer findings share one representation: a parser
+failure is a diagnostic with the reserved rule ID **`parse/error`**,
+severity `error`, a position-free `message`, and a zero-width `range` at
+the failure position when the front end provides one. The `parse/` category
+is reserved for the front end; analyzer rules must not use it.
+
+## Suppression (#19)
+
+Per the suppression contract (`docs/project/suppression.md`): suppressed
+findings are omitted from `diagnostics`, while `meta/*` diagnostics
+(`meta/malformed-suppression`, `meta/unused-suppression`) are always
+included, so integrations can audit suppression usage. Until suppression is
+implemented in the analyzer, no `meta/*` diagnostics are emitted; their
+inclusion is not a version change.
+
+## Exit codes
+
+Unchanged by the format flag: `0` no findings at `warning` or above, `1`
+findings at `warning`/`error` (including `parse/error`) or unreadable
+inputs, `2` usage or encoding errors.

--- a/internal/diag/json.go
+++ b/internal/diag/json.go
@@ -1,0 +1,90 @@
+package diag
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// JSONVersion is the version of the machine-readable output contract emitted
+// by WriteJSON. The contract is documented in docs/project/output-contract.md
+// (issue #20); any breaking change to the envelope or field semantics must
+// increment it.
+const JSONVersion = 1
+
+type jsonPosition struct {
+	Line   int `json:"line"`
+	Column int `json:"column"`
+	Offset int `json:"offset"`
+}
+
+type jsonRange struct {
+	Start jsonPosition `json:"start"`
+	End   jsonPosition `json:"end"`
+}
+
+type jsonDiagnostic struct {
+	Rule     string     `json:"rule"`
+	Severity string     `json:"severity"`
+	Message  string     `json:"message"`
+	File     string     `json:"file,omitempty"`
+	Range    *jsonRange `json:"range,omitempty"`
+}
+
+type jsonSummary struct {
+	Files       int `json:"files"`
+	Diagnostics int `json:"diagnostics"`
+	Errors      int `json:"errors"`
+	Warnings    int `json:"warnings"`
+	Infos       int `json:"infos"`
+	Hints       int `json:"hints"`
+}
+
+type jsonEnvelope struct {
+	Version     int              `json:"version"`
+	Diagnostics []jsonDiagnostic `json:"diagnostics"`
+	Summary     jsonSummary      `json:"summary"`
+}
+
+// WriteJSON renders diagnostics as the versioned machine-readable envelope
+// defined by the output contract (issue #20) and writes it to w followed by a
+// single newline. files is the number of files inspected (reported in the
+// summary; it is independent of how many files produced findings).
+//
+// Diagnostics are emitted in the given order; callers that need deterministic
+// output must call Diagnostics.Sort first. An unpositioned diagnostic (zero
+// Range) omits the "range" member entirely.
+func WriteJSON(w io.Writer, files int, diags Diagnostics) error {
+	env := jsonEnvelope{
+		Version:     JSONVersion,
+		Diagnostics: make([]jsonDiagnostic, 0, len(diags)),
+		Summary:     jsonSummary{Files: files, Diagnostics: len(diags)},
+	}
+	for _, d := range diags {
+		jd := jsonDiagnostic{
+			Rule:     string(d.RuleID),
+			Severity: d.Severity.String(),
+			Message:  d.Message,
+			File:     d.File,
+		}
+		if d.Range.IsValid() {
+			jd.Range = &jsonRange{
+				Start: jsonPosition(d.Range.Start),
+				End:   jsonPosition(d.Range.End),
+			}
+		}
+		env.Diagnostics = append(env.Diagnostics, jd)
+		switch d.Severity {
+		case Error:
+			env.Summary.Errors++
+		case Warning:
+			env.Summary.Warnings++
+		case Info:
+			env.Summary.Infos++
+		case Hint:
+			env.Summary.Hints++
+		}
+	}
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(env)
+}

--- a/internal/diag/json_test.go
+++ b/internal/diag/json_test.go
@@ -1,0 +1,123 @@
+package diag
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestWriteJSONEnvelope(t *testing.T) {
+	diags := Diagnostics{
+		{
+			RuleID:   "quoting/unquoted-var",
+			Severity: Warning,
+			Message:  "Unquoted variable expansion",
+			File:     "a.zsh",
+			Range: Range{
+				Start: Position{Line: 3, Column: 7, Offset: 42},
+				End:   Position{Line: 3, Column: 12, Offset: 47},
+			},
+		},
+		{
+			RuleID:   "parse/error",
+			Severity: Error,
+			Message:  "parameter expansion flags are a zsh feature",
+			File:     "b.zsh",
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, 2, diags); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+
+	var got struct {
+		Version     int `json:"version"`
+		Diagnostics []struct {
+			Rule     string `json:"rule"`
+			Severity string `json:"severity"`
+			Message  string `json:"message"`
+			File     string `json:"file"`
+			Range    *struct {
+				Start struct {
+					Line   int `json:"line"`
+					Column int `json:"column"`
+					Offset int `json:"offset"`
+				} `json:"start"`
+				End struct {
+					Line   int `json:"line"`
+					Column int `json:"column"`
+					Offset int `json:"offset"`
+				} `json:"end"`
+			} `json:"range"`
+		} `json:"diagnostics"`
+		Summary struct {
+			Files       int `json:"files"`
+			Diagnostics int `json:"diagnostics"`
+			Errors      int `json:"errors"`
+			Warnings    int `json:"warnings"`
+			Infos       int `json:"infos"`
+			Hints       int `json:"hints"`
+		} `json:"summary"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, buf.String())
+	}
+
+	if got.Version != 1 {
+		t.Errorf("version = %d, want 1", got.Version)
+	}
+	if len(got.Diagnostics) != 2 {
+		t.Fatalf("diagnostics len = %d, want 2", len(got.Diagnostics))
+	}
+
+	d0 := got.Diagnostics[0]
+	if d0.Rule != "quoting/unquoted-var" || d0.Severity != "warning" || d0.File != "a.zsh" {
+		t.Errorf("diagnostic[0] = %+v", d0)
+	}
+	if d0.Range == nil {
+		t.Fatal("diagnostic[0] should have a range")
+	}
+	if d0.Range.Start.Line != 3 || d0.Range.Start.Column != 7 || d0.Range.Start.Offset != 42 {
+		t.Errorf("diagnostic[0].range.start = %+v", d0.Range.Start)
+	}
+	if d0.Range.End.Line != 3 || d0.Range.End.Column != 12 || d0.Range.End.Offset != 47 {
+		t.Errorf("diagnostic[0].range.end = %+v", d0.Range.End)
+	}
+
+	d1 := got.Diagnostics[1]
+	if d1.Rule != "parse/error" || d1.Severity != "error" {
+		t.Errorf("diagnostic[1] = %+v", d1)
+	}
+	if d1.Range != nil {
+		t.Errorf("diagnostic[1] is unpositioned; range must be omitted, got %+v", d1.Range)
+	}
+
+	s := got.Summary
+	if s.Files != 2 || s.Diagnostics != 2 || s.Errors != 1 || s.Warnings != 1 || s.Infos != 0 || s.Hints != 0 {
+		t.Errorf("summary = %+v", s)
+	}
+
+	// The envelope ends with a single trailing newline so it is line-friendly
+	// in CI logs.
+	if !strings.HasSuffix(buf.String(), "}\n") {
+		t.Errorf("output must end with a single newline; got tail %q", buf.String()[len(buf.String())-3:])
+	}
+}
+
+func TestWriteJSONEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteJSON(&buf, 0, nil); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	// diagnostics must be an empty array, not null, so consumers can iterate
+	// without a nil check.
+	if diags, ok := got["diagnostics"].([]any); !ok || len(diags) != 0 {
+		t.Errorf("diagnostics = %#v, want empty array", got["diagnostics"])
+	}
+}


### PR DESCRIPTION
## Summary

Implements #20 on top of the merged rule policy (#55) and suppression contract (#56).

- **`internal/diag/json.go`**: `WriteJSON` renders the versioned envelope (`version: 1`, `diag.JSONVersion`) — diagnostics with rule ID, severity (canonical lowercase), message, file, and half-open range (1-based line/column, 0-based offset); unpositioned diagnostics omit `range`; `diagnostics` is never `null`; severity-bucketed summary. Covered by tests (`json_test.go`).
- **`cmd/zsh-lint --format=json`**: opt-in flag; human output and exit codes unchanged. Parser failures share the diagnostics model under the reserved rule ID `parse/error` with a zero-width range at the failure position and a position-free message. Output is deterministically sorted via `Diagnostics.Sort`.
- **`docs/project/output-contract.md`**: the contract — versioning policy, envelope shape, parser-failure representation strategy, suppression interaction per `docs/project/suppression.md` (suppressed findings omitted, `meta/*` always included), exit codes.

## Verification

- `go build ./... && go vet ./... && go test ./...` — all green, gofmt-clean.
- Smoke-tested against corpus fixtures: parse failure and rule finding both render correctly in JSON and human modes; exit codes preserved.

Acceptance criteria from #20: versioned schema documented ✔, rule ID/severity/message/range ✔, explicit parser-failure + analyzer representation ✔, contract covered by tests ✔.

Closes #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)