### PR TITLE
feat(rules): add plugin/function-scoped-options rule

### DIFF
--- a/internal/rules/function_scoped_options.go
+++ b/internal/rules/function_scoped_options.go
@@ -81,9 +81,7 @@ func isOptionScopingStatement(stmt *syntax.Stmt) bool {
 func hasUnsafeStatementEffect(stmt *syntax.Stmt) bool {
 	return stmt.Background ||
 		stmt.Coprocess ||
-		stmt.Disown ||
-		stmt.Negated ||
-		len(stmt.Redirs) != 0
+		stmt.Disown
 }
 
 func literalCommand(call *syntax.CallExpr) (int, string, bool) {

--- a/internal/rules/function_scoped_options.go
+++ b/internal/rules/function_scoped_options.go
@@ -55,7 +55,7 @@ func hasFunctionsPathSegment(path string) bool {
 }
 
 func isOptionScopingStatement(stmt *syntax.Stmt) bool {
-	if stmt == nil {
+	if stmt == nil || hasUnsafeStatementEffect(stmt) {
 		return false
 	}
 	call, ok := stmt.Cmd.(*syntax.CallExpr)
@@ -76,6 +76,14 @@ func isOptionScopingStatement(stmt *syntax.Stmt) bool {
 	default:
 		return false
 	}
+}
+
+func hasUnsafeStatementEffect(stmt *syntax.Stmt) bool {
+	return stmt.Background ||
+		stmt.Coprocess ||
+		stmt.Disown ||
+		stmt.Negated ||
+		len(stmt.Redirs) != 0
 }
 
 func literalCommand(call *syntax.CallExpr) (int, string, bool) {
@@ -119,6 +127,12 @@ func isLocalZshEmulate(args []*syntax.Word) bool {
 		values[i] = value
 	}
 
+	for _, value := range values {
+		if strings.HasPrefix(value, "-") && strings.Contains(value[1:], "c") {
+			return false
+		}
+	}
+
 	local := false
 	for _, value := range values {
 		if value == "zsh" {
@@ -144,12 +158,23 @@ func enablesLocalOptions(args []*syntax.Word) bool {
 		values[i] = value
 	}
 
-	for _, value := range values {
+	var localOptionsEnabled *bool
+	for i := 0; i < len(values); i++ {
+		value := values[i]
+		if (value == "+o" || value == "-o") && i+1 < len(values) {
+			i++
+			if normalizeOptionName(values[i]) == "localoptions" {
+				enabled := value == "-o"
+				localOptionsEnabled = &enabled
+			}
+			continue
+		}
 		if normalizeOptionName(value) == "localoptions" {
-			return true
+			enabled := true
+			localOptionsEnabled = &enabled
 		}
 	}
-	return false
+	return localOptionsEnabled != nil && *localOptionsEnabled
 }
 
 func normalizeOptionName(value string) string {

--- a/internal/rules/function_scoped_options.go
+++ b/internal/rules/function_scoped_options.go
@@ -171,7 +171,20 @@ func isLiteralReturnStatement(stmt *syntax.Stmt) bool {
 	if !ok || command != "return" {
 		return false
 	}
-	for _, arg := range call.Args[commandIndex+1:] {
+	args := call.Args[commandIndex+1:]
+	// Zsh return accepts at most one status, optionally after "--". Treating
+	// extra literal words as a guard is unsafe because return reports an error
+	// and execution continues in the function.
+	if len(args) > 2 {
+		return false
+	}
+	if len(args) == 2 {
+		optionTerminator, ok := literalWord(args[0])
+		if !ok || optionTerminator != "--" {
+			return false
+		}
+	}
+	for _, arg := range args {
 		if _, ok := literalWord(arg); !ok {
 			return false
 		}

--- a/internal/rules/function_scoped_options.go
+++ b/internal/rules/function_scoped_options.go
@@ -110,12 +110,17 @@ func literalWord(word *syntax.Word) (string, bool) {
 }
 
 func isLocalZshEmulate(args []*syntax.Word) bool {
-	local := false
-	for _, arg := range args {
+	values := make([]string, len(args))
+	for i, arg := range args {
 		value, ok := literalWord(arg)
 		if !ok {
 			return false
 		}
+		values[i] = value
+	}
+
+	local := false
+	for _, value := range values {
 		if value == "zsh" {
 			return local
 		}
@@ -130,9 +135,17 @@ func isLocalZshEmulate(args []*syntax.Word) bool {
 }
 
 func enablesLocalOptions(args []*syntax.Word) bool {
-	for _, arg := range args {
+	values := make([]string, len(args))
+	for i, arg := range args {
 		value, ok := literalWord(arg)
-		if ok && normalizeOptionName(value) == "localoptions" {
+		if !ok {
+			return false
+		}
+		values[i] = value
+	}
+
+	for _, value := range values {
+		if normalizeOptionName(value) == "localoptions" {
 			return true
 		}
 	}

--- a/internal/rules/function_scoped_options.go
+++ b/internal/rules/function_scoped_options.go
@@ -161,14 +161,22 @@ func enablesLocalOptions(args []*syntax.Word) bool {
 		value := values[i]
 		if (value == "+o" || value == "-o") && i+1 < len(values) {
 			i++
-			if normalizeOptionName(values[i]) == "localoptions" {
+			switch normalizeOptionName(values[i]) {
+			case "localoptions":
 				enabled := value == "-o"
+				localOptionsEnabled = &enabled
+			case "nolocaloptions":
+				enabled := value == "+o"
 				localOptionsEnabled = &enabled
 			}
 			continue
 		}
-		if normalizeOptionName(value) == "localoptions" {
+		switch normalizeOptionName(value) {
+		case "localoptions":
 			enabled := true
+			localOptionsEnabled = &enabled
+		case "nolocaloptions":
+			enabled := false
 			localOptionsEnabled = &enabled
 		}
 	}

--- a/internal/rules/function_scoped_options.go
+++ b/internal/rules/function_scoped_options.go
@@ -1,0 +1,144 @@
+package rules
+
+import (
+	"strings"
+
+	"github.com/z-shell/zsh-lint/internal/analyzer"
+	"github.com/z-shell/zsh-lint/internal/diag"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// FunctionScopedOptions reports autoloadable function files that execute logic
+// before localizing inherited shell options.
+type FunctionScopedOptions struct{}
+
+func (FunctionScopedOptions) ID() diag.RuleID {
+	return "plugin/function-scoped-options"
+}
+
+func (FunctionScopedOptions) Name() string {
+	return "Function files should scope shell options"
+}
+
+func (rule FunctionScopedOptions) Analyze(ctx *analyzer.Context, node syntax.Node) {
+	file, ok := node.(*syntax.File)
+	if !ok || !hasFunctionsPathSegment(ctx.FilePath) {
+		return
+	}
+
+	for _, stmt := range file.Stmts {
+		if stmt == nil {
+			continue
+		}
+		if isOptionScopingStatement(stmt) {
+			return
+		}
+		ctx.Report(
+			stmt.Pos(),
+			stmt.End(),
+			rule.ID(),
+			diag.Hint,
+			"Scope function options with 'builtin emulate -L zsh' or 'setopt local_options' before executable logic",
+		)
+		return
+	}
+}
+
+func hasFunctionsPathSegment(path string) bool {
+	normalized := strings.ReplaceAll(path, `\`, "/")
+	for _, segment := range strings.Split(normalized, "/") {
+		if segment == "functions" {
+			return true
+		}
+	}
+	return false
+}
+
+func isOptionScopingStatement(stmt *syntax.Stmt) bool {
+	if stmt == nil {
+		return false
+	}
+	call, ok := stmt.Cmd.(*syntax.CallExpr)
+	if !ok || len(call.Assigns) != 0 {
+		return false
+	}
+
+	commandIndex, command, ok := literalCommand(call)
+	if !ok {
+		return false
+	}
+
+	switch command {
+	case "emulate":
+		return isLocalZshEmulate(call.Args[commandIndex+1:])
+	case "setopt":
+		return enablesLocalOptions(call.Args[commandIndex+1:])
+	default:
+		return false
+	}
+}
+
+func literalCommand(call *syntax.CallExpr) (int, string, bool) {
+	if call == nil || len(call.Args) == 0 {
+		return 0, "", false
+	}
+
+	command, ok := literalWord(call.Args[0])
+	if !ok {
+		return 0, "", false
+	}
+	if command != "builtin" {
+		return 0, command, true
+	}
+	if len(call.Args) < 2 {
+		return 0, "", false
+	}
+
+	command, ok = literalWord(call.Args[1])
+	return 1, command, ok
+}
+
+func literalWord(word *syntax.Word) (string, bool) {
+	if word == nil || len(word.Parts) != 1 {
+		return "", false
+	}
+	literal, ok := word.Parts[0].(*syntax.Lit)
+	if !ok {
+		return "", false
+	}
+	return literal.Value, true
+}
+
+func isLocalZshEmulate(args []*syntax.Word) bool {
+	local := false
+	for _, arg := range args {
+		value, ok := literalWord(arg)
+		if !ok {
+			return false
+		}
+		if value == "zsh" {
+			return local
+		}
+		if !strings.HasPrefix(value, "-") {
+			return false
+		}
+		if strings.Contains(value[1:], "L") {
+			local = true
+		}
+	}
+	return false
+}
+
+func enablesLocalOptions(args []*syntax.Word) bool {
+	for _, arg := range args {
+		value, ok := literalWord(arg)
+		if ok && normalizeOptionName(value) == "localoptions" {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeOptionName(value string) string {
+	return strings.ToLower(strings.ReplaceAll(value, "_", ""))
+}

--- a/internal/rules/function_scoped_options.go
+++ b/internal/rules/function_scoped_options.go
@@ -10,6 +10,58 @@ import (
 
 // FunctionScopedOptions reports autoloadable function files that execute logic
 // before localizing inherited shell options.
+//
+// ID: `plugin/function-scoped-options`
+//
+// Name: Function files should scope shell options
+//
+// Summary: Reports executable files beneath a `functions` directory when
+// neither `builtin emulate -L zsh` nor `setopt local_options` appears before
+// the first non-guard top-level statement.
+//
+// Why: Zsh functions inherit the caller's option state. The Zsh manual
+// documents `LOCAL_OPTIONS` as restoring options on function return, while
+// `emulate -L` both selects Zsh emulation and makes option changes local.
+// Without either form, options such as `SH_WORD_SPLIT`, `KSH_ARRAYS`, or
+// `NO_EXTENDED_GLOB` can silently change function behavior.
+// See https://zsh.sourceforge.io/Doc/Release/Options.html#index-LOCAL_005fOPTIONS
+// and
+// https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-emulate.
+//
+// Bad:
+//
+//	local -a matches
+//	matches=( $~pattern )
+//
+// Good:
+//
+//	builtin emulate -L zsh
+//	local -a matches
+//	matches=( $~pattern )
+//
+// Severity: Hint. Missing option scoping enables latent caller-dependent bugs,
+// but some helper functions intentionally inspect or mutate caller option
+// state.
+//
+// False positives: Functions that intentionally share caller option state and
+// trivial single-builtin functions remain findings by design; suppress them
+// with a reason. Files outside a complete `functions` path segment are out of
+// scope. A contiguous prefix of recognized `condition || return` or
+// single-return `if` guards is accepted before scoping.
+//
+// Suppression: Use
+// `# zsh-lint disable=plugin/function-scoped-options -- <reason>` on the
+// finding line or immediately before the next non-comment, non-blank source
+// line.
+//
+// Corpus evidence: Issue #63 reported missing scoping across z-a-meta-plugins
+// and zsh-fancy-completions function files. The analyzer currently flags
+// `zsh-fancy-completions/functions/.completion-prediction` and
+// `zsh-fancy-completions/functions/.force_rehash`. The originally cited
+// `z-a-meta-plugins/functions/.za-meta-plugins-meta-cmd-help-handler` is a
+// fully commented-out stub and is correctly silent. Compliant
+// `setopt local_options` and `builtin emulate -L zsh` examples exist in the
+// same repositories.
 type FunctionScopedOptions struct{}
 
 func (FunctionScopedOptions) ID() diag.RuleID {

--- a/internal/rules/function_scoped_options.go
+++ b/internal/rules/function_scoped_options.go
@@ -33,6 +33,9 @@ func (rule FunctionScopedOptions) Analyze(ctx *analyzer.Context, node syntax.Nod
 		if isOptionScopingStatement(stmt) {
 			return
 		}
+		if isLeadingReturnGuard(stmt) {
+			continue
+		}
 		ctx.Report(
 			stmt.Pos(),
 			stmt.End(),
@@ -82,6 +85,52 @@ func hasUnsafeStatementEffect(stmt *syntax.Stmt) bool {
 	return stmt.Background ||
 		stmt.Coprocess ||
 		stmt.Disown
+}
+
+func isLeadingReturnGuard(stmt *syntax.Stmt) bool {
+	if stmt == nil || hasUnsafeGuardEffect(stmt) {
+		return false
+	}
+
+	switch command := stmt.Cmd.(type) {
+	case *syntax.BinaryCmd:
+		return command.Op == syntax.OrStmt && isLiteralReturnStatement(command.Y)
+	case *syntax.IfClause:
+		return command.Else == nil &&
+			len(command.Cond) > 0 &&
+			len(command.Then) == 1 &&
+			isLiteralReturnStatement(command.Then[0])
+	default:
+		return false
+	}
+}
+
+func isLiteralReturnStatement(stmt *syntax.Stmt) bool {
+	if stmt == nil || hasUnsafeGuardEffect(stmt) {
+		return false
+	}
+
+	call, ok := stmt.Cmd.(*syntax.CallExpr)
+	if !ok || len(call.Assigns) != 0 {
+		return false
+	}
+
+	commandIndex, command, ok := literalCommand(call)
+	if !ok || command != "return" {
+		return false
+	}
+	for _, arg := range call.Args[commandIndex+1:] {
+		if _, ok := literalWord(arg); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func hasUnsafeGuardEffect(stmt *syntax.Stmt) bool {
+	return stmt.Negated ||
+		hasUnsafeStatementEffect(stmt) ||
+		len(stmt.Redirs) != 0
 }
 
 func literalCommand(call *syntax.CallExpr) (int, string, bool) {

--- a/internal/rules/function_scoped_options_test.go
+++ b/internal/rules/function_scoped_options_test.go
@@ -198,3 +198,109 @@ func TestFunctionScopedOptionsStatementOrder(t *testing.T) {
 		})
 	}
 }
+
+func TestFunctionScopedOptionsLeadingGuards(t *testing.T) {
+	tests := []struct {
+		name      string
+		src       string
+		wantLines []int
+	}{
+		{
+			name: "accepts or-return guard",
+			src:  "(( $+commands[eza] )) || return 1\nemulate -L zsh\nrehash\n",
+		},
+		{
+			name: "accepts builtin return guard",
+			src:  "(( $+commands[eza] )) || builtin return 1\nsetopt local_options\nrehash\n",
+		},
+		{
+			name: "accepts bare return guard",
+			src:  "(( $+commands[eza] )) || return\nemulate -L zsh\nrehash\n",
+		},
+		{
+			name: "accepts literal return arguments",
+			src:  "(( $+commands[eza] )) || return 1 ignored\nemulate -L zsh\nrehash\n",
+		},
+		{
+			name: "accepts negated guard condition",
+			src:  "! (( $+commands[eza] )) || return 1\nemulate -L zsh\nrehash\n",
+		},
+		{
+			name: "accepts single-return if guard",
+			src:  "if [[ $TERM == dumb ]]; then\n  return 0\nfi\nemulate -L zsh\nrehash\n",
+		},
+		{
+			name: "accepts contiguous leading guards",
+			src:  "(( $+commands[eza] )) || return 1\nif [[ $TERM == dumb ]]; then\n  builtin return 0\nfi\nemulate -L zsh\nrehash\n",
+		},
+		{
+			name:      "rejects non-return or branch",
+			src:       "(( $+commands[eza] )) || print missing\nemulate -L zsh\n",
+			wantLines: []int{1},
+		},
+		{
+			name:      "rejects assigned return branch",
+			src:       "(( $+commands[eza] )) || status=1 return 1\nemulate -L zsh\n",
+			wantLines: []int{1},
+		},
+		{
+			name:      "rejects background return branch",
+			src:       "(( $+commands[eza] )) || return 1 &\nemulate -L zsh\n",
+			wantLines: []int{1},
+		},
+		{
+			name:      "rejects redirected return branch",
+			src:       "(( $+commands[eza] )) || return 1 >/dev/null\nemulate -L zsh\n",
+			wantLines: []int{1},
+		},
+		{
+			name:      "rejects negated return branch",
+			src:       "(( $+commands[eza] )) || ! return 1\nemulate -L zsh\n",
+			wantLines: []int{1},
+		},
+		{
+			name:      "rejects if body with work before return",
+			src:       "if [[ $TERM == dumb ]]; then\n  print skipped\n  return 0\nfi\nemulate -L zsh\n",
+			wantLines: []int{1},
+		},
+		{
+			name:      "rejects if with else branch",
+			src:       "if [[ $TERM == dumb ]]; then\n  return 0\nelse\n  return 1\nfi\nemulate -L zsh\n",
+			wantLines: []int{1},
+		},
+		{
+			name:      "rejects if with elif branch",
+			src:       "if [[ $TERM == dumb ]]; then\n  return 0\nelif [[ $TERM == unknown ]]; then\n  return 1\nfi\nemulate -L zsh\n",
+			wantLines: []int{1},
+		},
+		{
+			name:      "reports first statement after accepted guard",
+			src:       "(( $+commands[eza] )) || return 1\nprint preparing\nemulate -L zsh\n",
+			wantLines: []int{2},
+		},
+		{
+			name:      "later guard does not rescue ordinary statement",
+			src:       "print preparing\n(( $+commands[eza] )) || return 1\nemulate -L zsh\n",
+			wantLines: []int{1},
+		},
+		{
+			name:      "rejects dynamic return status",
+			src:       "(( $+commands[eza] )) || return \"$status\"\nemulate -L zsh\n",
+			wantLines: []int{1},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := analyzeFunctionScopedOptions(t, "functions/handler", test.src)
+			if len(got) != len(test.wantLines) {
+				t.Fatalf("diagnostic lines = %v, want %v", got, test.wantLines)
+			}
+			for i := range got {
+				if got[i] != test.wantLines[i] {
+					t.Errorf("diagnostic lines = %v, want %v", got, test.wantLines)
+				}
+			}
+		})
+	}
+}

--- a/internal/rules/function_scoped_options_test.go
+++ b/internal/rules/function_scoped_options_test.go
@@ -78,6 +78,11 @@ func TestFunctionScopedOptionsStatementOrder(t *testing.T) {
 			src:  "builtin emulate -LR zsh -o extended_glob\nrehash\n",
 		},
 		{
+			name: "accepts redirected emulate",
+			path: "functions/handler",
+			src:  "emulate -L zsh 2>/dev/null\nrehash\n",
+		},
+		{
 			name:      "rejects background emulate",
 			path:      "functions/handler",
 			src:       "emulate -L zsh &\nrehash\n",
@@ -116,6 +121,16 @@ func TestFunctionScopedOptionsStatementOrder(t *testing.T) {
 			name: "accepts builtin setopt and compact option name",
 			path: "functions/handler",
 			src:  "builtin setopt localoptions\nrehash\n",
+		},
+		{
+			name: "accepts redirected setopt",
+			path: "functions/handler",
+			src:  "setopt local_options >/dev/null\nrehash\n",
+		},
+		{
+			name: "accepts negated setopt",
+			path: "functions/handler",
+			src:  "! setopt local_options\nrehash\n",
 		},
 		{
 			name:      "rejects background setopt",

--- a/internal/rules/function_scoped_options_test.go
+++ b/internal/rules/function_scoped_options_test.go
@@ -304,3 +304,18 @@ func TestFunctionScopedOptionsLeadingGuards(t *testing.T) {
 		})
 	}
 }
+
+func TestFunctionScopedOptionsSuppression(t *testing.T) {
+	src := `# zsh-lint disable=plugin/function-scoped-options -- intentionally inherits caller options
+rehash
+`
+	file, err := parse.Parse(strings.NewReader(src), "functions/handler")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	diags := analyzer.New(FunctionScopedOptions{}).Analyze(file, "functions/handler")
+	if len(diags) != 0 {
+		t.Fatalf("suppressed diagnostics = %v, want none", diags)
+	}
+}

--- a/internal/rules/function_scoped_options_test.go
+++ b/internal/rules/function_scoped_options_test.go
@@ -1,0 +1,138 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/z-shell/zsh-lint/internal/analyzer"
+	"github.com/z-shell/zsh-lint/internal/parse"
+)
+
+func analyzeFunctionScopedOptions(t *testing.T, path, src string) []int {
+	t.Helper()
+
+	file, err := parse.Parse(strings.NewReader(src), path)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	diags := analyzer.New(FunctionScopedOptions{}).Analyze(file, path)
+	lines := make([]int, len(diags))
+	for i, diagnostic := range diags {
+		if diagnostic.RuleID != "plugin/function-scoped-options" {
+			t.Fatalf("diagnostic %d rule ID = %q", i, diagnostic.RuleID)
+		}
+		lines[i] = diagnostic.Range.Start.Line
+	}
+	return lines
+}
+
+func TestFunctionScopedOptionsStatementOrder(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		src       string
+		wantLines []int
+	}{
+		{
+			name:      "reports executable function file",
+			path:      "functions/.my-widget",
+			src:       "local -a matches\nmatches=( $~pattern )\n",
+			wantLines: []int{1},
+		},
+		{
+			name:      "reports absolute function path",
+			path:      "/checkout/plugin/functions/handler",
+			src:       "rehash\n",
+			wantLines: []int{1},
+		},
+		{
+			name:      "reports windows-separated function path",
+			path:      `C:\checkout\plugin\functions\handler`,
+			src:       "rehash\n",
+			wantLines: []int{1},
+		},
+		{
+			name: "ignores sourced library",
+			path: "lib/helpers.zsh",
+			src:  "rehash\n",
+		},
+		{
+			name: "ignores partial directory-name match",
+			path: "my-functions/handler",
+			src:  "rehash\n",
+		},
+		{
+			name: "accepts builtin emulate",
+			path: "functions/handler",
+			src:  "builtin emulate -L zsh\nrehash\n",
+		},
+		{
+			name: "accepts bare emulate",
+			path: "functions/handler",
+			src:  "emulate -L zsh\nrehash\n",
+		},
+		{
+			name: "accepts grouped emulate flags and trailing argument",
+			path: "functions/handler",
+			src:  "builtin emulate -LR zsh -o extended_glob\nrehash\n",
+		},
+		{
+			name:      "rejects emulate without local flag",
+			path:      "functions/handler",
+			src:       "emulate -R zsh\nrehash\n",
+			wantLines: []int{1},
+		},
+		{
+			name:      "rejects emulate for another shell",
+			path:      "functions/handler",
+			src:       "emulate -L sh\nrehash\n",
+			wantLines: []int{1},
+		},
+		{
+			name: "accepts normalized local options",
+			path: "functions/handler",
+			src:  "setopt LOCAL_OPTIONS extended_glob\nrehash\n",
+		},
+		{
+			name: "accepts builtin setopt and compact option name",
+			path: "functions/handler",
+			src:  "builtin setopt localoptions\nrehash\n",
+		},
+		{
+			name:      "reports command before later scoping",
+			path:      "functions/handler",
+			src:       "print preparing\nemulate -L zsh\n",
+			wantLines: []int{1},
+		},
+		{
+			name:      "reports assignment before later scoping",
+			path:      "functions/handler",
+			src:       "mode=fast\nemulate -L zsh\n",
+			wantLines: []int{1},
+		},
+		{
+			name: "ignores empty file",
+			path: "functions/handler",
+		},
+		{
+			name: "ignores comment-only file",
+			path: "functions/handler",
+			src:  "# no executable logic\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := analyzeFunctionScopedOptions(t, test.path, test.src)
+			if len(got) != len(test.wantLines) {
+				t.Fatalf("diagnostic lines = %v, want %v", got, test.wantLines)
+			}
+			for i := range got {
+				if got[i] != test.wantLines[i] {
+					t.Errorf("diagnostic lines = %v, want %v", got, test.wantLines)
+				}
+			}
+		})
+	}
+}

--- a/internal/rules/function_scoped_options_test.go
+++ b/internal/rules/function_scoped_options_test.go
@@ -145,6 +145,17 @@ func TestFunctionScopedOptionsStatementOrder(t *testing.T) {
 			wantLines: []int{1},
 		},
 		{
+			name:      "rejects inverse local options after enabling",
+			path:      "functions/handler",
+			src:       "setopt local_options no_local_options\nrehash\n",
+			wantLines: []int{1},
+		},
+		{
+			name: "accepts local options after inverse",
+			path: "functions/handler",
+			src:  "setopt no_local_options local_options\nrehash\n",
+		},
+		{
 			name:      "rejects dynamic setopt argument",
 			path:      "functions/handler",
 			src:       "setopt \"$dynamic\" local_options\nrehash\n",

--- a/internal/rules/function_scoped_options_test.go
+++ b/internal/rules/function_scoped_options_test.go
@@ -218,8 +218,13 @@ func TestFunctionScopedOptionsLeadingGuards(t *testing.T) {
 			src:  "(( $+commands[eza] )) || return\nemulate -L zsh\nrehash\n",
 		},
 		{
-			name: "accepts literal return arguments",
-			src:  "(( $+commands[eza] )) || return 1 ignored\nemulate -L zsh\nrehash\n",
+			name: "accepts option-terminated literal return status",
+			src:  "(( $+commands[eza] )) || return -- 1\nemulate -L zsh\nrehash\n",
+		},
+		{
+			name:      "rejects too many literal return arguments",
+			src:       "(( $+commands[eza] )) || return 1 ignored\nemulate -L zsh\n",
+			wantLines: []int{1},
 		},
 		{
 			name: "accepts negated guard condition",

--- a/internal/rules/function_scoped_options_test.go
+++ b/internal/rules/function_scoped_options_test.go
@@ -78,6 +78,18 @@ func TestFunctionScopedOptionsStatementOrder(t *testing.T) {
 			src:  "builtin emulate -LR zsh -o extended_glob\nrehash\n",
 		},
 		{
+			name:      "rejects background emulate",
+			path:      "functions/handler",
+			src:       "emulate -L zsh &\nrehash\n",
+			wantLines: []int{1},
+		},
+		{
+			name:      "rejects emulate command mode",
+			path:      "functions/handler",
+			src:       "emulate -L zsh -c true\nrehash\n",
+			wantLines: []int{1},
+		},
+		{
 			name:      "rejects dynamic emulate trailing argument",
 			path:      "functions/handler",
 			src:       "emulate -L zsh \"$dynamic\"\nrehash\n",
@@ -104,6 +116,18 @@ func TestFunctionScopedOptionsStatementOrder(t *testing.T) {
 			name: "accepts builtin setopt and compact option name",
 			path: "functions/handler",
 			src:  "builtin setopt localoptions\nrehash\n",
+		},
+		{
+			name:      "rejects background setopt",
+			path:      "functions/handler",
+			src:       "setopt local_options &\nrehash\n",
+			wantLines: []int{1},
+		},
+		{
+			name:      "rejects disabling local options",
+			path:      "functions/handler",
+			src:       "setopt +o local_options\nrehash\n",
+			wantLines: []int{1},
 		},
 		{
 			name:      "rejects dynamic setopt argument",

--- a/internal/rules/function_scoped_options_test.go
+++ b/internal/rules/function_scoped_options_test.go
@@ -78,6 +78,12 @@ func TestFunctionScopedOptionsStatementOrder(t *testing.T) {
 			src:  "builtin emulate -LR zsh -o extended_glob\nrehash\n",
 		},
 		{
+			name:      "rejects dynamic emulate trailing argument",
+			path:      "functions/handler",
+			src:       "emulate -L zsh \"$dynamic\"\nrehash\n",
+			wantLines: []int{1},
+		},
+		{
 			name:      "rejects emulate without local flag",
 			path:      "functions/handler",
 			src:       "emulate -R zsh\nrehash\n",
@@ -98,6 +104,12 @@ func TestFunctionScopedOptionsStatementOrder(t *testing.T) {
 			name: "accepts builtin setopt and compact option name",
 			path: "functions/handler",
 			src:  "builtin setopt localoptions\nrehash\n",
+		},
+		{
+			name:      "rejects dynamic setopt argument",
+			path:      "functions/handler",
+			src:       "setopt \"$dynamic\" local_options\nrehash\n",
+			wantLines: []int{1},
 		},
 		{
 			name:      "reports command before later scoping",

--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -12,5 +12,6 @@ func Default() []analyzer.Rule {
 		PreferDoubleBrackets{},
 		EvalUsage{},
 		FuncDeclStyle{},
+		FunctionScopedOptions{},
 	}
 }

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -17,21 +17,23 @@ func TestRuleSeverities(t *testing.T) {
 	tests := []struct {
 		rule analyzer.Rule
 		src  string
+		path string
 		want diag.Severity
 	}{
-		{UnquotedVar{}, "echo $x\n", diag.Warning},
-		{EvalUsage{}, "eval $cmd\n", diag.Info},
-		{Backquotes{}, "echo `pwd`\n", diag.Hint},
-		{FuncDeclStyle{}, "function f() { :; }\n", diag.Hint},
-		{PreferDoubleBrackets{}, "if [ -f x ]; then :; fi\n", diag.Hint},
+		{UnquotedVar{}, "echo $x\n", "test.zsh", diag.Warning},
+		{EvalUsage{}, "eval $cmd\n", "test.zsh", diag.Info},
+		{Backquotes{}, "echo `pwd`\n", "test.zsh", diag.Hint},
+		{FuncDeclStyle{}, "function f() { :; }\n", "test.zsh", diag.Hint},
+		{PreferDoubleBrackets{}, "if [ -f x ]; then :; fi\n", "test.zsh", diag.Hint},
+		{FunctionScopedOptions{}, "rehash\n", "functions/handler", diag.Hint},
 	}
 	for _, tt := range tests {
 		t.Run(string(tt.rule.ID()), func(t *testing.T) {
-			f, err := parse.Parse(strings.NewReader(tt.src), "test.zsh")
+			f, err := parse.Parse(strings.NewReader(tt.src), tt.path)
 			if err != nil {
 				t.Fatalf("parse failed: %v", err)
 			}
-			diags := analyzer.New(tt.rule).Analyze(f, "test.zsh")
+			diags := analyzer.New(tt.rule).Analyze(f, tt.path)
 			if len(diags) == 0 {
 				t.Fatalf("rule %s produced no finding on %q", tt.rule.ID(), tt.src)
 			}
@@ -40,4 +42,13 @@ func TestRuleSeverities(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDefaultIncludesFunctionScopedOptions(t *testing.T) {
+	for _, rule := range Default() {
+		if rule.ID() == "plugin/function-scoped-options" {
+			return
+		}
+	}
+	t.Fatal("Default rules do not include plugin/function-scoped-options")
 }


### PR DESCRIPTION
## Summary

Implements the approved rule proposal **`plugin/function-scoped-options`** (#63):
reports autoloadable function files (files under a `functions/` path segment)
that execute logic before localizing inherited shell options.

A file is **compliant** when, before its first non-guard executable top-level
statement, it scopes options via either:

- `emulate -L zsh` (optionally `builtin`-prefixed; grouped switches like `-LR`
  accepted; shell name must be the literal `zsh`), or
- `setopt local_options` (optionally `builtin`-prefixed; Zsh option-name
  normalization — case-insensitive, underscores ignored).

A contiguous prefix of narrow early-exit guards is allowed before scoping:
`condition || return` and single-return `if` (no `elif`/`else`).

Severity: **hint**. One diagnostic per file, at the first offending statement.
Inline suppression via the existing analyzer pass
(`# zsh-lint disable=plugin/function-scoped-options -- <reason>`).

## Notes for review

- The implementation is **broader than the original plan's code sketch** but
  stays within the design doc's stated intent: it also rejects
  `emulate -L zsh -c …` (command mode does not localize the file's options),
  handles `setopt` inverse forms (`+o local_options` / `no_local_options`,
  last-wins), and rejects backgrounded/redirected/negated guard shapes.
- **Corpus validation (issue #63 evidence):** the analyzer flags
  `zsh-fancy-completions/functions/.completion-prediction` and
  `…/.force_rehash`. The originally cited
  `z-a-meta-plugins/functions/.za-meta-plugins-meta-cmd-help-handler` is now a
  fully commented-out stub and is correctly silent; compliant alternatives
  stay silent.

## Verification

`gofmt` clean · `go test ./...` · `go vet ./...` · `go build ./...` ·
gomarkdoc generation includes the new rule.

## Refs

- Implements #63
- Tracker: ZSH-17 (zsh-lint corpus workflow & analyzer contract roadmap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
