### PR TITLE
ci: harden Go and Zsh validation

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -26,8 +26,8 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.25"
-      - name: ⬇️ Resolve modules
-        run: go mod tidy
+      - name: Verify module files are tidy
+        run: go mod tidy -diff
       - name: 🎨 Gofmt
         run: |
           unformatted="$(gofmt -l .)"

--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -1,5 +1,5 @@
 ---
-name: "✅ Zsh"
+name: Zsh Syntax Check
 on:
   push:
     tags: ["v*.*.*"]
@@ -7,18 +7,14 @@ on:
       - main
       - next
     paths:
-      - "*.zsh"
-      - "functions/**"
+      - "**/*.zsh"
+      - "legacy/functions/**"
+      - ".github/workflows/zsh-n.yml"
   pull_request:
     paths:
-      - "*.zsh"
-      - "functions/**"
-  workflow_run:
-    workflows:
-      - "⭕ Trunk"
-    types:
-      - completed
-    branches: [main]
+      - "**/*.zsh"
+      - "legacy/functions/**"
+      - ".github/workflows/zsh-n.yml"
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
## Summary

- make module resolution a non-mutating drift gate with `go mod tidy -diff`
- rename the Zsh workflow to the plain `Zsh Syntax Check` convention
- remove the stale/redundant `workflow_run` trigger
- trigger Zsh validation for nested `*.zsh` files, extensionless `legacy/functions/**` sources, and workflow changes

## Impact

The reconciled SHA pins, least-privilege permissions, concurrency cancellation, branch/tag/manual triggers, and release behavior are unchanged. GitHub does not evaluate path filters for tag pushes, so the existing semantic-tag trigger remains effective: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#using-filters

## Validation

- red/green workflow-contract assertions for drift, naming, paths, and stale-trigger removal
- both workflow YAML files parse successfully
- `go mod tidy -diff`
- `go test -count=1 ./...`
- `go vet ./...`
- `go build -buildvcs=false ./...`
- `gofmt -l .` returned no files
- exact workflow inventory: 16 files, all covered by trigger paths and all pass `zsh -n`
- Trunk/actionlint checked both changed workflows with no issues
- independent workflow review: no findings

Closes #80

Tracker: [ZSH-17](https://linear.app/ss-o/issue/ZSH-17/zsh-lint-corpus-workflow-and-analyzer-contract-roadmap)