### PR TITLE
feat(suppress): implement the inline suppression contract

### DIFF
--- a/docs/project/output-contract.md
+++ b/docs/project/output-contract.md
@@ -74,9 +74,9 @@ is reserved for the front end; analyzer rules must not use it.
 Per the suppression contract (`docs/project/suppression.md`): suppressed
 findings are omitted from `diagnostics`, while `meta/*` diagnostics
 (`meta/malformed-suppression`, `meta/unused-suppression`) are always
-included, so integrations can audit suppression usage. Until suppression is
-implemented in the analyzer, no `meta/*` diagnostics are emitted; their
-inclusion is not a version change.
+included, so integrations can audit suppression usage. Suppression is
+implemented in the analyzer (`internal/suppress`, #65); the introduction of
+`meta/*` diagnostics was not a version change.
 
 ## Exit codes
 

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -3,6 +3,7 @@ package analyzer
 import (
 	"github.com/z-shell/zsh-lint/internal/diag"
 	"github.com/z-shell/zsh-lint/internal/parse"
+	"github.com/z-shell/zsh-lint/internal/suppress"
 	"mvdan.cc/sh/v3/syntax"
 )
 
@@ -41,6 +42,17 @@ func (a *Analyzer) Analyze(file *parse.File, path string) diag.Diagnostics {
 			}
 			return true
 		})
+	}
+
+	// Pass 3: inline suppression (docs/project/suppression.md). Applying it
+	// here keeps human and JSON output consistent: suppressed findings are
+	// dropped and meta/* findings appended before the single final sort.
+	if ast != nil {
+		known := make(map[diag.RuleID]bool, len(a.rules))
+		for _, rule := range a.rules {
+			known[rule.ID()] = true
+		}
+		ctx.Diagnostics = suppress.Apply(suppress.Collect(file), ctx.Diagnostics, known, path)
 	}
 
 	ctx.Diagnostics.Sort()

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/z-shell/zsh-lint/internal/analyzer"
 	"github.com/z-shell/zsh-lint/internal/diag"
 	"github.com/z-shell/zsh-lint/internal/parse"
+	"github.com/z-shell/zsh-lint/internal/rules"
 	"mvdan.cc/sh/v3/syntax"
 )
 
@@ -74,5 +75,70 @@ func TestAnalyzerIndexesScopeForOptInRule(t *testing.T) {
 
 	if !rule.sawGlobal {
 		t.Fatal("scope-aware rule did not receive the declaration index")
+	}
+}
+
+func findByID(ds diag.Diagnostics, id diag.RuleID) []diag.Diagnostic {
+	var out []diag.Diagnostic
+	for _, d := range ds {
+		if d.RuleID == id {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+func TestAnalyzerAppliesSuppression(t *testing.T) {
+	code := "eval $x # zsh-lint disable=security/eval -- static table\n"
+	file, err := parse.Parse(strings.NewReader(code), "test.zsh")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	eng := analyzer.New(rules.Default()...)
+	diags := eng.Analyze(file, "test.zsh")
+
+	if got := findByID(diags, "security/eval"); len(got) != 0 {
+		t.Errorf("security/eval finding survived its suppression: %+v", got)
+	}
+	if got := findByID(diags, "quoting/unquoted-var"); len(got) != 1 {
+		t.Errorf("expected quoting/unquoted-var on the same line to be unaffected, got %d findings", len(got))
+	}
+	if got := findByID(diags, "meta/unused-suppression"); len(got) != 0 {
+		t.Errorf("used suppression reported stale: %+v", got)
+	}
+}
+
+func TestAnalyzerReportsStaleSuppression(t *testing.T) {
+	code := "print ok # zsh-lint disable=security/eval\n"
+	file, err := parse.Parse(strings.NewReader(code), "test.zsh")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	diags := analyzer.New(rules.Default()...).Analyze(file, "test.zsh")
+	got := findByID(diags, "meta/unused-suppression")
+	if len(got) != 1 {
+		t.Fatalf("expected one meta/unused-suppression, got %v", diags)
+	}
+	if got[0].Severity != diag.Info {
+		t.Errorf("stale suppression severity = %v, want Info", got[0].Severity)
+	}
+}
+
+func TestAnalyzerReportsMalformedSuppression(t *testing.T) {
+	code := "print ok # zsh-lint enable=security/eval\n"
+	file, err := parse.Parse(strings.NewReader(code), "test.zsh")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	diags := analyzer.New(rules.Default()...).Analyze(file, "test.zsh")
+	got := findByID(diags, "meta/malformed-suppression")
+	if len(got) != 1 {
+		t.Fatalf("expected one meta/malformed-suppression, got %v", diags)
+	}
+	if got[0].Severity != diag.Warning {
+		t.Errorf("malformed suppression severity = %v, want Warning", got[0].Severity)
 	}
 }

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -28,7 +28,8 @@ func (f *File) AST() *syntax.File {
 }
 
 // Lines returns the raw source split into lines (1-based line N is
-// Lines()[N-1]), without trailing newlines. Suppression-scope
+// Lines()[N-1]); each line excludes its terminating newline, and a final
+// newline does not produce a phantom empty line. Suppression-scope
 // classification needs real line content: a comment alone on a line inside
 // a multi-line construct shares the construct's AST span, so span math
 // alone cannot tell trailing from preceding directives.

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -9,14 +9,17 @@
 package parse
 
 import (
+	"bytes"
 	"io"
+	"strings"
 
 	"mvdan.cc/sh/v3/syntax"
 )
 
 // File is the parsed source produced by the front end.
 type File struct {
-	tree *syntax.File
+	tree  *syntax.File
+	lines []string
 }
 
 // AST returns the underlying mvdan.cc/sh syntax tree.
@@ -24,16 +27,30 @@ func (f *File) AST() *syntax.File {
 	return f.tree
 }
 
+// Lines returns the raw source split into lines (1-based line N is
+// Lines()[N-1]), without trailing newlines. Suppression-scope
+// classification needs real line content: a comment alone on a line inside
+// a multi-line construct shares the construct's AST span, so span math
+// alone cannot tell trailing from preceding directives.
+func (f *File) Lines() []string {
+	return f.lines
+}
+
 // Parse parses a single Zsh source read from r, using name in error
 // messages. It returns the parsed source or the first parse error.
 func Parse(r io.Reader, name string) (*File, error) {
+	src, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
 	parser := syntax.NewParser(
 		syntax.KeepComments(true),
 		syntax.Variant(syntax.LangZsh),
 	)
-	tree, err := parser.Parse(r, name)
+	tree, err := parser.Parse(bytes.NewReader(src), name)
 	if err != nil {
 		return nil, err
 	}
-	return &File{tree: tree}, nil
+	text := strings.TrimSuffix(string(src), "\n")
+	return &File{tree: tree, lines: strings.Split(text, "\n")}, nil
 }

--- a/internal/parse/parse_test.go
+++ b/internal/parse/parse_test.go
@@ -20,6 +20,24 @@ func TestParseError(t *testing.T) {
 	}
 }
 
+func TestParseRetainsSourceLines(t *testing.T) {
+	const src = "print one\n\n  # comment line\nprint two"
+	f, err := Parse(strings.NewReader(src), "lines.zsh")
+	if err != nil {
+		t.Fatalf("expected a valid parse, got error: %v", err)
+	}
+	want := []string{"print one", "", "  # comment line", "print two"}
+	got := f.Lines()
+	if len(got) != len(want) {
+		t.Fatalf("Lines() returned %d lines, want %d: %q", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Lines()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestParseFixture(t *testing.T) {
 	f, err := os.Open("testdata/sample.zsh")
 	if err != nil {

--- a/internal/suppress/suppress.go
+++ b/internal/suppress/suppress.go
@@ -1,0 +1,224 @@
+// Package suppress implements the inline suppression contract defined in
+// docs/project/suppression.md (#19, implemented under #65).
+//
+// A suppression is a comment directive of the form
+//
+//	# zsh-lint disable=<rule-id>[,<rule-id>...] [-- reason]
+//
+// with two line-based scopes: trailing (same line as code) and preceding
+// (next non-comment, non-blank source line). Malformed directives are
+// reported as meta/malformed-suppression and suppress nothing; listed rule
+// IDs that match no finding in scope are reported per ID as
+// meta/unused-suppression. meta/* findings are never suppressible, so
+// machine output always carries them (docs/project/output-contract.md).
+package suppress
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"mvdan.cc/sh/v3/syntax"
+
+	"github.com/z-shell/zsh-lint/internal/diag"
+	"github.com/z-shell/zsh-lint/internal/parse"
+)
+
+// Reserved meta diagnostic IDs (docs/project/suppression.md).
+const (
+	RuleMalformed diag.RuleID = "meta/malformed-suppression"
+	RuleUnused    diag.RuleID = "meta/unused-suppression"
+)
+
+// keyword is the directive marker, matched case-sensitively as a whole
+// token so prose like "zsh-lint-survey" never parses as a directive.
+const keyword = "zsh-lint"
+
+// slugRe is the rule-policy ID shape: category/rule-name kebab slugs.
+var slugRe = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*/[a-z0-9]+(-[a-z0-9]+)*$`)
+
+// Directive is one parsed zsh-lint comment directive.
+type Directive struct {
+	// Rules lists the rule IDs the directive disables; empty when Malformed.
+	Rules []diag.RuleID
+	// Target is the 1-based line findings must start on to be suppressed;
+	// 0 means the directive has no scope (nothing follows it).
+	Target int
+	// Range spans the source comment, for positioning meta findings.
+	Range diag.Range
+	// Malformed holds the parse-failure reason; empty means well-formed.
+	Malformed string
+}
+
+// Collect walks the parsed file's comments and returns every zsh-lint
+// directive, well-formed or not. Non-directive comments are ignored.
+func Collect(f *parse.File) []Directive {
+	lines := f.Lines()
+	var ds []Directive
+	syntax.Walk(f.AST(), func(n syntax.Node) bool {
+		c, ok := n.(*syntax.Comment)
+		if !ok {
+			return true
+		}
+		if d, ok := parseDirective(c, lines); ok {
+			ds = append(ds, d)
+		}
+		return true
+	})
+	return ds
+}
+
+// Apply filters findings through the directives: a finding is dropped when a
+// well-formed directive lists its rule ID and targets the line its range
+// starts on. meta/* findings are never dropped. Apply appends one
+// meta/malformed-suppression finding per malformed directive and one
+// meta/unused-suppression finding per listed rule ID that suppressed
+// nothing; known holds the active rule set so unknown IDs are called out.
+// The result is unsorted; callers own ordering.
+func Apply(ds []Directive, findings diag.Diagnostics, known map[diag.RuleID]bool, path string) diag.Diagnostics {
+	type key struct {
+		line int
+		id   diag.RuleID
+	}
+	type slot struct{ d, r int }
+	active := make(map[key][]slot)
+	for di, d := range ds {
+		if d.Malformed != "" || d.Target == 0 {
+			continue
+		}
+		for ri, id := range d.Rules {
+			k := key{d.Target, id}
+			active[k] = append(active[k], slot{di, ri})
+		}
+	}
+
+	used := make(map[slot]bool)
+	kept := make(diag.Diagnostics, 0, len(findings))
+	for _, f := range findings {
+		if strings.HasPrefix(string(f.RuleID), "meta/") {
+			kept = append(kept, f)
+			continue
+		}
+		if slots, ok := active[key{f.Range.Start.Line, f.RuleID}]; ok {
+			for _, s := range slots {
+				used[s] = true
+			}
+			continue
+		}
+		kept = append(kept, f)
+	}
+
+	for di, d := range ds {
+		if d.Malformed != "" {
+			kept = append(kept, diag.Diagnostic{
+				RuleID:   RuleMalformed,
+				Severity: diag.Warning,
+				Message:  fmt.Sprintf("malformed zsh-lint directive: %s; the directive suppresses nothing", d.Malformed),
+				File:     path,
+				Range:    d.Range,
+			})
+			continue
+		}
+		for ri, id := range d.Rules {
+			if used[slot{di, ri}] {
+				continue
+			}
+			msg := fmt.Sprintf("suppression for %s matched no finding in its scope", id)
+			if !known[id] {
+				msg = fmt.Sprintf("suppression for unknown rule ID %s (not in the current rule set) matched no finding in its scope", id)
+			}
+			kept = append(kept, diag.Diagnostic{
+				RuleID:   RuleUnused,
+				Severity: diag.Info,
+				Message:  msg,
+				File:     path,
+				Range:    d.Range,
+			})
+		}
+	}
+	return kept
+}
+
+// parseDirective reports whether the comment is a zsh-lint directive and, if
+// so, parses it. The keyword must be the comment's first whitespace token.
+func parseDirective(c *syntax.Comment, lines []string) (Directive, bool) {
+	fields := strings.Fields(c.Text)
+	if len(fields) == 0 || fields[0] != keyword {
+		return Directive{}, false
+	}
+	d := Directive{
+		Range:  commentRange(c),
+		Target: targetLine(int(c.Hash.Line()), int(c.Hash.Col()), lines),
+	}
+	rest := fields[1:]
+	if len(rest) == 0 {
+		d.Malformed = `missing "disable=" verb`
+		return d, true
+	}
+	verb := rest[0]
+	if !strings.HasPrefix(verb, "disable=") {
+		name := verb
+		if i := strings.IndexByte(name, '='); i >= 0 {
+			name = name[:i]
+		}
+		d.Malformed = fmt.Sprintf("unknown verb %q", name)
+		return d, true
+	}
+	if len(rest) > 1 && rest[1] != "--" {
+		if strings.HasSuffix(verb, ",") {
+			d.Malformed = "rule list must be comma-separated without spaces"
+		} else {
+			d.Malformed = `unexpected text after the rule list (use " -- " to add a reason)`
+		}
+		return d, true
+	}
+	list := strings.TrimPrefix(verb, "disable=")
+	if list == "" {
+		d.Malformed = "empty rule list"
+		return d, true
+	}
+	for _, id := range strings.Split(list, ",") {
+		if !slugRe.MatchString(id) {
+			d.Malformed = fmt.Sprintf("invalid rule ID %q", id)
+			d.Rules = nil
+			return d, true
+		}
+		d.Rules = append(d.Rules, diag.RuleID(id))
+	}
+	return d, true
+}
+
+// targetLine resolves the directive's scope per the contract: trailing when
+// code precedes the comment on its own line, otherwise the next line that is
+// neither blank nor comment-only. Returns 0 when no such line exists.
+// col is the comment's 1-based start column; for the trailing check only the
+// text before it matters, so any multi-byte drift upstream of the comment is
+// harmless (the prefix still contains the same non-whitespace content).
+func targetLine(line, col int, lines []string) int {
+	if line >= 1 && line <= len(lines) {
+		prefix := lines[line-1]
+		if col-1 >= 0 && col-1 <= len(prefix) {
+			prefix = prefix[:col-1]
+		}
+		if strings.TrimSpace(prefix) != "" {
+			return line
+		}
+	}
+	for i := line; i < len(lines); i++ {
+		t := strings.TrimSpace(lines[i])
+		if t == "" || strings.HasPrefix(t, "#") {
+			continue
+		}
+		return i + 1
+	}
+	return 0
+}
+
+// commentRange converts the comment's parser span to a diagnostic range.
+func commentRange(c *syntax.Comment) diag.Range {
+	start, end := c.Hash, c.End()
+	return diag.Range{
+		Start: diag.Position{Line: int(start.Line()), Column: int(start.Col()), Offset: int(start.Offset())},
+		End:   diag.Position{Line: int(end.Line()), Column: int(end.Col()), Offset: int(end.Offset())},
+	}
+}

--- a/internal/suppress/suppress_test.go
+++ b/internal/suppress/suppress_test.go
@@ -1,0 +1,307 @@
+package suppress
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/z-shell/zsh-lint/internal/diag"
+	"github.com/z-shell/zsh-lint/internal/parse"
+)
+
+func mustParse(t *testing.T, src string) *parse.File {
+	t.Helper()
+	f, err := parse.Parse(strings.NewReader(src), "test.zsh")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return f
+}
+
+func TestCollectDirectives(t *testing.T) {
+	tests := []struct {
+		name      string
+		src       string
+		wantLen   int
+		wantRules []diag.RuleID
+		wantTgt   int
+		wantBad   string // substring of Malformed; "" = well-formed
+	}{
+		{
+			name:      "trailing single ID",
+			src:       "eval $x # zsh-lint disable=security/eval\n",
+			wantLen:   1,
+			wantRules: []diag.RuleID{"security/eval"},
+			wantTgt:   1,
+		},
+		{
+			name:      "preceding multi ID with reason",
+			src:       "# zsh-lint disable=security/eval,quoting/unquoted-var -- table is static\neval $x\n",
+			wantLen:   1,
+			wantRules: []diag.RuleID{"security/eval", "quoting/unquoted-var"},
+			wantTgt:   2,
+		},
+		{
+			name:      "no space after hash",
+			src:       "#zsh-lint disable=style/backquotes\nfoo=`date`\n",
+			wantLen:   1,
+			wantRules: []diag.RuleID{"style/backquotes"},
+			wantTgt:   2,
+		},
+		{
+			name:    "regular comment ignored",
+			src:     "# regular comment about zsh\nprint ok\n",
+			wantLen: 0,
+		},
+		{
+			name:    "prose starting with product name variant ignored",
+			src:     "# zsh-lint-survey output below\nprint ok\n",
+			wantLen: 0,
+		},
+		{
+			name:    "missing verb",
+			src:     "# zsh-lint\nprint ok\n",
+			wantLen: 1,
+			wantBad: "missing",
+			wantTgt: 2,
+		},
+		{
+			name:    "unknown verb",
+			src:     "# zsh-lint enable=security/eval\nprint ok\n",
+			wantLen: 1,
+			wantBad: `unknown verb "enable"`,
+			wantTgt: 2,
+		},
+		{
+			name:    "empty rule list",
+			src:     "# zsh-lint disable=\nprint ok\n",
+			wantLen: 1,
+			wantBad: "empty rule list",
+			wantTgt: 2,
+		},
+		{
+			name:    "invalid rule ID",
+			src:     "# zsh-lint disable=Security/Eval\nprint ok\n",
+			wantLen: 1,
+			wantBad: `invalid rule ID "Security/Eval"`,
+			wantTgt: 2,
+		},
+		{
+			name:    "space in rule list",
+			src:     "# zsh-lint disable=security/eval, quoting/unquoted-var\nprint ok\n",
+			wantLen: 1,
+			wantBad: "without spaces",
+			wantTgt: 2,
+		},
+		{
+			name:    "junk after list",
+			src:     "# zsh-lint disable=security/eval reason without separator\nprint ok\n",
+			wantLen: 1,
+			wantBad: "unexpected text",
+			wantTgt: 2,
+		},
+		{
+			name:      "preceding skips blank and comment lines",
+			src:       "# zsh-lint disable=security/eval\n\n# explainer comment\neval $x\n",
+			wantLen:   1,
+			wantRules: []diag.RuleID{"security/eval"},
+			wantTgt:   4,
+		},
+		{
+			name:      "comment alone inside multi-line construct is preceding",
+			src:       "arr=(\n  one\n  # zsh-lint disable=quoting/unquoted-var\n  $two\n)\n",
+			wantLen:   1,
+			wantRules: []diag.RuleID{"quoting/unquoted-var"},
+			wantTgt:   4,
+		},
+		{
+			name:      "directive with no following code has no target",
+			src:       "print ok\n# zsh-lint disable=security/eval\n",
+			wantLen:   1,
+			wantRules: []diag.RuleID{"security/eval"},
+			wantTgt:   0,
+		},
+		{
+			name:      "empty reason after separator is fine",
+			src:       "eval $x # zsh-lint disable=security/eval --\n",
+			wantLen:   1,
+			wantRules: []diag.RuleID{"security/eval"},
+			wantTgt:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ds := Collect(mustParse(t, tt.src))
+			if len(ds) != tt.wantLen {
+				t.Fatalf("Collect returned %d directives, want %d: %+v", len(ds), tt.wantLen, ds)
+			}
+			if tt.wantLen == 0 {
+				return
+			}
+			d := ds[0]
+			if tt.wantBad != "" {
+				if d.Malformed == "" || !strings.Contains(d.Malformed, tt.wantBad) {
+					t.Errorf("Malformed = %q, want substring %q", d.Malformed, tt.wantBad)
+				}
+				if len(d.Rules) != 0 {
+					t.Errorf("malformed directive carries rules %v, want none", d.Rules)
+				}
+			} else {
+				if d.Malformed != "" {
+					t.Fatalf("unexpected Malformed: %q", d.Malformed)
+				}
+				if len(d.Rules) != len(tt.wantRules) {
+					t.Fatalf("Rules = %v, want %v", d.Rules, tt.wantRules)
+				}
+				for i := range tt.wantRules {
+					if d.Rules[i] != tt.wantRules[i] {
+						t.Errorf("Rules[%d] = %q, want %q", i, d.Rules[i], tt.wantRules[i])
+					}
+				}
+			}
+			if d.Target != tt.wantTgt {
+				t.Errorf("Target = %d, want %d", d.Target, tt.wantTgt)
+			}
+			if !d.Range.IsValid() {
+				t.Error("directive Range is invalid, want the comment span")
+			}
+		})
+	}
+}
+
+func finding(id diag.RuleID, line int) diag.Diagnostic {
+	return diag.Diagnostic{
+		RuleID:   id,
+		Severity: diag.Warning,
+		Message:  "x",
+		File:     "test.zsh",
+		Range: diag.Range{
+			Start: diag.Position{Line: line, Column: 1, Offset: 0},
+			End:   diag.Position{Line: line, Column: 2, Offset: 1},
+		},
+	}
+}
+
+func ids(ds diag.Diagnostics) []string {
+	var out []string
+	for _, d := range ds {
+		out = append(out, string(d.RuleID))
+	}
+	return out
+}
+
+func TestApply(t *testing.T) {
+	known := map[diag.RuleID]bool{
+		"security/eval":        true,
+		"quoting/unquoted-var": true,
+	}
+	wellFormed := func(target int, rules ...diag.RuleID) Directive {
+		return Directive{
+			Rules:  rules,
+			Target: target,
+			Range: diag.Range{
+				Start: diag.Position{Line: target, Column: 10, Offset: 9},
+				End:   diag.Position{Line: target, Column: 40, Offset: 39},
+			},
+		}
+	}
+
+	t.Run("suppresses only the listed rule on the target line", func(t *testing.T) {
+		got := Apply(
+			[]Directive{wellFormed(3, "security/eval")},
+			diag.Diagnostics{finding("security/eval", 3), finding("quoting/unquoted-var", 3), finding("security/eval", 5)},
+			known, "test.zsh",
+		)
+		want := []string{"quoting/unquoted-var", "security/eval"}
+		if len(got) != 2 || got[0].RuleID != "quoting/unquoted-var" || got[1].RuleID != "security/eval" || got[1].Range.Start.Line != 5 {
+			t.Fatalf("Apply = %v, want findings %v (other rule on line 3, eval on line 5)", ids(got), want)
+		}
+	})
+
+	t.Run("per-ID staleness within one directive", func(t *testing.T) {
+		got := Apply(
+			[]Directive{wellFormed(3, "security/eval", "quoting/unquoted-var")},
+			diag.Diagnostics{finding("security/eval", 3)},
+			known, "test.zsh",
+		)
+		if len(got) != 1 || got[0].RuleID != "meta/unused-suppression" {
+			t.Fatalf("Apply = %v, want exactly one meta/unused-suppression", ids(got))
+		}
+		if got[0].Severity != diag.Info {
+			t.Errorf("unused severity = %v, want Info", got[0].Severity)
+		}
+		if !strings.Contains(got[0].Message, "quoting/unquoted-var") {
+			t.Errorf("unused message %q does not name the stale ID", got[0].Message)
+		}
+		if strings.Contains(got[0].Message, "unknown") {
+			t.Errorf("known rule ID flagged as unknown: %q", got[0].Message)
+		}
+	})
+
+	t.Run("unknown rule ID is called out", func(t *testing.T) {
+		got := Apply(
+			[]Directive{wellFormed(3, "style/no-such-rule")},
+			nil, known, "test.zsh",
+		)
+		if len(got) != 1 || got[0].RuleID != "meta/unused-suppression" {
+			t.Fatalf("Apply = %v, want one meta/unused-suppression", ids(got))
+		}
+		if !strings.Contains(got[0].Message, "unknown rule ID") || !strings.Contains(got[0].Message, "style/no-such-rule") {
+			t.Errorf("message %q should call out the unknown rule ID", got[0].Message)
+		}
+	})
+
+	t.Run("malformed directive reports and suppresses nothing", func(t *testing.T) {
+		bad := Directive{Malformed: `unknown verb "enable"`, Target: 3,
+			Range: diag.Range{Start: diag.Position{Line: 2, Column: 1, Offset: 0}, End: diag.Position{Line: 2, Column: 30, Offset: 29}}}
+		got := Apply([]Directive{bad}, diag.Diagnostics{finding("security/eval", 3)}, known, "test.zsh")
+		if len(got) != 2 {
+			t.Fatalf("Apply = %v, want the original finding plus meta/malformed-suppression", ids(got))
+		}
+		var meta *diag.Diagnostic
+		for i := range got {
+			if got[i].RuleID == "meta/malformed-suppression" {
+				meta = &got[i]
+			}
+		}
+		if meta == nil {
+			t.Fatalf("no meta/malformed-suppression in %v", ids(got))
+		}
+		if meta.Severity != diag.Warning {
+			t.Errorf("malformed severity = %v, want Warning", meta.Severity)
+		}
+		if !strings.Contains(meta.Message, "enable") {
+			t.Errorf("malformed message %q should include the parse reason", meta.Message)
+		}
+	})
+
+	t.Run("meta findings are never suppressed", func(t *testing.T) {
+		got := Apply(
+			[]Directive{wellFormed(3, "meta/unused-suppression")},
+			diag.Diagnostics{finding("meta/unused-suppression", 3)},
+			known, "test.zsh",
+		)
+		// The meta finding survives, and the directive that tried to silence
+		// it is itself stale (its ID matched nothing suppressible).
+		var kept, stale bool
+		for _, d := range got {
+			if d.RuleID == "meta/unused-suppression" && d.Range.Start.Line == 3 && d.Message == "x" {
+				kept = true
+			}
+			if d.RuleID == "meta/unused-suppression" && d.Message != "x" {
+				stale = true
+			}
+		}
+		if !kept || !stale {
+			t.Fatalf("Apply = %+v, want the original meta finding kept and the directive reported stale", got)
+		}
+	})
+
+	t.Run("no-target directive reports all IDs unused", func(t *testing.T) {
+		d := wellFormed(0, "security/eval", "quoting/unquoted-var")
+		got := Apply([]Directive{d}, nil, known, "test.zsh")
+		if len(got) != 2 {
+			t.Fatalf("Apply = %v, want two meta/unused-suppression findings", ids(got))
+		}
+	})
+}

--- a/internal/suppress/suppress_test.go
+++ b/internal/suppress/suppress_test.go
@@ -298,10 +298,24 @@ func TestApply(t *testing.T) {
 	})
 
 	t.Run("no-target directive reports all IDs unused", func(t *testing.T) {
-		d := wellFormed(0, "security/eval", "quoting/unquoted-var")
+		// A real no-target directive (nothing follows it in the file) still
+		// has a valid comment range; the meta findings must carry it.
+		d := Directive{
+			Rules:  []diag.RuleID{"security/eval", "quoting/unquoted-var"},
+			Target: 0,
+			Range: diag.Range{
+				Start: diag.Position{Line: 5, Column: 1, Offset: 50},
+				End:   diag.Position{Line: 5, Column: 35, Offset: 84},
+			},
+		}
 		got := Apply([]Directive{d}, nil, known, "test.zsh")
 		if len(got) != 2 {
 			t.Fatalf("Apply = %v, want two meta/unused-suppression findings", ids(got))
+		}
+		for _, m := range got {
+			if m.Range.Start.Line != 5 {
+				t.Errorf("meta finding positioned at line %d, want the directive's line 5", m.Range.Start.Line)
+			}
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Implements #65 — the analyzer now honors the inline suppression contract (`docs/project/suppression.md`, #19):

- **`internal/parse`** retains source lines (`File.Lines()`): scope classification needs real line content because a comment alone on a line inside a multi-line construct shares the construct's AST span, so span math alone cannot tell trailing from preceding directives.
- **`internal/suppress`** (new): collects `# zsh-lint disable=<id>[,<id>...] [-- reason]` directives from parser comments (keyword matched as a whole token, so `zsh-lint-survey` prose never parses as a directive), classifies trailing vs preceding scope, filters findings by (target line, rule ID), and emits the contract's meta diagnostics:
  - `meta/malformed-suppression` (warning) — unknown verb, missing/empty rule list, invalid slug, space-separated list; the directive suppresses nothing.
  - `meta/unused-suppression` (info) — per listed rule ID that matched no finding in scope; unknown rule IDs are called out in the message.
  - `meta/*` findings are never themselves suppressible.
- **`internal/analyzer`**: suppression applied as a third pass before the final sort, so human and `--format=json` output stay consistent (suppressed findings omitted, `meta/*` included — per `docs/project/output-contract.md` §Suppression, whose "until implemented" wording is updated here).

No CLI changes: exit-code semantics follow naturally (`meta/malformed-suppression` is a warning → exit 1; `meta/unused-suppression` is info → exit 0).

## Verification

- `go build ./... && go vet ./... && go test ./...` green.
- New table-driven tests: 14 directive-parsing/scope cases (incl. the comment-inside-array preceding edge and a `File.Last` trailing comment), 6 Apply cases (per-ID staleness, unknown-ID callout, malformed reporting, meta unsuppressibility, no-target staleness), 3 analyzer end-to-end cases with the real default rules.
- CLI smoke test: `eval $x # zsh-lint disable=security/eval` drops only the eval finding (same-line `quoting/unquoted-var` unaffected); an unknown-ID directive surfaces as `meta/unused-suppression` in both human and JSON output with consistent summary counts.

Closes #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)