### PR TITLE
feat(rules): detect special parameter shadowing

### DIFF
--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -13,5 +13,6 @@ func Default() []analyzer.Rule {
 		EvalUsage{},
 		FuncDeclStyle{},
 		FunctionScopedOptions{},
+		SpecialParamShadow{},
 	}
 }

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -26,6 +26,7 @@ func TestRuleSeverities(t *testing.T) {
 		{FuncDeclStyle{}, "function f() { :; }\n", "test.zsh", diag.Hint},
 		{PreferDoubleBrackets{}, "if [ -f x ]; then :; fi\n", "test.zsh", diag.Hint},
 		{FunctionScopedOptions{}, "rehash\n", "functions/handler", diag.Hint},
+		{SpecialParamShadow{}, "local ZSH_VERSION=1\n", "test.zsh", diag.Warning},
 	}
 	for _, tt := range tests {
 		t.Run(string(tt.rule.ID()), func(t *testing.T) {
@@ -51,4 +52,13 @@ func TestDefaultIncludesFunctionScopedOptions(t *testing.T) {
 		}
 	}
 	t.Fatal("Default rules do not include plugin/function-scoped-options")
+}
+
+func TestDefaultIncludesSpecialParamShadow(t *testing.T) {
+	for _, rule := range Default() {
+		if rule.ID() == "compat/special-param-shadow" {
+			return
+		}
+	}
+	t.Fatal("Default rules do not include compat/special-param-shadow")
 }

--- a/internal/rules/special_param_shadow.go
+++ b/internal/rules/special_param_shadow.go
@@ -172,10 +172,6 @@ func (scan declarationOptionScan) tiedParameterSeparator(args []*syntax.Assign) 
 	return nil
 }
 
-func tiedParameterSeparator(args []*syntax.Assign) *syntax.Assign {
-	return scanDeclarationOptions("typeset", args).tiedParameterSeparator(args)
-}
-
 type declarationMode uint8
 
 const (
@@ -197,16 +193,6 @@ type declarationOptionScan struct {
 	mode         declarationMode
 	firstOperand int
 	tied         bool
-}
-
-// declarationModeFor classifies the effective options after Zsh removes
-// quoting, including separate decimal arguments consumed by options that
-// accept n. Option processing stops at the first operand, --, or the historical
-// single - terminator. A dynamic naked argument in the option region makes the
-// command's declaration mode unknowable, so callers must stay silent rather
-// than guess.
-func declarationModeFor(variant string, args []*syntax.Assign) declarationMode {
-	return scanDeclarationOptions(variant, args).mode
 }
 
 // scanDeclarationOptions follows the typeset-family option boundary once so

--- a/internal/rules/special_param_shadow.go
+++ b/internal/rules/special_param_shadow.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/z-shell/zsh-lint/internal/analyzer"
 	"github.com/z-shell/zsh-lint/internal/diag"
+	"mvdan.cc/sh/v3/expand"
 	"mvdan.cc/sh/v3/syntax"
 )
 
@@ -20,7 +21,9 @@ import (
 // `OSTYPE`, and `pipestatus`); explicit non-local `-g` declarations (including
 // `readonly -g`), the `export` builtin, and `typeset`-family
 // query/display/function modes (`-p`/`+p`, `-m`/`+m`, and `-f`/`+f`) are
-// excluded, and reads are never reported.
+// excluded. The rule also stays silent when dynamic option words or the
+// ambient `GLOBAL_EXPORT` option make declaration scope uncertain. Reads are
+// never reported.
 //
 // Why: The Zsh manual's zshparam "Parameters Set By The Shell" section
 // documents these as shell-provided state. In a function, `readonly` is
@@ -109,7 +112,7 @@ func (rule SpecialParamShadow) Analyze(ctx *analyzer.Context, node syntax.Node) 
 	if _, ok := shadowingDecls[decl.Variant.Value]; !ok {
 		return
 	}
-	if declaresGlobal(decl.Args) || usesNonDeclarationMode(decl.Args) {
+	if declarationModeFor(decl.Variant.Value, decl.Args) != declarationModeLocal {
 		return
 	}
 	for _, assign := range decl.Args {
@@ -130,35 +133,98 @@ func (rule SpecialParamShadow) Analyze(ctx *analyzer.Context, node syntax.Node) 
 	}
 }
 
-// declaresGlobal reports whether a declaration carries a -g switch, which makes
-// the declaration explicitly non-local and may target an enclosing binding.
-// Flag arguments are the args without a name (for example -g or -ga).
-func declaresGlobal(args []*syntax.Assign) bool {
-	return hasShortFlag(args, "-", "g")
-}
+type declarationMode uint8
 
-// usesNonDeclarationMode reports whether a typeset-family invocation selects
-// a query, pattern, or function mode instead of declaring its named arguments.
-// Zsh accepts both signs and grouped short flags for these modes.
-func usesNonDeclarationMode(args []*syntax.Assign) bool {
-	return hasShortFlag(args, "-+", "pmf")
-}
+const (
+	declarationModeUnknown declarationMode = iota
+	declarationModeLocal
+	declarationModeGlobal
+	declarationModeNonDeclaration
+)
 
-// hasShortFlag reports whether a literal flag argument starts with an allowed
-// sign and contains any requested option letter. Flag arguments are the args
-// without a name (for example -g, -ap, or +m).
-func hasShortFlag(args []*syntax.Assign, signs, letters string) bool {
+// declarationModeFor classifies the effective options after Zsh removes
+// quoting. A dynamic naked argument makes the command's declaration mode
+// unknowable, so callers must stay silent rather than guess. For typeset-family
+// declarations other than local, a final -x without an explicit g decision
+// depends on the ambient GLOBAL_EXPORT option and is likewise unknown.
+func declarationModeFor(variant string, args []*syntax.Assign) declarationMode {
+	var global, globalExplicit, exported bool
 	for _, assign := range args {
 		if assign == nil || assign.Name != nil {
 			continue
 		}
-		value, ok := literalWord(assign.Value)
-		if !ok || len(value) < 2 || !strings.ContainsRune(signs, rune(value[0])) || value[1] == value[0] {
+		value, ok := staticDeclarationWord(assign.Value)
+		if !ok {
+			return declarationModeUnknown
+		}
+		if len(value) < 2 || !strings.ContainsRune("-+", rune(value[0])) || value[1] == value[0] {
 			continue
 		}
-		if strings.ContainsAny(value[1:], letters) {
-			return true
+		if strings.ContainsAny(value[1:], "pmf") {
+			return declarationModeNonDeclaration
+		}
+
+		enabled := value[0] == '-'
+		for _, option := range value[1:] {
+			switch option {
+			case 'g':
+				globalExplicit = true
+				global = enabled
+			case 'x':
+				exported = enabled
+			}
 		}
 	}
-	return false
+
+	if globalExplicit {
+		if global {
+			return declarationModeGlobal
+		}
+		return declarationModeLocal
+	}
+	if variant != "local" && exported {
+		return declarationModeUnknown
+	}
+	return declarationModeLocal
+}
+
+// staticDeclarationWord reconstructs the limited word forms whose values are
+// known after Zsh removes quoting, including ANSI-C single-quoted escapes. Do
+// not use literalWord here: declaration options may be split across literal and
+// quoted AST parts. Any expansion makes the option dynamic and must leave
+// declaration mode unknown.
+func staticDeclarationWord(word *syntax.Word) (string, bool) {
+	if word == nil {
+		return "", false
+	}
+
+	var value strings.Builder
+	for _, part := range word.Parts {
+		switch part := part.(type) {
+		case *syntax.Lit:
+			value.WriteString(part.Value)
+		case *syntax.SglQuoted:
+			partValue := part.Value
+			if part.Dollar {
+				var err error
+				partValue, _, err = expand.Format(nil, partValue, nil)
+				if err != nil {
+					return "", false
+				}
+				partValue, _, _ = strings.Cut(partValue, "\x00")
+			}
+			value.WriteString(partValue)
+		case *syntax.DblQuoted:
+			for _, quotedPart := range part.Parts {
+				literal, ok := quotedPart.(*syntax.Lit)
+				if !ok {
+					return "", false
+				}
+				value.WriteString(literal.Value)
+			}
+		default:
+			return "", false
+		}
+	}
+	return value.String(), true
 }

--- a/internal/rules/special_param_shadow.go
+++ b/internal/rules/special_param_shadow.go
@@ -116,18 +116,31 @@ func (rule SpecialParamShadow) Analyze(ctx *analyzer.Context, node syntax.Node) 
 		return
 	}
 	for _, assign := range decl.Args {
-		if assign == nil || assign.Name == nil {
+		if assign == nil {
 			continue
 		}
-		if _, shadowed := shadowedSpecialParams[assign.Name.Value]; !shadowed {
+
+		var name string
+		start, end := assign.Pos(), assign.End()
+		if assign.Name != nil {
+			name = assign.Name.Value
+			start, end = assign.Name.Pos(), assign.Name.End()
+		} else if value, ok := staticDeclarationWord(assign.Value); ok {
+			var hasValue bool
+			name, _, hasValue = strings.Cut(value, "=")
+			if hasValue {
+				name = strings.TrimSuffix(name, "+")
+			}
+		}
+		if _, shadowed := shadowedSpecialParams[name]; !shadowed {
 			continue
 		}
 		ctx.Report(
-			assign.Name.Pos(),
-			assign.Name.End(),
+			start,
+			end,
 			rule.ID(),
 			diag.Warning,
-			"Declaring shell-set parameter '"+assign.Name.Value+
+			"Declaring shell-set parameter '"+name+
 				"' can override shell-managed state in this scope and nested code; use a different parameter name",
 		)
 	}
@@ -143,22 +156,35 @@ const (
 )
 
 // declarationModeFor classifies the effective options after Zsh removes
-// quoting. A dynamic naked argument makes the command's declaration mode
-// unknowable, so callers must stay silent rather than guess. For typeset-family
-// declarations other than local, a final -x without an explicit g decision
-// depends on the ambient GLOBAL_EXPORT option and is likewise unknown.
+// quoting. Option processing stops at the first operand, --, or the historical
+// single - terminator. A dynamic naked argument in the option region makes the
+// command's declaration mode unknowable, so callers must stay silent rather
+// than guess. For typeset-family declarations other than local, any observed
+// -x without an explicit g decision depends on the ambient GLOBAL_EXPORT option
+// and is likewise unknown; a later +x does not undo -x's implied -g.
 func declarationModeFor(variant string, args []*syntax.Assign) declarationMode {
-	var global, globalExplicit, exported bool
+	var global, globalExplicit, sawExport bool
 	for _, assign := range args {
-		if assign == nil || assign.Name != nil {
+		if assign == nil {
 			continue
+		}
+		if assign.Name != nil {
+			break
 		}
 		value, ok := staticDeclarationWord(assign.Value)
 		if !ok {
 			return declarationModeUnknown
 		}
+		if value == "-" || value == "--" {
+			break
+		}
 		if len(value) < 2 || !strings.ContainsRune("-+", rune(value[0])) || value[1] == value[0] {
-			continue
+			break
+		}
+		// A retained backslash denotes an invalid option character, not quoting
+		// around a later valid character. The builtin rejects such a word.
+		if strings.ContainsRune(value, '\\') {
+			return declarationModeUnknown
 		}
 		if strings.ContainsAny(value[1:], "pmf") {
 			return declarationModeNonDeclaration
@@ -171,7 +197,9 @@ func declarationModeFor(variant string, args []*syntax.Assign) declarationMode {
 				globalExplicit = true
 				global = enabled
 			case 'x':
-				exported = enabled
+				if enabled {
+					sawExport = true
+				}
 			}
 		}
 	}
@@ -182,7 +210,7 @@ func declarationModeFor(variant string, args []*syntax.Assign) declarationMode {
 		}
 		return declarationModeLocal
 	}
-	if variant != "local" && exported {
+	if variant != "local" && sawExport {
 		return declarationModeUnknown
 	}
 	return declarationModeLocal
@@ -202,7 +230,7 @@ func staticDeclarationWord(word *syntax.Word) (string, bool) {
 	for _, part := range word.Parts {
 		switch part := part.(type) {
 		case *syntax.Lit:
-			value.WriteString(part.Value)
+			value.WriteString(removeUnquotedBackslashEscapes(part.Value))
 		case *syntax.SglQuoted:
 			partValue := part.Value
 			if part.Dollar {
@@ -220,11 +248,57 @@ func staticDeclarationWord(word *syntax.Word) (string, bool) {
 				if !ok {
 					return "", false
 				}
-				value.WriteString(literal.Value)
+				value.WriteString(removeDoubleQuotedBackslashEscapes(literal.Value))
 			}
 		default:
 			return "", false
 		}
 	}
 	return value.String(), true
+}
+
+// removeUnquotedBackslashEscapes applies quote removal to static unquoted
+// literals. Outside quotes, a backslash quotes the following character; an
+// escaped newline is removed as a line continuation.
+func removeUnquotedBackslashEscapes(value string) string {
+	if !strings.ContainsRune(value, '\\') {
+		return value
+	}
+
+	var unquoted strings.Builder
+	unquoted.Grow(len(value))
+	for i := 0; i < len(value); i++ {
+		if value[i] != '\\' || i+1 == len(value) {
+			unquoted.WriteByte(value[i])
+			continue
+		}
+		i++
+		if value[i] != '\n' {
+			unquoted.WriteByte(value[i])
+		}
+	}
+	return unquoted.String()
+}
+
+// removeDoubleQuotedBackslashEscapes preserves backslashes before ordinary
+// characters. Within double quotes, only shell-special characters and newline
+// can be quoted with a backslash.
+func removeDoubleQuotedBackslashEscapes(value string) string {
+	if !strings.ContainsRune(value, '\\') {
+		return value
+	}
+
+	var unquoted strings.Builder
+	unquoted.Grow(len(value))
+	for i := 0; i < len(value); i++ {
+		if value[i] != '\\' || i+1 == len(value) || !strings.ContainsRune("$`\"\\\n", rune(value[i+1])) {
+			unquoted.WriteByte(value[i])
+			continue
+		}
+		i++
+		if value[i] != '\n' {
+			unquoted.WriteByte(value[i])
+		}
+	}
+	return unquoted.String()
 }

--- a/internal/rules/special_param_shadow.go
+++ b/internal/rules/special_param_shadow.go
@@ -20,11 +20,11 @@ import (
 // of a curated set of shell-set parameters (for example `ZSH_VERSION`,
 // `OSTYPE`, and `pipestatus`); explicit non-local `-g` declarations (including
 // `readonly -g`), the `export` builtin, and `typeset`-family
-// query/display/function modes (`-p`/`+p`, `+m`, and `-f`/`+f`) are excluded.
-// Pattern declarations with `-m` are reported only when an effective `+g`
-// makes matching non-local parameters local. The rule also stays silent when
-// dynamic option words or the ambient `GLOBAL_EXPORT` option make declaration
-// scope uncertain. Reads are never reported.
+// query/display/function modes (standalone `+`, `-p`/`+p`, `+m`, and
+// `-f`/`+f`) are excluded. Pattern declarations with `-m` are reported only
+// when an effective `+g` makes matching non-local parameters local. The rule
+// also stays silent when dynamic option words or the ambient `GLOBAL_EXPORT`
+// option make declaration scope uncertain. Reads are never reported.
 //
 // Why: The Zsh manual's zshparam "Parameters Set By The Shell" section
 // documents these as shell-provided state. In a function, `readonly` is
@@ -113,10 +113,11 @@ func (rule SpecialParamShadow) Analyze(ctx *analyzer.Context, node syntax.Node) 
 	if _, ok := shadowingDecls[decl.Variant.Value]; !ok {
 		return
 	}
-	if declarationModeFor(decl.Variant.Value, decl.Args) != declarationModeLocal {
+	optionScan := scanDeclarationOptions(decl.Variant.Value, decl.Args)
+	if optionScan.mode != declarationModeLocal {
 		return
 	}
-	tieSeparator := tiedParameterSeparator(decl.Args)
+	tieSeparator := optionScan.tiedParameterSeparator(decl.Args)
 	for _, assign := range decl.Args {
 		if assign == nil || assign == tieSeparator {
 			continue
@@ -150,46 +151,16 @@ func (rule SpecialParamShadow) Analyze(ctx *analyzer.Context, node syntax.Node) 
 
 // tiedParameterSeparator returns the optional third operand of typeset -T.
 // Zsh declares only the first two operands as the tied scalar and array; the
-// third is separator data even when its text is a valid parameter name. The
-// option scan stops at the same boundaries as declarationModeFor so an
-// option-looking separator is never reinterpreted as an option.
-func tiedParameterSeparator(args []*syntax.Assign) *syntax.Assign {
-	tied := false
-	firstOperand := len(args)
-	for i, assign := range args {
-		if assign == nil {
-			continue
-		}
-		if assign.Name != nil {
-			firstOperand = i
-			break
-		}
-		value, ok := staticDeclarationWord(assign.Value)
-		if !ok {
-			return nil
-		}
-		if value == "-" || value == "--" {
-			firstOperand = i + 1
-			break
-		}
-		if len(value) < 2 || !strings.ContainsRune("-+", rune(value[0])) || value[1] == value[0] {
-			firstOperand = i
-			break
-		}
-
-		enabled := value[0] == '-'
-		for _, option := range value[1:] {
-			if option == 'T' {
-				tied = enabled
-			}
-		}
-	}
-	if !tied {
+// third is separator data even when its text is a valid parameter name. Its
+// operand boundary comes from the same scan that classified declaration mode,
+// so numeric option arguments cannot be miscounted as tied operands.
+func (scan declarationOptionScan) tiedParameterSeparator(args []*syntax.Assign) *syntax.Assign {
+	if !scan.tied {
 		return nil
 	}
 
 	operand := 0
-	for _, assign := range args[firstOperand:] {
+	for _, assign := range args[scan.firstOperand:] {
 		if assign == nil {
 			continue
 		}
@@ -201,6 +172,10 @@ func tiedParameterSeparator(args []*syntax.Assign) *syntax.Assign {
 	return nil
 }
 
+func tiedParameterSeparator(args []*syntax.Assign) *syntax.Assign {
+	return scanDeclarationOptions("typeset", args).tiedParameterSeparator(args)
+}
+
 type declarationMode uint8
 
 const (
@@ -210,42 +185,93 @@ const (
 	declarationModeNonDeclaration
 )
 
+type numericOptionArgument uint8
+
+const (
+	numericOptionArgumentNone numericOptionArgument = iota
+	numericOptionArgumentExpected
+	numericOptionArgumentAmbiguous
+)
+
+type declarationOptionScan struct {
+	mode         declarationMode
+	firstOperand int
+	tied         bool
+}
+
 // declarationModeFor classifies the effective options after Zsh removes
-// quoting. Option processing stops at the first operand, --, or the historical
+// quoting, including separate decimal arguments consumed by options that
+// accept n. Option processing stops at the first operand, --, or the historical
 // single - terminator. A dynamic naked argument in the option region makes the
 // command's declaration mode unknowable, so callers must stay silent rather
-// than guess. For typeset-family declarations other than local, any observed
-// -x without an explicit g decision depends on the ambient GLOBAL_EXPORT option
-// and is likewise unknown; a later +x does not undo -x's implied -g. Pattern
-// mode creates local parameters only when -m is combined with an effective
-// +g; the final explicit g state therefore controls whether it declares in the
-// current scope.
+// than guess.
 func declarationModeFor(variant string, args []*syntax.Assign) declarationMode {
+	return scanDeclarationOptions(variant, args).mode
+}
+
+// scanDeclarationOptions follows the typeset-family option boundary once so
+// declaration mode and operand roles can share the same Zsh semantics. A
+// decimal word after E, F, L, R, Z, i, or p is option data, not an operand;
+// option-looking words after it must therefore still be interpreted. If the
+// candidate is dynamic, or grouped ordering leaves it unclear which option
+// would consume a decimal, the safe static result is unknown. For declarations
+// other than local, -x without an explicit g decision also remains unknown
+// because GLOBAL_EXPORT controls its scope; a later +x does not undo that
+// uncertainty. Pattern mode declares local matches only with an effective +g.
+func scanDeclarationOptions(variant string, args []*syntax.Assign) declarationOptionScan {
+	scan := declarationOptionScan{
+		mode:         declarationModeLocal,
+		firstOperand: len(args),
+	}
 	var global, globalExplicit, pattern, patternExplicit, sawExport bool
-	for _, assign := range args {
+	var nonDeclaration bool
+	numericArgument := numericOptionArgumentNone
+	for i, assign := range args {
 		if assign == nil {
 			continue
 		}
 		if assign.Name != nil {
+			scan.firstOperand = i
 			break
 		}
 		value, ok := staticDeclarationWord(assign.Value)
 		if !ok {
-			return declarationModeUnknown
+			scan.mode = declarationModeUnknown
+			return scan
+		}
+		if numericArgument != numericOptionArgumentNone {
+			if isDecimalOptionArgument(value) {
+				if numericArgument == numericOptionArgumentAmbiguous {
+					scan.mode = declarationModeUnknown
+					return scan
+				}
+				numericArgument = numericOptionArgumentNone
+				continue
+			}
+			numericArgument = numericOptionArgumentNone
+		}
+		// Unlike the historical single '-' option terminator, standalone '+' is
+		// a typeset display control form and never introduces declarations.
+		if value == "+" {
+			scan.mode = declarationModeNonDeclaration
+			return scan
 		}
 		if value == "-" || value == "--" {
+			scan.firstOperand = i + 1
 			break
 		}
 		if len(value) < 2 || !strings.ContainsRune("-+", rune(value[0])) || value[1] == value[0] {
+			scan.firstOperand = i
 			break
 		}
 		// A retained backslash denotes an invalid option character, not quoting
 		// around a later valid character. The builtin rejects such a word.
 		if strings.ContainsRune(value, '\\') {
-			return declarationModeUnknown
+			scan.mode = declarationModeUnknown
+			return scan
 		}
 		if strings.ContainsAny(value[1:], "pf") {
-			return declarationModeNonDeclaration
+			nonDeclaration = true
 		}
 
 		enabled := value[0] == '-'
@@ -257,27 +283,67 @@ func declarationModeFor(variant string, args []*syntax.Assign) declarationMode {
 			case 'm':
 				patternExplicit = true
 				pattern = enabled
+			case 'T':
+				scan.tied = enabled
 			case 'x':
 				if enabled {
 					sawExport = true
 				}
 			}
 		}
+		numericArgument = numericOptionArgumentFor(value[1:])
 	}
 
+	if nonDeclaration {
+		scan.mode = declarationModeNonDeclaration
+		return scan
+	}
 	if patternExplicit && (!pattern || !globalExplicit || global) {
-		return declarationModeNonDeclaration
+		scan.mode = declarationModeNonDeclaration
+		return scan
 	}
 	if globalExplicit {
 		if global {
-			return declarationModeGlobal
+			scan.mode = declarationModeGlobal
+			return scan
 		}
-		return declarationModeLocal
+		return scan
 	}
 	if variant != "local" && sawExport {
-		return declarationModeUnknown
+		scan.mode = declarationModeUnknown
 	}
-	return declarationModeLocal
+	return scan
+}
+
+func numericOptionArgumentFor(options string) numericOptionArgument {
+	numericCount := 0
+	lastNumeric := false
+	for i, option := range options {
+		if !strings.ContainsRune("EFLRZip", option) {
+			continue
+		}
+		numericCount++
+		lastNumeric = i == len(options)-1
+	}
+	if numericCount == 0 {
+		return numericOptionArgumentNone
+	}
+	if numericCount == 1 && lastNumeric {
+		return numericOptionArgumentExpected
+	}
+	return numericOptionArgumentAmbiguous
+}
+
+func isDecimalOptionArgument(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, digit := range value {
+		if digit < '0' || digit > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // staticDeclarationWord reconstructs the limited word forms whose values are

--- a/internal/rules/special_param_shadow.go
+++ b/internal/rules/special_param_shadow.go
@@ -20,10 +20,11 @@ import (
 // of a curated set of shell-set parameters (for example `ZSH_VERSION`,
 // `OSTYPE`, and `pipestatus`); explicit non-local `-g` declarations (including
 // `readonly -g`), the `export` builtin, and `typeset`-family
-// query/display/function modes (`-p`/`+p`, `-m`/`+m`, and `-f`/`+f`) are
-// excluded. The rule also stays silent when dynamic option words or the
-// ambient `GLOBAL_EXPORT` option make declaration scope uncertain. Reads are
-// never reported.
+// query/display/function modes (`-p`/`+p`, `+m`, and `-f`/`+f`) are excluded.
+// Pattern declarations with `-m` are reported only when an effective `+g`
+// makes matching non-local parameters local. The rule also stays silent when
+// dynamic option words or the ambient `GLOBAL_EXPORT` option make declaration
+// scope uncertain. Reads are never reported.
 //
 // Why: The Zsh manual's zshparam "Parameters Set By The Shell" section
 // documents these as shell-provided state. In a function, `readonly` is
@@ -115,8 +116,9 @@ func (rule SpecialParamShadow) Analyze(ctx *analyzer.Context, node syntax.Node) 
 	if declarationModeFor(decl.Variant.Value, decl.Args) != declarationModeLocal {
 		return
 	}
+	tieSeparator := tiedParameterSeparator(decl.Args)
 	for _, assign := range decl.Args {
-		if assign == nil {
+		if assign == nil || assign == tieSeparator {
 			continue
 		}
 
@@ -146,6 +148,59 @@ func (rule SpecialParamShadow) Analyze(ctx *analyzer.Context, node syntax.Node) 
 	}
 }
 
+// tiedParameterSeparator returns the optional third operand of typeset -T.
+// Zsh declares only the first two operands as the tied scalar and array; the
+// third is separator data even when its text is a valid parameter name. The
+// option scan stops at the same boundaries as declarationModeFor so an
+// option-looking separator is never reinterpreted as an option.
+func tiedParameterSeparator(args []*syntax.Assign) *syntax.Assign {
+	tied := false
+	firstOperand := len(args)
+	for i, assign := range args {
+		if assign == nil {
+			continue
+		}
+		if assign.Name != nil {
+			firstOperand = i
+			break
+		}
+		value, ok := staticDeclarationWord(assign.Value)
+		if !ok {
+			return nil
+		}
+		if value == "-" || value == "--" {
+			firstOperand = i + 1
+			break
+		}
+		if len(value) < 2 || !strings.ContainsRune("-+", rune(value[0])) || value[1] == value[0] {
+			firstOperand = i
+			break
+		}
+
+		enabled := value[0] == '-'
+		for _, option := range value[1:] {
+			if option == 'T' {
+				tied = enabled
+			}
+		}
+	}
+	if !tied {
+		return nil
+	}
+
+	operand := 0
+	for _, assign := range args[firstOperand:] {
+		if assign == nil {
+			continue
+		}
+		operand++
+		if operand == 3 {
+			return assign
+		}
+	}
+	return nil
+}
+
 type declarationMode uint8
 
 const (
@@ -161,9 +216,12 @@ const (
 // command's declaration mode unknowable, so callers must stay silent rather
 // than guess. For typeset-family declarations other than local, any observed
 // -x without an explicit g decision depends on the ambient GLOBAL_EXPORT option
-// and is likewise unknown; a later +x does not undo -x's implied -g.
+// and is likewise unknown; a later +x does not undo -x's implied -g. Pattern
+// mode creates local parameters only when -m is combined with an effective
+// +g; the final explicit g state therefore controls whether it declares in the
+// current scope.
 func declarationModeFor(variant string, args []*syntax.Assign) declarationMode {
-	var global, globalExplicit, sawExport bool
+	var global, globalExplicit, pattern, patternExplicit, sawExport bool
 	for _, assign := range args {
 		if assign == nil {
 			continue
@@ -186,7 +244,7 @@ func declarationModeFor(variant string, args []*syntax.Assign) declarationMode {
 		if strings.ContainsRune(value, '\\') {
 			return declarationModeUnknown
 		}
-		if strings.ContainsAny(value[1:], "pmf") {
+		if strings.ContainsAny(value[1:], "pf") {
 			return declarationModeNonDeclaration
 		}
 
@@ -196,6 +254,9 @@ func declarationModeFor(variant string, args []*syntax.Assign) declarationMode {
 			case 'g':
 				globalExplicit = true
 				global = enabled
+			case 'm':
+				patternExplicit = true
+				pattern = enabled
 			case 'x':
 				if enabled {
 					sawExport = true
@@ -204,6 +265,9 @@ func declarationModeFor(variant string, args []*syntax.Assign) declarationMode {
 		}
 	}
 
+	if patternExplicit && (!pattern || !globalExplicit || global) {
+		return declarationModeNonDeclaration
+	}
 	if globalExplicit {
 		if global {
 			return declarationModeGlobal

--- a/internal/rules/special_param_shadow.go
+++ b/internal/rules/special_param_shadow.go
@@ -1,0 +1,107 @@
+package rules
+
+import (
+	"strings"
+
+	"github.com/z-shell/zsh-lint/internal/analyzer"
+	"github.com/z-shell/zsh-lint/internal/diag"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// SpecialParamShadow reports declarations that shadow parameters set by the
+// shell.
+type SpecialParamShadow struct{}
+
+func (SpecialParamShadow) ID() diag.RuleID {
+	return "compat/special-param-shadow"
+}
+
+func (SpecialParamShadow) Name() string {
+	return "Shadowing special shell parameters"
+}
+
+// shadowedSpecialParams is the curated set of shell-set parameters whose
+// declaration can override state the shell maintains in the current scope and
+// nested code. Names are matched exactly and case-sensitively.
+var shadowedSpecialParams = map[string]struct{}{
+	"ZSH_VERSION":    {},
+	"ZSH_PATCHLEVEL": {},
+	"ZSH_NAME":       {},
+	"ZSH_ARGZERO":    {},
+	"OSTYPE":         {},
+	"MACHTYPE":       {},
+	"VENDOR":         {},
+	"pipestatus":     {},
+	"status":         {},
+}
+
+// shadowingDecls are typeset-family builtins whose declaration forms can
+// override shell-set parameters. export is intentionally excluded.
+var shadowingDecls = map[string]struct{}{
+	"local":    {},
+	"typeset":  {},
+	"declare":  {},
+	"readonly": {},
+}
+
+func (rule SpecialParamShadow) Analyze(ctx *analyzer.Context, node syntax.Node) {
+	decl, ok := node.(*syntax.DeclClause)
+	if !ok || decl.Variant == nil {
+		return
+	}
+	if _, ok := shadowingDecls[decl.Variant.Value]; !ok {
+		return
+	}
+	if declaresGlobal(decl.Args) || usesNonDeclarationMode(decl.Args) {
+		return
+	}
+	for _, assign := range decl.Args {
+		if assign == nil || assign.Name == nil {
+			continue
+		}
+		if _, shadowed := shadowedSpecialParams[assign.Name.Value]; !shadowed {
+			continue
+		}
+		ctx.Report(
+			assign.Name.Pos(),
+			assign.Name.End(),
+			rule.ID(),
+			diag.Warning,
+			"Declaring shell-set parameter '"+assign.Name.Value+
+				"' can override shell-managed state in this scope and nested code; use a different parameter name",
+		)
+	}
+}
+
+// declaresGlobal reports whether a declaration carries a -g switch, which makes
+// the declaration explicitly non-local and may target an enclosing binding.
+// Flag arguments are the args without a name (for example -g or -ga).
+func declaresGlobal(args []*syntax.Assign) bool {
+	return hasShortFlag(args, "-", "g")
+}
+
+// usesNonDeclarationMode reports whether a typeset-family invocation selects
+// a query, pattern, or function mode instead of declaring its named arguments.
+// Zsh accepts both signs and grouped short flags for these modes.
+func usesNonDeclarationMode(args []*syntax.Assign) bool {
+	return hasShortFlag(args, "-+", "pmf")
+}
+
+// hasShortFlag reports whether a literal flag argument starts with an allowed
+// sign and contains any requested option letter. Flag arguments are the args
+// without a name (for example -g, -ap, or +m).
+func hasShortFlag(args []*syntax.Assign, signs, letters string) bool {
+	for _, assign := range args {
+		if assign == nil || assign.Name != nil {
+			continue
+		}
+		value, ok := literalWord(assign.Value)
+		if !ok || len(value) < 2 || !strings.ContainsRune(signs, rune(value[0])) || value[1] == value[0] {
+			continue
+		}
+		if strings.ContainsAny(value[1:], letters) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rules/special_param_shadow.go
+++ b/internal/rules/special_param_shadow.go
@@ -10,6 +10,63 @@ import (
 
 // SpecialParamShadow reports declarations that shadow parameters set by the
 // shell.
+//
+// ID: `compat/special-param-shadow`
+//
+// Name: Shadowing special shell parameters
+//
+// Summary: Reports `local`, `typeset`, `declare`, or `readonly` declarations
+// of a curated set of shell-set parameters (for example `ZSH_VERSION`,
+// `OSTYPE`, and `pipestatus`); explicit non-local `-g` declarations (including
+// `readonly -g`), the `export` builtin, and `typeset`-family
+// query/display/function modes (`-p`/`+p`, `-m`/`+m`, and `-f`/`+f`) are
+// excluded, and reads are never reported.
+//
+// Why: The Zsh manual's zshparam "Parameters Set By The Shell" section
+// documents these as shell-provided state. In a function, `readonly` is
+// `typeset -r` and creates a local binding unless `-g` explicitly selects
+// non-local behavior. Version probes such as `is-at-least $ZSH_VERSION` are
+// pervasive in plugin code, so a `local ZSH_VERSION=...` in a caller silently
+// feeds the override to all nested code for the lifetime of the scope. At top
+// level, the same declaration form clobbers the shell-managed outer binding
+// instead of creating a temporary local. Unlike ordinary shadowing, the reader
+// has no declaration of the original to look up -- the shell set it. See
+// https://zsh.sourceforge.io/Doc/Release/Parameters.html#Parameters-Set-By-The-Shell.
+//
+// Bad:
+//
+//	compile_zsh() {
+//	  local ZSH_VERSION="$1"
+//	}
+//
+// Good:
+//
+//	compile_zsh() {
+//	  local target_zsh_version="$1"
+//	}
+//
+// Severity: Warning. The pattern is functional but misleading and can change
+// what nested code observes; deliberate compatibility shims are realistic, so
+// it is suppressible rather than an error.
+//
+// False positives: Deliberate compatibility shims or test harnesses that fake
+// `ZSH_VERSION` or `OSTYPE` for downstream code are the rule's target behavior
+// made intentional; suppress them with a reason. The rule flags only a curated
+// allowlist of read-mostly shell-set parameters and stays silent for reads and
+// the conventionally mutated `path`, `fpath`, `PATH`, `REPLY`, and `match`.
+// The shell-special `status` and `pipestatus` cases remain included because
+// `local -h status=...` and `local -h pipestatus=(...)` can replace their
+// special behavior with ordinary local bindings.
+//
+// Suppression: Use
+// `# zsh-lint disable=compat/special-param-shadow -- <reason>` on the finding
+// line or immediately before the next non-comment, non-blank source line.
+//
+// Corpus evidence: Issue #64 records `zd/docker/utils.zsh:78`:
+// `local ZSH_VERSION="$1"` inside a helper that takes a target version as its
+// first argument. Deferred issue #72 tracks bare assignments in function scope
+// and `integer`/`float` declarations; both are out of scope for this rule
+// version.
 type SpecialParamShadow struct{}
 
 func (SpecialParamShadow) ID() diag.RuleID {

--- a/internal/rules/special_param_shadow_test.go
+++ b/internal/rules/special_param_shadow_test.go
@@ -53,6 +53,7 @@ func TestSpecialParamShadowDeclarations(t *testing.T) {
 		{name: "-h creates local status and removes shell-special behavior", src: "local -h status=7\n", wantNames: []string{"status"}},
 		{name: "-h creates local pipestatus and removes shell-special behavior", src: "local -h pipestatus=(7 8)\n", wantNames: []string{"pipestatus"}},
 		{name: "global -g excluded", src: "typeset -g ZSH_VERSION=1\n"},
+		{name: "plus g remains local", src: "typeset +g ZSH_VERSION=1\n", wantNames: []string{"ZSH_VERSION"}},
 		{name: "grouped -ga excluded", src: "typeset -ga pipestatus\n"},
 		{name: "readonly -g excluded", src: "readonly -g ZSH_VERSION=1\n"},
 		{name: "export excluded", src: "export ZSH_VERSION=1\n"},
@@ -113,6 +114,60 @@ func TestSpecialParamShadowNonDeclarationModes(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			requireSpecialParamNames(t, analyzeSpecialParamShadow(t, test.src), nil)
+		})
+	}
+}
+
+func TestSpecialParamShadowStaticQuotedModes(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{name: "single quoted global", src: "typeset '-g' ZSH_VERSION=1\n"},
+		{name: "single quoted query", src: "typeset '+p' ZSH_VERSION\n"},
+		{name: "double quoted global", src: "typeset \"-g\" ZSH_VERSION=1\n"},
+		{name: "double quoted query", src: "typeset \"+p\" ZSH_VERSION\n"},
+		{name: "concatenated global", src: "typeset \"-\"g ZSH_VERSION=1\n"},
+		{name: "concatenated query", src: "typeset \"+\"p ZSH_VERSION\n"},
+		{name: "double quoted grouped global", src: "typeset \"-ag\" ZSH_VERSION=1\n"},
+		{name: "single quoted grouped query", src: "typeset '+mp' ZSH_VERSION\n"},
+		{name: "ANSI-C escaped global", src: "typeset $'\\x2dg' ZSH_VERSION=1\n"},
+		{name: "ANSI-C escaped query", src: "typeset $'\\x2bp' ZSH_VERSION\n"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requireSpecialParamNames(t, analyzeSpecialParamShadow(t, test.src), nil)
+		})
+	}
+}
+
+func TestSpecialParamShadowDynamicModeIsSilent(t *testing.T) {
+	requireSpecialParamNames(t, analyzeSpecialParamShadow(t, "typeset \"$mode\" ZSH_VERSION=1\n"), nil)
+}
+
+func TestSpecialParamShadowOrderedGlobalAndExportModes(t *testing.T) {
+	tests := []struct {
+		name      string
+		src       string
+		wantNames []string
+	}{
+		{name: "final plus g is local", src: "typeset -g +g ZSH_VERSION=1\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "ANSI-C escaped plus g is local", src: "typeset $'\\x2bg' ZSH_VERSION=1\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "final minus g is global", src: "typeset +g -g ZSH_VERSION=1\n"},
+		{name: "local export is local", src: "local -x ZSH_VERSION=1\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "typeset export depends on ambient global export", src: "typeset -x ZSH_VERSION=1\n"},
+		{name: "declare export depends on ambient global export", src: "declare -x ZSH_VERSION=1\n"},
+		{name: "readonly export depends on ambient global export", src: "readonly -x ZSH_VERSION=1\n"},
+		{name: "export then explicit local", src: "typeset -x +g ZSH_VERSION=1\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "explicit local then export", src: "typeset +g -x ZSH_VERSION=1\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "final plus x is local", src: "typeset -x +x ZSH_VERSION=1\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "final minus x depends on ambient global export", src: "typeset +x -x ZSH_VERSION=1\n"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requireSpecialParamNames(t, analyzeSpecialParamShadow(t, test.src), test.wantNames)
 		})
 	}
 }

--- a/internal/rules/special_param_shadow_test.go
+++ b/internal/rules/special_param_shadow_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/z-shell/zsh-lint/internal/analyzer"
 	"github.com/z-shell/zsh-lint/internal/diag"
 	"github.com/z-shell/zsh-lint/internal/parse"
+	"mvdan.cc/sh/v3/syntax"
 )
 
 func analyzeSpecialParamShadow(t *testing.T, src string) diag.Diagnostics {
@@ -120,8 +121,9 @@ func TestSpecialParamShadowNonDeclarationModes(t *testing.T) {
 
 func TestSpecialParamShadowStaticQuotedModes(t *testing.T) {
 	tests := []struct {
-		name string
-		src  string
+		name      string
+		src       string
+		wantNames []string
 	}{
 		{name: "single quoted global", src: "typeset '-g' ZSH_VERSION=1\n"},
 		{name: "single quoted query", src: "typeset '+p' ZSH_VERSION\n"},
@@ -133,11 +135,52 @@ func TestSpecialParamShadowStaticQuotedModes(t *testing.T) {
 		{name: "single quoted grouped query", src: "typeset '+mp' ZSH_VERSION\n"},
 		{name: "ANSI-C escaped global", src: "typeset $'\\x2dg' ZSH_VERSION=1\n"},
 		{name: "ANSI-C escaped query", src: "typeset $'\\x2bp' ZSH_VERSION\n"},
+		{name: "unquoted escaped global", src: "typeset \\-g ZSH_VERSION=1\n"},
+		{name: "unquoted escaped query", src: "typeset \\-p ZSH_VERSION\n"},
+		{name: "double quotes preserve backslash before ordinary character", src: `typeset "-\g" ZSH_VERSION=1`},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			requireSpecialParamNames(t, analyzeSpecialParamShadow(t, test.src), nil)
+			requireSpecialParamNames(t, analyzeSpecialParamShadow(t, test.src), test.wantNames)
+		})
+	}
+}
+
+func TestStaticDeclarationWordQuoteRemoval(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{name: "unquoted backslash escapes option sign", src: "typeset \\-g ZSH_VERSION=1\n", want: "-g"},
+		{name: "ordinary single quotes preserve backslash", src: "typeset '\\-g' ZSH_VERSION=1\n", want: "\\-g"},
+		{name: "double quotes preserve backslash before ordinary character", src: `typeset "-\g" ZSH_VERSION=1`, want: "-\\g"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			file, err := parse.Parse(strings.NewReader(test.src), "test.zsh")
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+
+			var decl *syntax.DeclClause
+			syntax.Walk(file.AST(), func(node syntax.Node) bool {
+				if candidate, ok := node.(*syntax.DeclClause); ok {
+					decl = candidate
+					return false
+				}
+				return true
+			})
+			if decl == nil || len(decl.Args) == 0 {
+				t.Fatalf("declaration args not found in %q", test.src)
+			}
+
+			got, ok := staticDeclarationWord(decl.Args[0].Value)
+			if !ok || got != test.want {
+				t.Fatalf("staticDeclarationWord() = %q, %v; want %q, true", got, ok, test.want)
+			}
 		})
 	}
 }
@@ -161,8 +204,53 @@ func TestSpecialParamShadowOrderedGlobalAndExportModes(t *testing.T) {
 		{name: "readonly export depends on ambient global export", src: "readonly -x ZSH_VERSION=1\n"},
 		{name: "export then explicit local", src: "typeset -x +g ZSH_VERSION=1\n", wantNames: []string{"ZSH_VERSION"}},
 		{name: "explicit local then export", src: "typeset +g -x ZSH_VERSION=1\n", wantNames: []string{"ZSH_VERSION"}},
-		{name: "final plus x is local", src: "typeset -x +x ZSH_VERSION=1\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "typeset export remains unknown after plus x", src: "typeset -x +x ZSH_VERSION=1\n"},
+		{name: "declare export remains unknown after plus x", src: "declare -x +x ZSH_VERSION=1\n"},
+		{name: "readonly export remains unknown after plus x", src: "readonly -x +x ZSH_VERSION=1\n"},
 		{name: "final minus x depends on ambient global export", src: "typeset +x -x ZSH_VERSION=1\n"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requireSpecialParamNames(t, analyzeSpecialParamShadow(t, test.src), test.wantNames)
+		})
+	}
+}
+
+func TestSpecialParamShadowOptionProcessingStopsAtFirstOperand(t *testing.T) {
+	tests := []struct {
+		name      string
+		src       string
+		wantNames []string
+	}{
+		{name: "dynamic word before operand is unknown", src: "typeset \"$mode\" ZSH_VERSION=1\n"},
+		{name: "dynamic word after assignment does not hide declaration", src: "typeset ZSH_VERSION=1 \"$value\"\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "global-looking word after assignment is an operand", src: "typeset ZSH_VERSION=1 -g\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "query-looking word after assignment is an operand", src: "typeset ZSH_VERSION=1 -p\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "double dash terminates options", src: "typeset -- ZSH_VERSION=1 \"$value\"\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "single dash terminates options", src: "typeset - ZSH_VERSION=1 \"$value\"\n", wantNames: []string{"ZSH_VERSION"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requireSpecialParamNames(t, analyzeSpecialParamShadow(t, test.src), test.wantNames)
+		})
+	}
+}
+
+func TestSpecialParamShadowStaticDeclarationOperands(t *testing.T) {
+	tests := []struct {
+		name      string
+		src       string
+		wantNames []string
+	}{
+		{name: "double quoted assignment", src: "local \"ZSH_VERSION=shadow\"\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "concatenated quoted assignment", src: "local ZSH\"_\"VERSION=shadow\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "dynamic quoted name is unknown", src: "local \"ZSH_${part}=shadow\"\n"},
+		{name: "dynamic concatenated name is unknown", src: "local ZSH_\"$part\"=shadow\n"},
+		{name: "quoted name matching is case sensitive", src: "local \"zsh_version=shadow\"\n"},
+		{name: "quoted trailing plus is not an append assignment", src: "local \"ZSH_VERSION+\"\n"},
+		{name: "ordinary assignment is not duplicated", src: "local ZSH_VERSION=shadow\n", wantNames: []string{"ZSH_VERSION"}},
 	}
 
 	for _, test := range tests {

--- a/internal/rules/special_param_shadow_test.go
+++ b/internal/rules/special_param_shadow_test.go
@@ -166,3 +166,16 @@ func TestSpecialParamShadowDiagnostic(t *testing.T) {
 		t.Errorf("range = %+v, want %+v", diags[0].Range, wantRange)
 	}
 }
+
+func TestSpecialParamShadowSuppression(t *testing.T) {
+	src := "local ZSH_VERSION=\"$1\" # zsh-lint disable=compat/special-param-shadow -- intentional version shim\n"
+	file, err := parse.Parse(strings.NewReader(src), "test.zsh")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	diags := analyzer.New(SpecialParamShadow{}).Analyze(file, "test.zsh")
+	if len(diags) != 0 {
+		t.Fatalf("suppressed diagnostics = %v, want none", diags)
+	}
+}

--- a/internal/rules/special_param_shadow_test.go
+++ b/internal/rules/special_param_shadow_test.go
@@ -238,6 +238,51 @@ func TestSpecialParamShadowPatternDeclarations(t *testing.T) {
 	}
 }
 
+func TestSpecialParamShadowNumericOptionArguments(t *testing.T) {
+	tests := []struct {
+		name      string
+		src       string
+		wantNames []string
+	}{
+		{name: "E width permits later global", src: "typeset -E 5 -g ZSH_VERSION\n"},
+		{name: "F quoted width permits later global", src: "typeset -F '5' -g ZSH_VERSION\n"},
+		{name: "L width permits later global", src: "typeset -L 5 -g ZSH_VERSION\n"},
+		{name: "plus R width permits later global", src: "typeset +R 5 -g ZSH_VERSION\n"},
+		{name: "Z width permits later global", src: "typeset -Z 5 -g ZSH_VERSION\n"},
+		{name: "i base permits later global", src: "typeset -i 10 -g ZSH_VERSION\n"},
+		{name: "later explicit local reports", src: "typeset -L 5 +g ZSH_VERSION\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "nonnumeric candidate starts operands", src: "typeset -L width -g ZSH_VERSION\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "dynamic candidate is unknown", src: "typeset -L \"$width\" -g ZSH_VERSION\n"},
+		{name: "later pattern mode is processed", src: "typeset -L 5 -m ZSH_VERSION\n"},
+		{name: "later display pattern mode is processed", src: "typeset -L 5 +m ZSH_VERSION\n"},
+		{name: "later export mode is processed", src: "typeset -L 5 -x ZSH_VERSION\n"},
+		{name: "later explicit local overrides export ambiguity", src: "typeset -L 5 -x +g ZSH_VERSION\n", wantNames: []string{"ZSH_VERSION"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requireSpecialParamNames(t, analyzeSpecialParamShadow(t, test.src), test.wantNames)
+		})
+	}
+}
+
+func TestSpecialParamShadowStandalonePlusDisplay(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{name: "standalone plus", src: "typeset + ZSH_VERSION\n"},
+		{name: "standalone plus after option", src: "typeset -U + ZSH_VERSION\n"},
+		{name: "quoted standalone plus", src: "typeset '+' ZSH_VERSION\n"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requireSpecialParamNames(t, analyzeSpecialParamShadow(t, test.src), nil)
+		})
+	}
+}
+
 func TestSpecialParamShadowTiedParameterOperands(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -248,6 +293,12 @@ func TestSpecialParamShadowTiedParameterOperands(t *testing.T) {
 		{name: "first operand is scalar declaration", src: "typeset -T ZSH_VERSION tied_array\n", wantNames: []string{"ZSH_VERSION"}},
 		{name: "second operand is array declaration", src: "typeset -T tied_scalar ZSH_VERSION\n", wantNames: []string{"ZSH_VERSION"}},
 		{name: "quoted third operand is separator", src: "typeset -T tied_scalar tied_array 'ZSH_VERSION'\n"},
+		{name: "numeric option after T preserves separator", src: "typeset -T -L 5 tied_scalar tied_array ZSH_VERSION\n"},
+		{name: "numeric option before T preserves separator", src: "typeset -L 5 -T tied_scalar tied_array ZSH_VERSION\n"},
+		{name: "grouped T and numeric option preserve separator", src: "typeset -TL 5 tied_scalar tied_array ZSH_VERSION\n"},
+		{name: "numeric option preserves curated scalar", src: "typeset -T -R 5 ZSH_VERSION tied_array separator\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "numeric option preserves curated array", src: "typeset -Z 5 -T tied_scalar ZSH_VERSION separator\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "ambiguous grouped numeric ordering is silent", src: "typeset -LT 5 ZSH_VERSION tied_array separator\n"},
 	}
 
 	for _, test := range tests {

--- a/internal/rules/special_param_shadow_test.go
+++ b/internal/rules/special_param_shadow_test.go
@@ -1,0 +1,168 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/z-shell/zsh-lint/internal/analyzer"
+	"github.com/z-shell/zsh-lint/internal/diag"
+	"github.com/z-shell/zsh-lint/internal/parse"
+)
+
+func analyzeSpecialParamShadow(t *testing.T, src string) diag.Diagnostics {
+	t.Helper()
+
+	file, err := parse.Parse(strings.NewReader(src), "test.zsh")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	diags := analyzer.New(SpecialParamShadow{}).Analyze(file, "test.zsh")
+	for i, diagnostic := range diags {
+		if diagnostic.RuleID != "compat/special-param-shadow" {
+			t.Fatalf("diagnostic %d rule ID = %q", i, diagnostic.RuleID)
+		}
+	}
+	return diags
+}
+
+func requireSpecialParamNames(t *testing.T, got diag.Diagnostics, wantNames []string) {
+	t.Helper()
+
+	if len(got) != len(wantNames) {
+		t.Fatalf("diagnostics = %v, want names %v", got, wantNames)
+	}
+	for i, name := range wantNames {
+		if !strings.Contains(got[i].Message, name) {
+			t.Errorf("diagnostic %d = %q, want it to mention %q", i, got[i].Message, name)
+		}
+	}
+}
+
+func TestSpecialParamShadowDeclarations(t *testing.T) {
+	tests := []struct {
+		name      string
+		src       string
+		wantNames []string
+	}{
+		{name: "valueless local pipestatus", src: "local pipestatus\n", wantNames: []string{"pipestatus"}},
+		{name: "array local of curated param", src: "local -a pipestatus\n", wantNames: []string{"pipestatus"}},
+		{name: "multiple curated names in one decl", src: "typeset ZSH_VERSION=1 OSTYPE=x\n", wantNames: []string{"ZSH_VERSION", "OSTYPE"}},
+		{name: "flags only curated among mixed names", src: "typeset foo=1 ZSH_VERSION=2\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "-h creates local status and removes shell-special behavior", src: "local -h status=7\n", wantNames: []string{"status"}},
+		{name: "-h creates local pipestatus and removes shell-special behavior", src: "local -h pipestatus=(7 8)\n", wantNames: []string{"pipestatus"}},
+		{name: "global -g excluded", src: "typeset -g ZSH_VERSION=1\n"},
+		{name: "grouped -ga excluded", src: "typeset -ga pipestatus\n"},
+		{name: "readonly -g excluded", src: "readonly -g ZSH_VERSION=1\n"},
+		{name: "export excluded", src: "export ZSH_VERSION=1\n"},
+		{name: "ordinary local silent", src: "local target_version=$1\n"},
+		{name: "read not flagged", src: "print $ZSH_VERSION\n"},
+		{name: "empty file", src: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := analyzeSpecialParamShadow(t, test.src)
+			requireSpecialParamNames(t, got, test.wantNames)
+		})
+	}
+}
+
+func TestSpecialParamShadowCuratedNamesAcrossVariants(t *testing.T) {
+	curatedNames := []string{
+		"ZSH_VERSION",
+		"ZSH_PATCHLEVEL",
+		"ZSH_NAME",
+		"ZSH_ARGZERO",
+		"OSTYPE",
+		"MACHTYPE",
+		"VENDOR",
+		"pipestatus",
+		"status",
+	}
+	variants := []string{"local", "typeset", "declare", "readonly"}
+
+	for _, variant := range variants {
+		for _, name := range curatedNames {
+			t.Run(variant+"/"+name, func(t *testing.T) {
+				src := fmt.Sprintf("%s %s=value\n", variant, name)
+				requireSpecialParamNames(t, analyzeSpecialParamShadow(t, src), []string{name})
+			})
+		}
+	}
+}
+
+func TestSpecialParamShadowNonDeclarationModes(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{name: "typeset minus p", src: "typeset -p ZSH_VERSION\n"},
+		{name: "typeset plus p", src: "typeset +p ZSH_VERSION\n"},
+		{name: "typeset minus m", src: "typeset -m ZSH_VERSION\n"},
+		{name: "typeset plus m", src: "typeset +m ZSH_VERSION\n"},
+		{name: "typeset minus f", src: "typeset -f ZSH_VERSION\n"},
+		{name: "typeset plus f", src: "typeset +f ZSH_VERSION\n"},
+		{name: "readonly minus p", src: "readonly -p ZSH_VERSION\n"},
+		{name: "grouped minus p", src: "typeset -ap ZSH_VERSION\n"},
+		{name: "grouped plus m and p", src: "typeset +mp ZSH_VERSION\n"},
+		{name: "grouped readonly p", src: "readonly -rp ZSH_VERSION\n"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requireSpecialParamNames(t, analyzeSpecialParamShadow(t, test.src), nil)
+		})
+	}
+}
+
+func TestSpecialParamShadowExclusionsAreExact(t *testing.T) {
+	for _, name := range []string{"path", "fpath", "PATH", "REPLY", "match"} {
+		t.Run("excluded/"+name, func(t *testing.T) {
+			src := fmt.Sprintf("local %s=value\n", name)
+			requireSpecialParamNames(t, analyzeSpecialParamShadow(t, src), nil)
+		})
+	}
+
+	curatedNames := []string{
+		"ZSH_VERSION",
+		"ZSH_PATCHLEVEL",
+		"ZSH_NAME",
+		"ZSH_ARGZERO",
+		"OSTYPE",
+		"MACHTYPE",
+		"VENDOR",
+		"pipestatus",
+		"status",
+	}
+	for _, name := range curatedNames {
+		t.Run("case/"+name, func(t *testing.T) {
+			otherCase := strings.ToLower(name)
+			if otherCase == name {
+				otherCase = strings.ToUpper(name)
+			}
+			src := fmt.Sprintf("local %s=value\n", otherCase)
+			requireSpecialParamNames(t, analyzeSpecialParamShadow(t, src), nil)
+		})
+	}
+}
+
+func TestSpecialParamShadowDiagnostic(t *testing.T) {
+	diags := analyzeSpecialParamShadow(t, "local ZSH_VERSION=\"$1\"\n")
+	if len(diags) != 1 {
+		t.Fatalf("diagnostics = %v, want one", diags)
+	}
+
+	wantMessage := "Declaring shell-set parameter 'ZSH_VERSION' can override shell-managed state in this scope and nested code; use a different parameter name"
+	if diags[0].Message != wantMessage {
+		t.Errorf("message = %q, want %q", diags[0].Message, wantMessage)
+	}
+	wantRange := diag.Range{
+		Start: diag.Position{Line: 1, Column: 7, Offset: 6},
+		End:   diag.Position{Line: 1, Column: 18, Offset: 17},
+	}
+	if diags[0].Range != wantRange {
+		t.Errorf("range = %+v, want %+v", diags[0].Range, wantRange)
+	}
+}

--- a/internal/rules/special_param_shadow_test.go
+++ b/internal/rules/special_param_shadow_test.go
@@ -217,6 +217,46 @@ func TestSpecialParamShadowOrderedGlobalAndExportModes(t *testing.T) {
 	}
 }
 
+func TestSpecialParamShadowPatternDeclarations(t *testing.T) {
+	tests := []struct {
+		name      string
+		src       string
+		wantNames []string
+	}{
+		{name: "plus g before minus m creates locals", src: "typeset +g -m ZSH_VERSION\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "plus g after minus m creates locals", src: "typeset -m +g ZSH_VERSION\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "final minus g keeps matches non-local", src: "typeset +g -m -g ZSH_VERSION\n"},
+		{name: "final plus g restores local creation", src: "typeset -m -g +g ZSH_VERSION\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "plus m remains display mode", src: "typeset +g +m ZSH_VERSION\n"},
+		{name: "assignment to exact curated name creates local", src: "typeset +g -m ZSH_VERSION=shadow\n", wantNames: []string{"ZSH_VERSION"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requireSpecialParamNames(t, analyzeSpecialParamShadow(t, test.src), test.wantNames)
+		})
+	}
+}
+
+func TestSpecialParamShadowTiedParameterOperands(t *testing.T) {
+	tests := []struct {
+		name      string
+		src       string
+		wantNames []string
+	}{
+		{name: "static third operand is separator", src: "typeset -T tied_scalar tied_array ZSH_VERSION\n"},
+		{name: "first operand is scalar declaration", src: "typeset -T ZSH_VERSION tied_array\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "second operand is array declaration", src: "typeset -T tied_scalar ZSH_VERSION\n", wantNames: []string{"ZSH_VERSION"}},
+		{name: "quoted third operand is separator", src: "typeset -T tied_scalar tied_array 'ZSH_VERSION'\n"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requireSpecialParamNames(t, analyzeSpecialParamShadow(t, test.src), test.wantNames)
+		})
+	}
+}
+
 func TestSpecialParamShadowOptionProcessingStopsAtFirstOperand(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Summary

- add `compat/special-param-shadow` for declarations that override a curated set of parameters managed by Zsh
- cover `local`, `typeset`, `declare`, and `readonly` while excluding explicit non-local declarations, display/query/function forms, and `export`
- model Zsh-specific ordered option semantics, quoted and escaped words, numeric option arguments, `GLOBAL_EXPORT`, `+g -m` local creation, and `typeset -T` operand roles
- register the rule at warning severity and document its rationale, suppression, corpus evidence, and deferred scope

## Zsh grounding

- [Parameters Set By The Shell](https://zsh.sourceforge.io/Doc/Release/Parameters.html#Parameters-Set-By-The-Shell)
- [Local Parameters](https://zsh.sourceforge.io/Doc/Release/Parameters.html#Local-Parameters)
- [Shell Builtin Commands: `typeset`](https://zsh.sourceforge.io/Doc/Release/Shell-Builtin-Commands.html#index-typeset)

## Verification

- `gofmt -l`: clean
- `go test ./... -count=1`: pass
- `go vet ./...`: pass
- `go build -buildvcs=false ./...`: pass
- fresh gomarkdoc generation: contains the new rule and final summary
- 19-file workspace corpus: 11 diagnostics — 8 parser errors already tracked in #12, #13, #15, #60, and #61; 2 existing unrelated hints; 1 true-positive warning at `zd/docker/utils.zsh:78`
- independent whole-branch and incremental reviews: no remaining findings

## Scope

Bare assignments and `integer`/`float` declaration paths remain deliberately deferred to #72.

Closes #64