### PR TITLE
feat(parse): switch front end to mvdan/sh LangZsh dialect

### DIFF
--- a/docs/project/2026-06-12-langzsh-switch.md
+++ b/docs/project/2026-06-12-langzsh-switch.md
@@ -1,0 +1,100 @@
+# Front-End Switch to LangZsh — 2026-06-12
+
+Tracking issues:
+[#11](https://github.com/z-shell/zsh-lint/issues/11),
+[#53](https://github.com/z-shell/zsh-lint/issues/53)
+(strategy decision they both required), with direct impact on
+[#12](https://github.com/z-shell/zsh-lint/issues/12),
+[#15](https://github.com/z-shell/zsh-lint/issues/15),
+[#16](https://github.com/z-shell/zsh-lint/issues/16),
+[#17](https://github.com/z-shell/zsh-lint/issues/17).
+
+## Decision
+
+`internal/parse` now parses with `syntax.LangZsh` instead of
+`syntax.LangBash`. mvdan/sh gained a dedicated Zsh dialect in the v3.13
+line (upstream umbrella
+[mvdan/sh#120](https://github.com/mvdan/sh/issues/120), closed), which the
+earlier survey work predated.
+
+## Measured evidence (19-file corpus, `docs/project/corpus.md`)
+
+| Front end                                    | Parsed | Failed |
+| -------------------------------------------- | -----: | -----: |
+| mvdan/sh v3.13.1 `LangBash` (previous)       |      6 |     13 |
+| mvdan/sh v3.13.1 `LangZsh` (this PR)         |     11 |      8 |
+| mvdan/sh master `LangZsh` (preview)          |     13 |      6 |
+| tree-sitter-zsh `86b37f8` (#17, 16-file run) |      6 |     10 |
+
+The master preview (`v3.13.2-0.20260611081601`) additionally fixes
+reverse subscripts (#15) and one statement-separation case; those arrive by
+staying on the upstream release train rather than via local workarounds.
+
+## Effect on tracked gaps
+
+| Issue | Construct                              | Status under LangZsh v3.13.1                                                                                                                                                                                    |
+| ----- | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| #11   | expansion flags `${(kv)x}`, `${+name}` | **fixed** — fixture promoted to `ok-param-expansion-flags.zsh`                                                                                                                                                  |
+| #53   | ZERO idiom nested expansions           | **fixed** — `ok-nested-param-expansion.zsh`; all three plugin entry files now parse past their ZERO line                                                                                                        |
+| #12   | `}` without preceding terminator       | **fixed for function bodies** (`ok-brace-termination.zsh`); the remaining family is zsh brace-form `if [[ ... ]] {` and `} always {` blocks (upstream [mvdan/sh#1211](https://github.com/mvdan/sh/issues/1211)) |
+| #16   | glob patterns `(^zunit)`               | **fixed** — `ok-glob-patterns.zsh`; `zunit/build.zsh` parses fully                                                                                                                                              |
+| #13   | multi-name `for`                       | still failing; upstream [mvdan/sh#1297](https://github.com/mvdan/sh/issues/1297) is open                                                                                                                        |
+| #15   | reverse subscripts `[(I)pat]`          | still failing on v3.13.1; fixed on upstream master                                                                                                                                                              |
+
+## Survey after the switch (LangZsh, v3.13.1)
+
+```text
+FAIL z-a-meta-plugins/functions/.za-meta-plugins-before-load-handler
+z-a-meta-plugins/functions/.za-meta-plugins-before-load-handler:12:23: statements must be separated by &, ; or a newline
+OK   z-a-meta-plugins/functions/.za-meta-plugins-meta-cmd
+OK   z-a-meta-plugins/functions/.za-meta-plugins-meta-cmd-help-handler
+FAIL z-a-meta-plugins/z-a-meta-plugins.plugin.zsh
+z-a-meta-plugins/z-a-meta-plugins.plugin.zsh:11:25: statements must be separated by &, ; or a newline
+FAIL src/public/zsh/init.zsh
+src/public/zsh/init.zsh:133:5: statements must be separated by &, ; or a newline
+OK   zd/docker/utils.zsh
+OK   zd/docker/zshenv
+OK   zd/docker/zshrc
+FAIL zsh-eza/zsh-eza.plugin.zsh
+zsh-eza/zsh-eza.plugin.zsh:24:16: `[` must be followed by an expression
+OK   zsh-fancy-completions/functions/.complete_menu
+OK   zsh-fancy-completions/functions/.completion-prediction
+OK   zsh-fancy-completions/functions/.expand-or-complete-with-dots
+OK   zsh-fancy-completions/functions/.force_rehash
+FAIL zsh-fancy-completions/functions/.man_glob
+zsh-fancy-completions/functions/.man_glob:21:13: this expansion operator is a bash feature; tried parsing as zsh
+OK   zsh-fancy-completions/lib/compatibility.zsh
+FAIL zsh-fancy-completions/lib/completion.zsh
+zsh-fancy-completions/lib/completion.zsh:110:87: `*` must follow an expression
+FAIL zsh-fancy-completions/lib/state.zsh
+zsh-fancy-completions/lib/state.zsh:84:3: `for foo` must be followed by `in`, `do`, `;`, or a newline
+FAIL zsh-fancy-completions/zsh-fancy-completions.plugin.zsh
+zsh-fancy-completions/zsh-fancy-completions.plugin.zsh:27:5: statements must be separated by &, ; or a newline
+OK   zunit/build.zsh
+
+19 file(s) surveyed, 11 ok, 8 failed
+```
+
+## Remaining gap mapping
+
+| File                                                                                                                   | Failing construct                          | Tracking                                                                                                                            |
+| ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `z-a-meta-plugins/...` (entry:11, handler:12), `src/public/zsh/init.zsh:133`, `zsh-fancy-completions/...plugin.zsh:27` | brace-form `if [[ ... ]] {` / `} always {` | [#12](https://github.com/z-shell/zsh-lint/issues/12) (re-scoped); upstream [mvdan/sh#1211](https://github.com/mvdan/sh/issues/1211) |
+| `zsh-fancy-completions/lib/state.zsh:84`                                                                               | multi-name `for`                           | [#13](https://github.com/z-shell/zsh-lint/issues/13); upstream [mvdan/sh#1297](https://github.com/mvdan/sh/issues/1297)             |
+| `zsh-fancy-completions/lib/completion.zsh:110`                                                                         | reverse subscript `[(I)...]`               | [#15](https://github.com/z-shell/zsh-lint/issues/15); fixed on upstream master                                                      |
+| `zsh-eza/zsh-eza.plugin.zsh:24`                                                                                        | `${+functions[.zsh-eza]}` inside `(( ))`   | new minimization candidate                                                                                                          |
+| `zsh-fancy-completions/functions/.man_glob:21`                                                                         | `${^manpath}` (rc-expand caret)            | new minimization candidate                                                                                                          |
+
+## Consequences
+
+- All five semantic rules pass their existing tests unchanged under
+  LangZsh.
+- The survey fixture `gap.zsh` (previously `${+commands[git]}`, which now
+  parses) was replaced with a multi-name `for` reproduction so the survey
+  tests keep exercising a real failure.
+- Upstream-first strategy: remaining gaps map to open mvdan/sh issues;
+  prefer tracking/contributing upstream over local preprocessing. Bump to
+  the next mvdan/sh release when it ships to pick up #15 and further
+  statement-separation fixes.
+- tree-sitter-zsh (#17) is now measurably behind on this corpus and stays
+  a tracking-only option.

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -1,9 +1,11 @@
 // Package parse wraps the mvdan.cc/sh parser as the analyzer's front end.
 //
-// mvdan/sh has no dedicated Zsh dialect, so the reboot uses the Bash variant as
-// the closest available grammar and records Zsh-specific gaps from real code
-// (see issues #8, #11–#16). Isolating the front end here lets it be swapped
-// later (e.g. tree-sitter-zsh, issue #17) without touching callers.
+// The front end uses mvdan/sh's Zsh dialect (LangZsh, available since
+// v3.13.x), which on the documented survey corpus parses roughly twice as
+// many real Z-Shell files as the Bash variant the reboot started with
+// (issues #11, #53). Remaining Zsh gaps are tracked as corpus fixtures (see
+// issues #12, #13, #15 and docs/project/parser-gap-workflow.md). Isolating
+// the front end here lets it be swapped without touching callers.
 package parse
 
 import (
@@ -22,12 +24,12 @@ func (f *File) AST() *syntax.File {
 	return f.tree
 }
 
-// Parse parses a single Zsh/Bash source read from r, using name in error
+// Parse parses a single Zsh source read from r, using name in error
 // messages. It returns the parsed source or the first parse error.
 func Parse(r io.Reader, name string) (*File, error) {
 	parser := syntax.NewParser(
 		syntax.KeepComments(true),
-		syntax.Variant(syntax.LangBash),
+		syntax.Variant(syntax.LangZsh),
 	)
 	tree, err := parser.Parse(r, name)
 	if err != nil {

--- a/internal/survey/corpus_test.go
+++ b/internal/survey/corpus_test.go
@@ -14,13 +14,13 @@ import (
 // against accidental deletion without asserting a brittle total count
 // (issue #14): new fixtures can be added freely without touching this test.
 var requiredFixtures = []string{
-	"gap-11-param-expansion-flags.zsh",
-	"gap-12-brace-termination.zsh",
 	"gap-13-multi-name-loop.zsh",
 	"gap-15-reverse-subscript.zsh",
-	"gap-16-glob-patterns.zsh",
-	"gap-53-nested-param-expansion.zsh",
 	"ok-baseline.zsh",
+	"ok-brace-termination.zsh",
+	"ok-glob-patterns.zsh",
+	"ok-nested-param-expansion.zsh",
+	"ok-param-expansion-flags.zsh",
 }
 
 // Fixture naming contract from docs/project/parser-gap-workflow.md:

--- a/internal/survey/testdata/corpus/gap-12-brace-termination.zsh
+++ b/internal/survey/testdata/corpus/gap-12-brace-termination.zsh
@@ -1,5 +1,0 @@
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# Issue #12: Zsh allows `}` to close a brace body without a preceding
-# terminator; minimized from zsh-fancy-completions .completion-prediction.
-f() { print -r -- hi }

--- a/internal/survey/testdata/corpus/ok-brace-termination.zsh
+++ b/internal/survey/testdata/corpus/ok-brace-termination.zsh
@@ -1,0 +1,5 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# Regression (was gap #12): `}` closing a brace body without a preceding
+# terminator parses under LangZsh; minimized from .completion-prediction.
+f() { print -r -- hi }

--- a/internal/survey/testdata/corpus/ok-glob-patterns.zsh
+++ b/internal/survey/testdata/corpus/ok-glob-patterns.zsh
@@ -1,5 +1,5 @@
 # -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
 # vim: ft=zsh sw=2 ts=2 et
-# Issue #16: filename-generation patterns used in build/completion discovery;
+# Regression (was gap #16): filename-generation patterns parse under LangZsh;
 # minimized from zunit build.zsh.
 cat src/**/(^zunit).zsh

--- a/internal/survey/testdata/corpus/ok-nested-param-expansion.zsh
+++ b/internal/survey/testdata/corpus/ok-nested-param-expansion.zsh
@@ -1,4 +1,4 @@
 # -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
 # vim: ft=zsh sw=2 ts=2 et
-# Issue #53: nested parameter expansions (Z-Shell Plugin Standard ZERO idiom).
+# Regression (was gap #53): the Plugin Standard ZERO idiom parses under LangZsh.
 0="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"

--- a/internal/survey/testdata/corpus/ok-param-expansion-flags.zsh
+++ b/internal/survey/testdata/corpus/ok-param-expansion-flags.zsh
@@ -1,6 +1,6 @@
 # -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
 # vim: ft=zsh sw=2 ts=2 et
-# Issue #11: Zsh parameter-expansion flags are not part of the Bash grammar.
+# Regression (was gap #11): parameter-expansion flags parse under LangZsh.
 typeset -A opts
 opts=( verbose 1 )
 print -r -- ${(kv)opts}

--- a/internal/survey/testdata/gap.zsh
+++ b/internal/survey/testdata/gap.zsh
@@ -1,3 +1,5 @@
 # -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
 # vim: ft=zsh sw=2 ts=2 et
-print -r -- ${+commands[git]}
+for key value in a 1 b 2; do
+  print -r -- "$key=$value"
+done


### PR DESCRIPTION
## Summary

Resolves the front-end strategy question behind #53 and #11: mvdan/sh has shipped a dedicated Zsh dialect (`syntax.LangZsh`, upstream umbrella mvdan/sh#120) since the v3.13 line — already available in our pinned v3.13.1. Switching `internal/parse` from `LangBash` to `LangZsh`:

| Front end | Parsed | Failed |
| --- | ---: | ---: |
| LangBash v3.13.1 (previous) | 6 | 13 |
| **LangZsh v3.13.1 (this PR)** | **11** | **8** |
| LangZsh master preview | 13 | 6 |
| tree-sitter-zsh (#17 run) | 6 | 10 |

- Gaps **#11, #16, #53** and the function-body case of **#12** are fixed; per the parser-gap workflow their fixtures are promoted to `ok-*` permanent regression coverage and `requiredFixtures` updated.
- `internal/survey/testdata/gap.zsh` (`${+commands[git]}`, which now parses) is replaced with a still-failing multi-name `for` (#13, upstream mvdan/sh#1297) so survey tests keep exercising a real failure.
- Remaining corpus failures are classified in **`docs/project/2026-06-12-langzsh-switch.md`**: brace-form `if [[ ]] {` / `} always {` (#12 re-scoped, upstream mvdan/sh#1211), multi-name `for` (#13), reverse subscripts (#15, fixed on upstream master), plus two new minimization candidates (`${^manpath}`, `${+functions[.name]}` in arithmetic).
- Strategy: upstream-first — track/contribute mvdan/sh issues, bump on next release; no local preprocessing.

## Verification

- `go build ./... && go vet ./... && go test ./...` all green; gofmt-clean.
- All five semantic rules pass unchanged under LangZsh.
- Every fixture validated with `zsh -n`; survey re-run over the 19-file corpus recorded in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)