### PR TITLE
test(corpus): track new parser gaps #60 and #61 as fixtures

### DIFF
--- a/internal/survey/testdata/corpus/gap-60-rc-expand-caret.zsh
+++ b/internal/survey/testdata/corpus/gap-60-rc-expand-caret.zsh
@@ -1,0 +1,5 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# Issue #60: rc-expand caret ${^spec} (zshexpn, RC_EXPAND_PARAM) does not
+# parse under LangZsh; minimized from zsh-fancy-completions .man_glob.
+print -- ${^manpath}

--- a/internal/survey/testdata/corpus/gap-61-assoc-subscript-leading-dot.zsh
+++ b/internal/survey/testdata/corpus/gap-61-assoc-subscript-leading-dot.zsh
@@ -1,0 +1,6 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# Issue #61: associative-array subscripts beginning with a dot (zshparam,
+# Array Subscripts) do not parse under LangZsh; minimized from the
+# ${+functions[.zsh-eza]} probe in zsh-eza.plugin.zsh.
+print ${functions[.foo]}


### PR DESCRIPTION
## Summary

Promotes the two minimization candidates left by the LangZsh switch (`docs/project/2026-06-12-langzsh-switch.md`) into tracked parser-gap fixtures, per `docs/project/parser-gap-workflow.md`:

- `gap-60-rc-expand-caret.zsh` — `print -- ${^manpath}` (#60, from `.man_glob:21`): rc-expand caret expansion, diagnostic `this expansion operator is a bash feature; tried parsing as zsh`.
- `gap-61-assoc-subscript-leading-dot.zsh` — `print ${functions[.foo]}` (#61, from `zsh-eza.plugin.zsh:24`): subscripts beginning with a dot, diagnostic `` `[` must be followed by an expression ``. Minimization showed the arithmetic context in the original is irrelevant.

Both gaps have no matching upstream mvdan/sh issue as of today and still fail on the master preview; upstream filing is the tracked next step in each issue.

## Verification

- `zsh -n` passes both fixtures (the gap is real Zsh, not a broken script).
- `go build ./... && go vet ./... && go test ./...` green — `TestMinimizedCorpus` enforces that both `gap-*` fixtures fail to parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)