### PR TITLE
fix(ci): harden and restore phase 1 gates

### DIFF
--- a/.github/workflows/docs-generate.yml
+++ b/.github/workflows/docs-generate.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: ⎔ Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/.github/workflows/docs-generate.yml
+++ b/.github/workflows/docs-generate.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: ⎔ Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: ⎔ Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: ⎔ Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/.github/workflows/parser-survey.yml
+++ b/.github/workflows/parser-survey.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⤵️ Check out the calling repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: target
           # The calling repo's contents are treated as untrusted data (only
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
 
       - name: ⤵️ Check out zsh-lint
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: z-shell/zsh-lint
           ref: ${{ inputs['zsh-lint-ref'] }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Verify semantic tag
         run: |
           tag="${GITHUB_REF_NAME}"

--- a/.github/workflows/trunk-check.yml
+++ b/.github/workflows/trunk-check.yml
@@ -25,6 +25,6 @@ jobs:
       actions: read
       checks: write
       contents: read
-    uses: z-shell/.github/.github/workflows/trunk.yml@8ee041623cd5a2892887357ea9f0fb443ff3d2b4 # main
+    uses: z-shell/.github/.github/workflows/trunk.yml@98500a481c810dfd1c2f9cda1334e3eb2c334f9f # main
     with:
       arguments: --no-progress

--- a/.github/workflows/wiki-docs-sync.yml
+++ b/.github/workflows/wiki-docs-sync.yml
@@ -41,12 +41,12 @@ jobs:
           permission-pull-requests: write
 
       - name: Check out zsh-lint
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: zsh-lint
 
       - name: Check out wiki (next)
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: z-shell/wiki
           ref: next

--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -31,7 +31,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: "Set matrix output"
         id: set-matrix
         run: |
@@ -46,7 +46,7 @@ jobs:
       matrix: ${{ fromJSON(needs.zsh-matrix.outputs.matrix) }}
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: "⚡ Install dependencies"
         run: sudo apt update && sudo apt-get install -y zsh && touch ~/.zshrc
       - name: "⚡ zsh -n: ${{ matrix.file }}"

--- a/internal/wikidoc/wikidoc.go
+++ b/internal/wikidoc/wikidoc.go
@@ -1,29 +1,24 @@
 // Package wikidoc transforms gomarkdoc-generated Markdown into MDX-safe content
 // and injects it into a marked region of a Docusaurus .mdx page. It is dev/CI
 // tooling, not product code.
-//
-// # Known limitations
-//
-// Step 4 (bare-character escaping) operates line-by-line and does NOT exempt
-// inline code spans (single-backtick runs) on prose lines. Characters inside
-// `backtick spans` on prose lines will be escaped along with the surrounding
-// text. This is acceptable for the current gomarkdoc output, which uses only
-// indented blocks and fenced blocks for code samples, not inline spans
-// containing angle brackets or braces.
 package wikidoc
 
 import (
 	"fmt"
+	"html"
 	"regexp"
 	"strings"
 )
 
 var (
-	reHTMLComment = regexp.MustCompile(`(?s)<!--.*?-->`)
-	reHTMLAnchor  = regexp.MustCompile(`</?a\b[^>]*>`)
-	reAngleLink   = regexp.MustCompile(`\]\(<([^>\s]*)>\)`)
-	reHeading     = regexp.MustCompile(`(?m)^(#{1,6})([ \t]+)`)
-	reAPIHeading  = regexp.MustCompile(`(?m)^#{2,} (func|type|var|const) ([A-Za-z_][A-Za-z0-9_]*)\b.*$`)
+	reHTMLComment      = regexp.MustCompile(`(?s)<!--.*?-->`)
+	reHTMLAnchor       = regexp.MustCompile(`</?a\b[^>]*>`)
+	reAngleLink        = regexp.MustCompile(`\]\(<([^>\s]*)>\)`)
+	reHeading          = regexp.MustCompile(`(?m)^(#{1,6})([ \t]+)`)
+	reAPIHeading       = regexp.MustCompile(`(?m)^#{2,} (func|type|var|const) ([A-Za-z_][A-Za-z0-9_]*)\b.*$`)
+	reAPIMethodHeading = regexp.MustCompile(
+		`(?m)^#{2,} func \\\(([A-Za-z_][A-Za-z0-9_]*)\\\) ([A-Za-z_][A-Za-z0-9_]*)\b.*$`,
+	)
 )
 
 // Sanitize transforms a gomarkdoc Markdown string into MDX-safe content by
@@ -35,11 +30,14 @@ var (
 //     and closing <a> tags are stripped (inner text, if any, is preserved).
 //  3. Unwrap angle-bracketed link destinations (](<#Run>) → ](#Run)).
 //  4. Normalize leading tabs to four spaces for Markdown indentation.
-//  5. Escape bare <, >, {, } on prose lines (not inside fenced or indented code).
-//  6. Demote generated headings by three levels so they nest under the wiki
+//  5. Convert indented code blocks to fenced blocks that MDX parses as code.
+//  6. Escape bare <, >, {, } on prose lines (not inside fenced code).
+//  7. Restore gomarkdoc's escaped inline-code spans, removing Markdown
+//     punctuation escapes and decoding entities only inside paired spans.
+//  8. Demote generated headings by three levels so they nest under the wiki
 //     page's "### Reference" section.
-//  7. Rewrite top-level Go declaration fragment links to Docusaurus slugs, so
-//     gomarkdoc fragment links like #Run resolve as #func-run.
+//  9. Rewrite Go declaration fragment links to Docusaurus slugs, so gomarkdoc
+//     fragments like #Run and #Backquotes.Analyze resolve to their headings.
 func Sanitize(md string) string {
 	// Step 1: remove HTML comments.
 	out := reHTMLComment.ReplaceAllString(md, "")
@@ -53,13 +51,21 @@ func Sanitize(md string) string {
 	// Step 4: use spaces for Markdown indentation and repository whitespace.
 	out = normalizeIndent(out)
 
-	// Step 5: escape bare MDX special chars on prose lines only.
+	// Step 5: MDX does not recognize Markdown-indented code blocks. Fence them
+	// so braces in generated examples are not parsed as JSX expressions.
+	out = fenceIndentedCodeBlocks(out)
+
+	// Step 6: escape bare MDX special chars on prose lines only.
 	out = escapeProse(out)
 
-	// Step 6: nest generated headings under the page's Reference section.
+	// Step 7: restore inline code after prose escaping so code contents remain
+	// literal, including angle brackets and braces.
+	out = normalizeEscapedInlineCode(out)
+
+	// Step 8: nest generated headings under the page's Reference section.
 	out = demoteHeadings(out)
 
-	// Step 7: target the slugs Docusaurus derives from declaration headings.
+	// Step 9: target the slugs Docusaurus derives from declaration headings.
 	out = rewriteAPIFragmentLinks(out)
 
 	return out
@@ -78,6 +84,49 @@ func normalizeIndent(s string) string {
 	return strings.Join(lines, "\n")
 }
 
+// fenceIndentedCodeBlocks converts Markdown-indented code into fenced blocks.
+// MDX v3 treats four-space indentation as ordinary text, so raw braces in such
+// blocks are otherwise parsed as expressions instead of rendered as code.
+func fenceIndentedCodeBlocks(s string) string {
+	lines := strings.Split(s, "\n")
+	out := make([]string, 0, len(lines))
+	inFenced := false
+
+	for i := 0; i < len(lines); {
+		trimmed := strings.TrimSpace(lines[i])
+		if strings.HasPrefix(trimmed, "```") {
+			inFenced = !inFenced
+			out = append(out, lines[i])
+			i++
+			continue
+		}
+		if inFenced || !strings.HasPrefix(lines[i], "    ") {
+			out = append(out, lines[i])
+			i++
+			continue
+		}
+
+		block := make([]string, 0, 1)
+		for i < len(lines) && strings.HasPrefix(lines[i], "    ") {
+			block = append(block, strings.TrimPrefix(lines[i], "    "))
+			i++
+		}
+		for len(block) > 0 && strings.TrimSpace(block[len(block)-1]) == "" {
+			block = block[:len(block)-1]
+		}
+		if len(block) == 0 {
+			out = append(out, "")
+			continue
+		}
+
+		out = append(out, "```")
+		out = append(out, block...)
+		out = append(out, "```")
+	}
+
+	return strings.Join(out, "\n")
+}
+
 // demoteHeadings shifts generated Markdown headings down three levels. Markdown
 // has only six heading levels, so deeper input is clamped at h6.
 func demoteHeadings(s string) string {
@@ -88,22 +137,81 @@ func demoteHeadings(s string) string {
 	})
 }
 
-// rewriteAPIFragmentLinks rewrites gomarkdoc's top-level declaration links to
-// the slugs Docusaurus derives from headings such as "## func Run".
+// rewriteAPIFragmentLinks rewrites gomarkdoc declaration links to the slugs
+// Docusaurus derives from headings such as "## func Run" and
+// "### func \(Backquotes\) Analyze".
 func rewriteAPIFragmentLinks(s string) string {
 	for _, match := range reAPIHeading.FindAllStringSubmatch(s, -1) {
 		name := match[2]
 		slug := strings.ToLower(match[1] + "-" + name)
 		s = strings.ReplaceAll(s, "](#"+name+")", "](#"+slug+")")
 	}
+	for _, match := range reAPIMethodHeading.FindAllStringSubmatch(s, -1) {
+		receiver := match[1]
+		method := match[2]
+		slug := strings.ToLower("func-" + receiver + "-" + method)
+		s = strings.ReplaceAll(s, "](#"+receiver+"."+method+")", "](#"+slug+")")
+	}
 	return s
 }
 
-// escapeProse escapes bare <, >, {, } on non-code lines.
-// Code lines are:
-//   - lines inside a fenced block (toggled by lines whose trimmed text starts
-//     with three backticks), or
-//   - indented lines (start with a tab or 4+ spaces).
+// normalizeEscapedInlineCode restores paired inline-code spans emitted by
+// gomarkdoc's plain formatter. Unmatched delimiters are left unchanged.
+func normalizeEscapedInlineCode(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = normalizeEscapedInlineCodeLine(line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func normalizeEscapedInlineCodeLine(line string) string {
+	const delimiter = "\\`"
+
+	var out strings.Builder
+	for {
+		start := strings.Index(line, delimiter)
+		if start < 0 {
+			out.WriteString(line)
+			break
+		}
+		afterStart := start + len(delimiter)
+		endOffset := strings.Index(line[afterStart:], delimiter)
+		if endOffset < 0 {
+			out.WriteString(line)
+			break
+		}
+		end := afterStart + endOffset
+
+		out.WriteString(line[:start])
+		out.WriteByte('`')
+		out.WriteString(html.UnescapeString(unescapeMarkdownPunctuation(line[afterStart:end])))
+		out.WriteByte('`')
+		line = line[end+len(delimiter):]
+	}
+	return out.String()
+}
+
+func unescapeMarkdownPunctuation(s string) string {
+	var out strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) && isASCIIPunctuation(s[i+1]) {
+			i++
+		}
+		out.WriteByte(s[i])
+	}
+	return out.String()
+}
+
+func isASCIIPunctuation(b byte) bool {
+	return (b >= '!' && b <= '/') ||
+		(b >= ':' && b <= '@') ||
+		(b >= '[' && b <= '`') ||
+		(b >= '{' && b <= '~')
+}
+
+// escapeProse escapes bare <, >, {, } on non-code lines. Fenced code content
+// is left verbatim.
 func escapeProse(s string) string {
 	lines := strings.Split(s, "\n")
 	inFenced := false
@@ -116,10 +224,6 @@ func escapeProse(s string) string {
 			continue
 		}
 		if inFenced {
-			continue
-		}
-		// Indented code line: starts with a tab or 4+ spaces.
-		if strings.HasPrefix(line, "\t") || strings.HasPrefix(line, "    ") {
 			continue
 		}
 		// Prose line — escape MDX special characters.

--- a/internal/wikidoc/wikidoc_test.go
+++ b/internal/wikidoc/wikidoc_test.go
@@ -200,6 +200,56 @@ func TestSanitize_RewriteDocusaurusHeadingID(t *testing.T) {
 	}
 }
 
+// TestSanitize_RewriteDocusaurusMethodHeadingID verifies receiver-method links
+// target the slug Docusaurus derives from the corresponding generated heading.
+func TestSanitize_RewriteDocusaurusMethodHeadingID(t *testing.T) {
+	input := "[func \\(r Backquotes\\) Analyze\\(ctx \\*analyzer.Context\\)](#Backquotes.Analyze)\n\n" +
+		"### func \\(Backquotes\\) Analyze"
+	got := wikidoc.Sanitize(input)
+	want := "[func \\(r Backquotes\\) Analyze\\(ctx \\*analyzer.Context\\)](#func-backquotes-analyze)\n\n" +
+		"###### func \\(Backquotes\\) Analyze"
+	if got != want {
+		t.Errorf("Sanitize(%q) = %q; want %q", input, got, want)
+	}
+}
+
+// TestSanitize_EscapedInlineCode verifies gomarkdoc's plain-format escapes are
+// removed only inside complete inline-code spans.
+func TestSanitize_EscapedInlineCode(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name: "punctuation and entities",
+			input: "ID: \\`style/backquotes\\`\n" +
+				"Suppression: \\`\\# zsh\\-lint disable=style/backquotes \\-\\- \\&lt;reason\\&gt;\\`",
+			want: "ID: `style/backquotes`\n" +
+				"Suppression: `# zsh-lint disable=style/backquotes -- <reason>`",
+		},
+		{
+			name:  "unmatched delimiter",
+			input: "Prefix \\`unterminated",
+			want:  "Prefix \\`unterminated",
+		},
+		{
+			name:  "non punctuation backslashes",
+			input: "Path: \\`C:\\temp\\name\\`",
+			want:  "Path: `C:\\temp\\name`",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := wikidoc.Sanitize(tc.input)
+			if got != tc.want {
+				t.Errorf("Sanitize(%q) = %q; want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestSanitize_DemoteHeadings verifies generated headings nest beneath the
 // wiki page's h3 Reference section without producing invalid h7 headings.
 func TestSanitize_DemoteHeadings(t *testing.T) {
@@ -211,12 +261,23 @@ func TestSanitize_DemoteHeadings(t *testing.T) {
 	}
 }
 
-// TestSanitize_NormalizeIndent verifies generated Markdown code indentation
-// uses spaces so wiki whitespace checks accept newly generated lines.
-func TestSanitize_NormalizeIndent(t *testing.T) {
-	input := "\timport \"example.test/pkg\"\n\t\tdeep"
+// TestSanitize_FenceIndentedCode verifies gomarkdoc's tab-indented code is
+// converted to fenced code that MDX both parses and renders as code.
+func TestSanitize_FenceIndentedCode(t *testing.T) {
+	input := "\tfunc render() { print ok; }\n\t  print done\n\t\n\nProse"
 	got := wikidoc.Sanitize(input)
-	want := "    import \"example.test/pkg\"\n        deep"
+	want := "```\nfunc render() { print ok; }\n  print done\n```\n\nProse"
+	if got != want {
+		t.Errorf("Sanitize(%q) = %q; want %q", input, got, want)
+	}
+}
+
+// TestSanitize_WhitespaceOnlyIndent verifies a tab-only separator is cleaned
+// without producing an empty fenced block.
+func TestSanitize_WhitespaceOnlyIndent(t *testing.T) {
+	input := "\t\n\nProse"
+	got := wikidoc.Sanitize(input)
+	want := "\n\nProse"
 	if got != want {
 		t.Errorf("Sanitize(%q) = %q; want %q", input, got, want)
 	}
@@ -232,14 +293,14 @@ func TestSanitize_EscapeProseChars(t *testing.T) {
 	}
 }
 
-// TestSanitize_IndentedCodeNotEscaped verifies tab-indented code lines are
-// normalized to spaces without escaping their code contents.
-func TestSanitize_IndentedCodeNotEscaped(t *testing.T) {
+// TestSanitize_IndentedCodePreservesContent verifies fenced conversion leaves
+// code contents untouched.
+func TestSanitize_IndentedCodePreservesContent(t *testing.T) {
 	input := "\tfunc F(a <T>) {}"
 	got := wikidoc.Sanitize(input)
-	want := "    func F(a <T>) {}"
+	want := "```\nfunc F(a <T>) {}\n```"
 	if got != want {
-		t.Errorf("Sanitize should normalize but not escape tab-indented code; got: %q, want: %q", got, want)
+		t.Errorf("Sanitize should fence tab-indented code without escaping it; got: %q, want: %q", got, want)
 	}
 }
 
@@ -252,11 +313,13 @@ func TestSanitize_FencedCodeNotEscaped(t *testing.T) {
 	}
 }
 
-// TestSanitize_FourSpaceIndentNotEscaped verifies 4-space-indented code lines are left verbatim.
-func TestSanitize_FourSpaceIndentNotEscaped(t *testing.T) {
+// TestSanitize_FourSpaceIndentFenced verifies existing Markdown-indented code
+// is converted to MDX-compatible fenced code.
+func TestSanitize_FourSpaceIndentFenced(t *testing.T) {
 	input := "    func F(a <T>) {}"
 	got := wikidoc.Sanitize(input)
-	if got != input {
-		t.Errorf("Sanitize should not escape 4-space-indented code; got: %q, want: %q", got, input)
+	want := "```\nfunc F(a <T>) {}\n```"
+	if got != want {
+		t.Errorf("Sanitize should fence 4-space-indented code; got: %q, want: %q", got, want)
 	}
 }

--- a/internal/workflowcontract/ci_release_test.go
+++ b/internal/workflowcontract/ci_release_test.go
@@ -268,6 +268,38 @@ func TestZshSyntaxCheckoutsDoNotPersistCredentials(t *testing.T) {
 	}
 }
 
+func TestPullRequestValidationCheckoutsDoNotPersistCredentials(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		jobName string
+	}{
+		{name: "Go CI", path: "go-ci.yml", jobName: "build-test"},
+		{name: "Docs Generate Check", path: "docs-generate.yml", jobName: "generate"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workflow := readRepositoryFile(t, ".github", "workflows", tt.path)
+			var checkoutSteps []string
+			for _, step := range workflowJobSteps(t, workflow, tt.jobName) {
+				uses := directWorkflowMapping(step, 8)["uses"]
+				if len(uses) == 1 && strings.HasPrefix(uses[0], "actions/checkout@") {
+					checkoutSteps = append(checkoutSteps, step)
+				}
+			}
+			if len(checkoutSteps) != 1 {
+				t.Fatalf("job %q must contain exactly one checkout step; got %d", tt.jobName, len(checkoutSteps))
+			}
+			withBlock := workflowBlock(t, checkoutSteps[0], "with:", 8)
+			values := directWorkflowMapping(withBlock, 10)["persist-credentials"]
+			if len(values) != 1 || values[0] != "false" {
+				t.Fatalf("job %q checkout must disable persisted credentials; got %q", tt.jobName, values)
+			}
+		})
+	}
+}
+
 func workflowPushBranches(t *testing.T, workflow string) []string {
 	t.Helper()
 

--- a/internal/workflowcontract/wiki_docs_sync_test.go
+++ b/internal/workflowcontract/wiki_docs_sync_test.go
@@ -255,7 +255,7 @@ func wikiDocsSyncContractViolations(t *testing.T, workflow string) []string {
 		{"organization scope", "owner: z-shell"},
 		{"repository scope", "repositories: wiki"},
 		{"app token action pin", "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1"},
-		{"checkout action pin", "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"},
+		{"checkout action pin", "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"},
 		{"setup Go action pin", "actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e"},
 		{"pull request action pin", "peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1"},
 		{"pull request step ID", "id: sync-pr"},
@@ -387,8 +387,8 @@ func wikiDocsSyncContractViolations(t *testing.T, workflow string) []string {
 		workflow,
 		[]string{
 			"        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0",
-			"        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0",
-			"        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0",
+			"        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1",
+			"        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1",
 			"        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0",
 			"        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1",
 		},
@@ -442,14 +442,14 @@ func wikiDocsSyncContractViolations(t *testing.T, workflow string) []string {
 		sourceCheckoutStep,
 		8,
 		[]workflowMappingField{
-			{name: "uses", value: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0"},
+			{name: "uses", value: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"},
 			{name: "with", value: ""},
 		},
 	)...)
 	violations = append(violations, exactWorkflowLineViolations(
 		"source checkout step",
 		sourceCheckoutStep,
-		"        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0",
+		"        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1",
 	)...)
 	sourceCheckoutInputs := workflowBlock(t, sourceCheckoutStep, "with:", 8)
 	violations = append(violations, exactWorkflowMappingViolations(
@@ -465,14 +465,14 @@ func wikiDocsSyncContractViolations(t *testing.T, workflow string) []string {
 		wikiCheckoutStep,
 		8,
 		[]workflowMappingField{
-			{name: "uses", value: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0"},
+			{name: "uses", value: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"},
 			{name: "with", value: ""},
 		},
 	)...)
 	violations = append(violations, exactWorkflowLineViolations(
 		"wiki checkout step",
 		wikiCheckoutStep,
-		"        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0",
+		"        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1",
 	)...)
 	wikiCheckoutInputs := workflowBlock(t, wikiCheckoutStep, "with:", 8)
 	violations = append(violations, exactWorkflowMappingViolations(
@@ -747,14 +747,14 @@ func TestWikiDocsSyncRejectsTriggerIdentityActionAndVerificationMutations(t *tes
 		{
 			name: "source checkout mutable ref",
 			old: "      - name: Check out zsh-lint\n" +
-				"        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0",
+				"        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1",
 			replacement: "      - name: Check out zsh-lint\n" +
 				"        uses: actions/checkout@v7",
 		},
 		{
 			name: "wiki checkout mutable ref",
 			old: "      - name: Check out wiki (next)\n" +
-				"        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0",
+				"        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1",
 			replacement: "      - name: Check out wiki (next)\n" +
 				"        uses: actions/checkout@v7",
 		},

--- a/internal/workflowcontract/wiki_docs_sync_test.go
+++ b/internal/workflowcontract/wiki_docs_sync_test.go
@@ -256,7 +256,7 @@ func wikiDocsSyncContractViolations(t *testing.T, workflow string) []string {
 		{"repository scope", "repositories: wiki"},
 		{"app token action pin", "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1"},
 		{"checkout action pin", "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"},
-		{"setup Go action pin", "actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16"},
+		{"setup Go action pin", "actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e"},
 		{"pull request action pin", "peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1"},
 		{"pull request step ID", "id: sync-pr"},
 		{"generated path scope", "add-paths: community/04_zsh_lint/index.mdx"},
@@ -389,7 +389,7 @@ func wikiDocsSyncContractViolations(t *testing.T, workflow string) []string {
 			"        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0",
 			"        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0",
 			"        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0",
-			"        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0",
+			"        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0",
 			"        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1",
 		},
 	)...)
@@ -494,14 +494,14 @@ func wikiDocsSyncContractViolations(t *testing.T, workflow string) []string {
 		setupGoStep,
 		8,
 		[]workflowMappingField{
-			{name: "uses", value: "actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0"},
+			{name: "uses", value: "actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0"},
 			{name: "with", value: ""},
 		},
 	)...)
 	violations = append(violations, exactWorkflowLineViolations(
 		"setup Go step",
 		setupGoStep,
-		"        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0",
+		"        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0",
 	)...)
 	setupGoInputs := workflowBlock(t, setupGoStep, "with:", 8)
 	violations = append(violations, exactWorkflowMappingViolations(
@@ -760,8 +760,8 @@ func TestWikiDocsSyncRejectsTriggerIdentityActionAndVerificationMutations(t *tes
 		},
 		{
 			name:        "setup Go action mutable ref",
-			old:         "        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0",
-			replacement: "        uses: actions/setup-go@v6",
+			old:         "        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0",
+			replacement: "        uses: actions/setup-go@v7",
 		},
 		{
 			name:        "pull request action mutable ref",


### PR DESCRIPTION
## Summary

- harden the Zsh compilation workflow against workflow-command injection by using NUL-delimited filename transport and positional parameters
- reconcile `next` development routing with `main` promotion guards, Renovate, and Dependabot behavior
- restore stable Go CI and bind releases to an annotated `vX.Y.Z` tag at the exact workflow event commit
- add workflow contract and mutation tests for the security and routing boundaries

## Why

Phase 1 addresses the workflow injection, branch-routing, and release-validation gaps tracked in #98 and #90. The underlying problems were unsafe filename interpolation into generated shell source, branch automation that was not reconciled with the repository's `next` development model, and release automation that did not bind the tag, checked-out commit, and workflow event SHA tightly enough.

## Impact

CI safely handles filenames containing shell metacharacters or newlines. Routine dependency updates target `next`. Promotion to `main` is restricted to the intended same-repository routes, including the authenticated Dependabot exception. Releases require an annotated semantic-version tag and run the uncached Go validation suite before creating one verified GitHub release.

No analyzer, parser, rule, command, or parser-backlog source is changed.

## Validation

- `go test -count=1 ./...`
- `go vet ./...`
- `go build -buildvcs=false ./...`
- `go mod tidy -diff`
- `gofmt -l .`
- actionlint 1.7.12
- Renovate 43.280.5 strict config validation
- Dependabot YAML structural validation
- signed commit, parent order, and final reviewed diff verification

## Known boundary

GitHub workflow event data can authenticate a same-repository `dependabot/*` pull request and its bot author, but cannot prove that a maintainer-retargeted bot PR is specifically a security update. The organization-level policy reconciliation is tracked separately in z-shell/.github#487.

## Tracking

- Addresses #90
- Phase 1 of #98
- Policy follow-up: z-shell/.github#487