### PR TITLE
docs(policy): reconcile suppression and parser mode

### DIFF
--- a/.github/ISSUE_TEMPLATE/rule-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/rule-proposal.yml
@@ -97,7 +97,7 @@ body:
     id: suppression
     attributes:
       label: Suppression
-      description: How an intentional finding is silenced, per the shared suppression contract (#19). Until that contract lands, write `pending #19` — rules may not document ad-hoc escape hatches.
-      value: pending #19
+      description: Document how an intentional finding is silenced with the shared `# zsh-lint disable=<rule-id>[,...] [-- reason]` directive. Rules may not define ad-hoc escape hatches.
+      value: "# zsh-lint disable=<rule-id>[,...] [-- reason]"
     validations:
       required: true

--- a/docs/project/rule-policy.md
+++ b/docs/project/rule-policy.md
@@ -75,8 +75,9 @@ reference docs (Go doc comment on the rule type):
 - **Bad / Good** — at least one minimal flagged snippet and its fix.
 - **Severity** — with a one-line justification per the mapping above.
 - **False positives** — known legitimate uses and how the rule treats them.
-- **Suppression** — how to silence an intentional finding. Until #19 lands,
-  write `pending #19`; rules may not document ad-hoc escape hatches.
+- **Suppression** — how to silence an intentional finding with the shared
+  `# zsh-lint disable=<rule-id>[,...] [-- reason]` directive; rules may not
+  document ad-hoc escape hatches.
 - **Corpus evidence** — file/line citations from the survey corpus.
 
 ## Shipping checklist

--- a/docs/project/suppression.md
+++ b/docs/project/suppression.md
@@ -5,11 +5,10 @@ Tracking issue: [#19](https://github.com/z-shell/zsh-lint/issues/19).
 How users silence an intentional finding without weakening unrelated
 diagnostics. This is the single shared contract required by the first-wave
 rule policy ([#7](https://github.com/z-shell/zsh-lint/issues/7),
-`docs/project/rule-policy.md` once
-[PR #55](https://github.com/z-shell/zsh-lint/pull/55) merges); rules must
-not invent their own escape
-hatches. This document defines the contract; the implementation is tracked
-separately and must cite this file.
+`docs/project/rule-policy.md`); rules must not invent their own escape
+hatches. The implementation lives in `internal/suppress` and is applied by
+`internal/analyzer` ([#65](https://github.com/z-shell/zsh-lint/issues/65),
+[PR #67](https://github.com/z-shell/zsh-lint/pull/67)).
 
 ## Syntax
 
@@ -88,12 +87,11 @@ listed.
 
 ## Interaction with machine-readable output (#20)
 
-Suppressed findings are dropped from default human output. The
-machine-readable contract (#20) must represent suppression explicitly —
-either by omitting suppressed findings or by tagging them
-(`"suppressed": true`) — and must include `meta/*` diagnostics, so editor
-and CI integrations can audit suppression usage. The choice is deferred to
-#20 and must reference this section.
+Suppressed findings are omitted from both default human output and the JSON
+`diagnostics` array. Malformed- and unused-suppression `meta/*` diagnostics
+remain included so editor and CI integrations can audit suppression usage.
+See `docs/project/output-contract.md` for the settled machine-readable
+contract.
 
 ## Out of scope (first wave)
 

--- a/internal/survey/survey.go
+++ b/internal/survey/survey.go
@@ -55,11 +55,11 @@ func surveyFile(name string) error {
 }
 
 // formatErr renders a parser/IO error as a greppable `path:line:col: message`
-// line. The mvdan/sh front end reports syntax errors as syntax.ParseError and
-// zsh-only constructs (the parser runs in bash mode) as syntax.LangError. Both
-// embed their own filename in Error(); since errors.As yields a copy, the
-// filename is blanked so the path can be controlled by the caller. Anything
-// else (e.g. an IO error) falls back to `path: message`.
+// line. The parser uses mvdan/sh's LangZsh variant and can return either
+// syntax.ParseError or syntax.LangError. Both embed their own filename in
+// Error(); errors.As yields a copy, so the filename is blanked and the caller
+// controls the path. Other errors (for example, IO failures) fall back to
+// `path: message`.
 func formatErr(name string, err error) string {
 	var perr syntax.ParseError
 	if errors.As(err, &perr) {


### PR DESCRIPTION
## Summary

- replace stale `pending #19` guidance with the implemented inline-suppression directive
- update the rule-proposal form while preserving the leading `#` in YAML
- align the suppression contract with the settled JSON behavior
- correct the survey comment to describe the `LangZsh` parser configuration

## Impact

This reconciles contributor-facing contracts with behavior already shipped on `next`. Analyzer and output behavior are unchanged, and historical dated survey records remain intact.

## Validation

- stale-claim acceptance grep changed from failing to passing
- issue-form YAML parses and preserves the exact directive default
- `go test -count=1 ./...`
- `gofmt -l internal/survey/survey.go` returned no files
- generated reference is byte-identical to the reconciled `next` baseline
- Trunk checked all 4 changed files with no issues
- `git diff --check`

Closes #79

Tracker: [ZSH-17](https://linear.app/ss-o/issue/ZSH-17/zsh-lint-corpus-workflow-and-analyzer-contract-roadmap)