### PR TITLE
docs(rules): backfill grandfathered rule reference

### DIFF
--- a/.github/workflows/docs-generate.yml
+++ b/.github/workflows/docs-generate.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           go-version: "1.25"
       - name: 📝 Generate reference Markdown
-        run: go tool gomarkdoc --output "$RUNNER_TEMP/ref.md" ./cmd/zsh-lint ./cmd/zsh-lint-survey ./internal/survey
+        run: >-
+          go tool gomarkdoc --output "$RUNNER_TEMP/ref.md"
+          ./cmd/zsh-lint ./cmd/zsh-lint-survey ./internal/survey ./internal/rules
       - name: ✅ Verify generation is non-empty
         run: test -s "$RUNNER_TEMP/ref.md"

--- a/.github/workflows/wiki-docs-sync.yml
+++ b/.github/workflows/wiki-docs-sync.yml
@@ -77,7 +77,8 @@ jobs:
         if: steps.app.outputs.present == 'true'
         working-directory: zsh-lint
         run: |
-          go tool gomarkdoc --output "$RUNNER_TEMP/ref.md" ./cmd/zsh-lint ./cmd/zsh-lint-survey ./internal/survey
+          go tool gomarkdoc --output "$RUNNER_TEMP/ref.md" \
+            ./cmd/zsh-lint ./cmd/zsh-lint-survey ./internal/survey ./internal/rules
           go run ./cmd/wikidoc \
             -in "$RUNNER_TEMP/ref.md" \
             -mdx ../wiki/community/04_zsh_lint/index.mdx

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Canonical reader docs live on the **wiki**
 reference is generated from Go doc comments and synced into the wiki — do not
 hand-edit the generated region there. Regenerate locally with:
 
-    go tool gomarkdoc --output ref.md ./cmd/zsh-lint ./cmd/zsh-lint-survey ./internal/survey
+    go tool gomarkdoc --output ref.md ./cmd/zsh-lint ./cmd/zsh-lint-survey ./internal/survey ./internal/rules
 
 ## Writing Lint Rules
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,8 @@ by hand on the wiki.
 
 ```sh
 go build ./... && go vet ./... && go test ./...
-go tool gomarkdoc --output ref.md ./cmd/zsh-lint ./cmd/zsh-lint-survey ./internal/survey   # regenerate reference
+go tool gomarkdoc --output ref.md \
+  ./cmd/zsh-lint ./cmd/zsh-lint-survey ./internal/survey ./internal/rules
 ```
 
 The legacy interactive Zi/`.zshrc` plugin is archived under [`../legacy/`](../legacy/).

--- a/internal/rules/backquotes.go
+++ b/internal/rules/backquotes.go
@@ -7,7 +7,42 @@ import (
 	"github.com/z-shell/zsh-lint/internal/diag"
 )
 
-// Backquotes checks for deprecated backtick command substitutions.
+// Backquotes reports grave-accent command substitutions.
+//
+// ID: `style/backquotes`
+//
+// Name: Prefer dollar-parenthesis command substitution
+//
+// Summary: Reports the grave-accent form of command substitution in favor of
+// `$()`.
+//
+// Why: The Zsh manual's Command Substitution section documents both `$()` and
+// grave accents as supported forms. This rule prefers `$()` as the clearer,
+// readily nestable modern idiom; it does not claim grave accents are invalid
+// Zsh syntax.
+// See https://zsh.sourceforge.io/Doc/Release/Expansion.html#Command-Substitution.
+//
+// Bad:
+//
+//	current=`pwd`
+//
+// Good:
+//
+//	current=$(pwd)
+//
+// Severity: Hint. The forms are semantically supported; this is an idiom and
+// readability preference rather than a correctness diagnostic.
+//
+// False positives: A project may intentionally preserve historical style or
+// mirror code shared with an environment where that spelling is required.
+//
+// Suppression: Use
+// `# zsh-lint disable=style/backquotes -- <reason>` on the finding line or
+// immediately before the next non-comment, non-blank source line.
+//
+// Corpus evidence: The June 12, 2026 LangZsh clean-baseline run produced zero
+// findings from this rule across the 11 parseable corpus files. This
+// grandfathered rule therefore has no positive corpus citation yet.
 type Backquotes struct{}
 
 func (r Backquotes) ID() diag.RuleID {
@@ -15,11 +50,11 @@ func (r Backquotes) ID() diag.RuleID {
 }
 
 func (r Backquotes) Name() string {
-	return "Deprecated backtick command substitution"
+	return "Prefer dollar-parenthesis command substitution"
 }
 
 func (r Backquotes) Analyze(ctx *analyzer.Context, node syntax.Node) {
 	if cs, ok := node.(*syntax.CmdSubst); ok && cs.Backquotes {
-		ctx.Report(cs.Pos(), cs.End(), r.ID(), diag.Hint, "Use $(...) instead of deprecated `...` for command substitution")
+		ctx.Report(cs.Pos(), cs.End(), r.ID(), diag.Hint, "Prefer $(...) over grave accents for command substitution")
 	}
 }

--- a/internal/rules/backquotes.go
+++ b/internal/rules/backquotes.go
@@ -20,6 +20,6 @@ func (r Backquotes) Name() string {
 
 func (r Backquotes) Analyze(ctx *analyzer.Context, node syntax.Node) {
 	if cs, ok := node.(*syntax.CmdSubst); ok && cs.Backquotes {
-		ctx.Report(cs.Pos(), cs.End(), r.ID(), diag.Warning, "Use $(...) instead of deprecated `...` for command substitution")
+		ctx.Report(cs.Pos(), cs.End(), r.ID(), diag.Hint, "Use $(...) instead of deprecated `...` for command substitution")
 	}
 }

--- a/internal/rules/eval.go
+++ b/internal/rules/eval.go
@@ -28,7 +28,7 @@ func (r EvalUsage) Analyze(ctx *analyzer.Context, node syntax.Node) {
 	if len(word.Parts) == 1 {
 		if lit, ok := word.Parts[0].(*syntax.Lit); ok {
 			if lit.Value == "eval" {
-				ctx.Report(call.Pos(), call.End(), r.ID(), diag.Warning, "Use of 'eval' can be dangerous; ensure inputs are properly sanitized")
+				ctx.Report(call.Pos(), call.End(), r.ID(), diag.Info, "Use of 'eval' can be dangerous; ensure inputs are properly sanitized")
 			}
 		}
 	}

--- a/internal/rules/eval.go
+++ b/internal/rules/eval.go
@@ -7,7 +7,43 @@ import (
 	"github.com/z-shell/zsh-lint/internal/diag"
 )
 
-// EvalUsage checks for the use of the 'eval' command.
+// EvalUsage reports calls to the `eval` shell builtin.
+//
+// ID: `security/eval`
+//
+// Name: Use of eval
+//
+// Summary: Reports commands whose literal command name is `eval`.
+//
+// Why: The Zsh manual documents that `eval` reads its arguments as shell input
+// and executes the resulting commands in the current shell process. Dynamic or
+// untrusted text can therefore become shell syntax rather than inert data.
+// See https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-eval.
+//
+// Bad:
+//
+//	eval "print -r -- $user_input"
+//
+// Good:
+//
+//	print -r -- "$user_input"
+//
+// Severity: Info. Re-evaluating dynamic input is risky, but deliberate uses
+// such as trusted code generation and compatibility shims are common enough
+// that the pattern is not automatically a bug.
+//
+// False positives: Static, maintainer-controlled command strings and deliberate
+// shell-language adapters may require `eval`. Keep the finding visible unless
+// the trust boundary is documented next to the call.
+//
+// Suppression: Use
+// `# zsh-lint disable=security/eval -- <reason>` on the finding line or
+// immediately before the next non-comment, non-blank source line. A reason is
+// strongly recommended for this security-category rule.
+//
+// Corpus evidence: The June 12, 2026 LangZsh clean-baseline run produced zero
+// findings from this rule across the 11 parseable corpus files. This
+// grandfathered rule therefore has no positive corpus citation yet.
 type EvalUsage struct{}
 
 func (r EvalUsage) ID() diag.RuleID {

--- a/internal/rules/func_decl.go
+++ b/internal/rules/func_decl.go
@@ -7,7 +7,42 @@ import (
 	"github.com/z-shell/zsh-lint/internal/diag"
 )
 
-// FuncDeclStyle checks for mixing the 'function' keyword with '()' in declarations.
+// FuncDeclStyle reports function declarations that combine `function` and `()`.
+//
+// ID: `style/function-decl`
+//
+// Name: Function declaration style
+//
+// Summary: Reports declarations written as `function name()` instead of
+// choosing either `name()` or `function name`.
+//
+// Why: The Zsh manual's Complex Commands grammar documents the sh-compatible
+// `word ()` form and the Zsh `function word` form as alternatives. Combining
+// both spellings is accepted but redundant, so choosing one form communicates
+// the intended style more clearly.
+// See https://zsh.sourceforge.io/Doc/Release/Shell-Grammar.html#Complex-Commands.
+//
+// Bad:
+//
+//	function render() { print ok; }
+//
+// Good:
+//
+//	render() { print ok; }
+//
+// Severity: Hint. The mixed declaration is valid Zsh and the suggested change
+// is stylistic.
+//
+// False positives: Generated code or a project-wide convention may
+// intentionally use the mixed spelling even though Zsh does not require it.
+//
+// Suppression: Use
+// `# zsh-lint disable=style/function-decl -- <reason>` on the finding line or
+// immediately before the next non-comment, non-blank source line.
+//
+// Corpus evidence: The June 12, 2026 LangZsh clean-baseline run produced zero
+// findings from this rule across the 11 parseable corpus files. This
+// grandfathered rule therefore has no positive corpus citation yet.
 type FuncDeclStyle struct{}
 
 func (r FuncDeclStyle) ID() diag.RuleID {

--- a/internal/rules/func_decl.go
+++ b/internal/rules/func_decl.go
@@ -26,6 +26,6 @@ func (r FuncDeclStyle) Analyze(ctx *analyzer.Context, node syntax.Node) {
 
 	// Mixing 'function foo' and 'foo()' -> 'function foo()'
 	if decl.RsrvWord && decl.Parens {
-		ctx.Report(decl.Pos(), decl.End(), r.ID(), diag.Warning, "Avoid mixing 'function' keyword with '()' for function declarations; use 'foo()' or 'function foo'")
+		ctx.Report(decl.Pos(), decl.End(), r.ID(), diag.Hint, "Avoid mixing 'function' keyword with '()' for function declarations; use 'foo()' or 'function foo'")
 	}
 }

--- a/internal/rules/prefer_double_brackets.go
+++ b/internal/rules/prefer_double_brackets.go
@@ -28,7 +28,7 @@ func (r PreferDoubleBrackets) Analyze(ctx *analyzer.Context, node syntax.Node) {
 	if len(word.Parts) == 1 {
 		if lit, ok := word.Parts[0].(*syntax.Lit); ok {
 			if lit.Value == "[" || lit.Value == "test" {
-				ctx.Report(call.Pos(), call.End(), r.ID(), diag.Warning, "Prefer Zsh's [[ ... ]] over [ ... ] or test for conditions")
+				ctx.Report(call.Pos(), call.End(), r.ID(), diag.Hint, "Prefer Zsh's [[ ... ]] over [ ... ] or test for conditions")
 			}
 		}
 	}

--- a/internal/rules/prefer_double_brackets.go
+++ b/internal/rules/prefer_double_brackets.go
@@ -7,7 +7,43 @@ import (
 	"github.com/z-shell/zsh-lint/internal/diag"
 )
 
-// PreferDoubleBrackets flags uses of [ ] or test in favor of Zsh's [[ ]].
+// PreferDoubleBrackets reports `[` and `test` conditional commands.
+//
+// ID: `style/prefer-double-brackets`
+//
+// Name: Prefer [[ ]] over [ ] or test
+//
+// Summary: Reports literal `[` and `test` command names in favor of Zsh's
+// `[[ ... ]]` compound command.
+//
+// Why: The Zsh manual's Conditional Expressions section documents that
+// expansions inside `[[ ... ]]` are constrained to one word and do not perform
+// filename generation. With `[` or `test`, normal command-line globbing can
+// produce multiple words and confuse the test command's syntax.
+// See https://zsh.sourceforge.io/Doc/Release/Conditional-Expressions.html.
+//
+// Bad:
+//
+//	if [ "$name" = *.zsh ]; then print match; fi
+//
+// Good:
+//
+//	if [[ $name = *.zsh ]]; then print match; fi
+//
+// Severity: Hint. `[` and `test` remain valid commands; the rule recommends
+// the safer and more expressive Zsh-native conditional syntax.
+//
+// False positives: Scripts intentionally kept portable across POSIX shells, or
+// code that explicitly needs `test` command semantics, should retain the
+// portable form and document the choice.
+//
+// Suppression: Use
+// `# zsh-lint disable=style/prefer-double-brackets -- <reason>` on the finding
+// line or immediately before the next non-comment, non-blank source line.
+//
+// Corpus evidence: The June 12, 2026 LangZsh clean-baseline run produced zero
+// findings from this rule across the 11 parseable corpus files. This
+// grandfathered rule therefore has no positive corpus citation yet.
 type PreferDoubleBrackets struct{}
 
 func (r PreferDoubleBrackets) ID() diag.RuleID {

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -1,0 +1,43 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/z-shell/zsh-lint/internal/analyzer"
+	"github.com/z-shell/zsh-lint/internal/diag"
+	"github.com/z-shell/zsh-lint/internal/parse"
+)
+
+// TestRuleSeverities pins each default rule to the severity mapping in
+// docs/project/rule-policy.md: hint for style/idiom preferences, info for
+// risky-but-sometimes-intentional patterns (the policy's example is
+// security/eval), warning for likely-bug patterns.
+func TestRuleSeverities(t *testing.T) {
+	tests := []struct {
+		rule analyzer.Rule
+		src  string
+		want diag.Severity
+	}{
+		{UnquotedVar{}, "echo $x\n", diag.Warning},
+		{EvalUsage{}, "eval $cmd\n", diag.Info},
+		{Backquotes{}, "echo `pwd`\n", diag.Hint},
+		{FuncDeclStyle{}, "function f() { :; }\n", diag.Hint},
+		{PreferDoubleBrackets{}, "if [ -f x ]; then :; fi\n", diag.Hint},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.rule.ID()), func(t *testing.T) {
+			f, err := parse.Parse(strings.NewReader(tt.src), "test.zsh")
+			if err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+			diags := analyzer.New(tt.rule).Analyze(f, "test.zsh")
+			if len(diags) == 0 {
+				t.Fatalf("rule %s produced no finding on %q", tt.rule.ID(), tt.src)
+			}
+			if got := diags[0].Severity; got != tt.want {
+				t.Errorf("rule %s severity = %v, want %v", tt.rule.ID(), got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/rules/unquoted_var.go
+++ b/internal/rules/unquoted_var.go
@@ -7,9 +7,45 @@ import (
 	"github.com/z-shell/zsh-lint/internal/diag"
 )
 
-// UnquotedVar checks for variable expansions that are not enclosed in double quotes.
-// Zsh does not perform word splitting by default, but quoting is still recommended
-// for safety and portability (e.g. against empty values).
+// UnquotedVar reports direct, unquoted parameter expansions in command words.
+//
+// ID: `quoting/unquoted-var`
+//
+// Name: Unquoted variable expansion
+//
+// Summary: Reports parameter expansions in command names or arguments that are
+// not enclosed in double quotes.
+//
+// Why: The Zsh manual's Parameter Expansion section explains that unquoted
+// parameters are not split on whitespace by default, unlike in sh, but null
+// words are still elided; enabling `SH_WORD_SPLIT` also makes unquoted values
+// subject to field splitting. Double quotes preserve an empty scalar as an
+// argument and keep the expansion single-word under either option state.
+// See https://zsh.sourceforge.io/Doc/Release/Expansion.html#Parameter-Expansion.
+//
+// Bad:
+//
+//	print -r -- $value
+//
+// Good:
+//
+//	print -r -- "$value"
+//
+// Severity: Warning. Losing an empty argument or inheriting `SH_WORD_SPLIT`
+// can change command behavior, while intentional elision remains realistic.
+//
+// False positives: Code may intentionally omit an empty argument, deliberately
+// rely on `SH_WORD_SPLIT`, or expand a value guaranteed to be non-empty. Those
+// cases should use a reasoned suppression rather than weakening unrelated
+// diagnostics.
+//
+// Suppression: Use
+// `# zsh-lint disable=quoting/unquoted-var -- <reason>` on the finding line or
+// immediately before the next non-comment, non-blank source line.
+//
+// Corpus evidence: The June 12, 2026 LangZsh clean-baseline run produced zero
+// findings from this rule across the 11 parseable corpus files. This
+// grandfathered rule therefore has no positive corpus citation yet.
 type UnquotedVar struct{}
 
 func (r UnquotedVar) ID() diag.RuleID {
@@ -21,10 +57,11 @@ func (r UnquotedVar) Name() string {
 }
 
 func (r UnquotedVar) Analyze(ctx *analyzer.Context, node syntax.Node) {
-	// Only inspect command words: the command name and its arguments. An
-	// unquoted expansion there is subject to word splitting and globbing. This
-	// deliberately excludes assignment right-hand sides (e.g. A=$BAZ), where
-	// expansion is safe in both Zsh and Bash.
+	// Only inspect command words: the command name and its arguments. Empty
+	// unquoted expansions can be elided there, and SH_WORD_SPLIT can split
+	// their values into multiple arguments. This deliberately excludes
+	// assignment right-hand sides (e.g. A=$BAZ), where the rule's
+	// argument-vector preservation rationale does not apply.
 	call, ok := node.(*syntax.CallExpr)
 	if !ok {
 		return


### PR DESCRIPTION
## Summary

- align the five grandfathered rule severities with the first-wave rule policy
- add the complete generated-reference schema to every grandfathered rule
- ground rule rationale in the official Zsh manual and correct the unsupported backquotes deprecation wording
- include `./internal/rules` in CI generation, wiki sync, and contributor commands
- record the June 12, 2026 clean-baseline result honestly: zero findings across the 11 LangZsh-parseable corpus files

Resolves #66

## Verification

- rule schema source contract: all five rule types contain ID, Name, Summary, Why, Bad, Good, Severity, False positives, Suppression, and Corpus evidence
- gomarkdoc package contract: `./internal/rules` is present in both workflows and contributor commands
- workflow YAML parse via Ruby Psych
- `gofmt -d` via the cached `docker-zd` Go toolchain: no output
- `git diff --check` for non-Go files

Full Go 1.25 tests and gomarkdoc generation are delegated to this PR's trusted CI because the local host does not provide Go 1.25 and external toolchain/module downloads were not authorized.