### PR TITLE
chore(trunk): deliberate compatible Trunk plugin/runtime upgrade

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Go source is gofmt-formatted and always tab-indented; don't let a
+# contributor's core.whitespace=tab-in-indent flag that as an error in
+# git-diff-check.
+*.go whitespace=-tab-in-indent

--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -2,6 +2,8 @@
 *logs
 *actions
 *notifications
+*tools
 plugins
 user_trunk.yaml
 user.yaml
+tmp

--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,3 +1,5 @@
+# out/ dirs capture subprocess stdout/stderr and may contain env vars or other
+# secret values — never commit or share .trunk/out/ contents.
 *out
 *logs
 *actions

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,25 +1,30 @@
 version: 0.1
 cli:
-  version: 1.3.1
+  version: 1.25.0
 plugins:
   sources:
     - id: trunk
-      ref: v0.0.8
+      ref: v1.10.2
       uri: https://github.com/trunk-io/plugins
 lint:
   enabled:
-    - prettier@2.8.2
-    - gitleaks@8.15.2
-    - actionlint@1.6.23
+    - gofmt@1.24.11
+    - golangci-lint2@2.12.2
+    - prettier@3.9.6
+    - gitleaks@8.30.1
+    - actionlint@1.7.12
     - git-diff-check
-    - markdownlint@0.33.0
+    - markdownlint@0.49.1
 runtimes:
   enabled:
-    - go@1.18.3
-    - node@18.12.1
+    - go@1.24.11
+    - node@22.16.0
 actions:
   enabled:
     - trunk-announce
     - trunk-check-pre-push
     - trunk-fmt-pre-commit
+  disabled:
     - trunk-upgrade-available
+    - trunk-single-player-auto-upgrade
+    - trunk-single-player-auto-on-upgrade

--- a/cmd/zsh-lint/main.go
+++ b/cmd/zsh-lint/main.go
@@ -39,7 +39,7 @@ func main() {
 		}
 
 		file, err := parse.Parse(f, name)
-		f.Close()
+		_ = f.Close()
 
 		if err != nil {
 			exitNonZero = true

--- a/internal/parse/parse_test.go
+++ b/internal/parse/parse_test.go
@@ -43,7 +43,7 @@ func TestParseFixture(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open fixture: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	if _, err := Parse(f, "sample.zsh"); err != nil {
 		t.Fatalf("expected fixture to parse, got error: %v", err)
 	}

--- a/internal/rules/special_param_shadow.go
+++ b/internal/rules/special_param_shadow.go
@@ -234,7 +234,6 @@ func scanDeclarationOptions(variant string, args []*syntax.Assign) declarationOp
 				numericArgument = numericOptionArgumentNone
 				continue
 			}
-			numericArgument = numericOptionArgumentNone
 		}
 		// Unlike the historical single '-' option terminator, standalone '+' is
 		// a typeset display control form and never introduces declarations.

--- a/internal/survey/corpus_test.go
+++ b/internal/survey/corpus_test.go
@@ -53,7 +53,7 @@ func TestMinimizedCorpus(t *testing.T) {
 			t.Fatalf("opening %s: %v", path, err)
 		}
 		_, perr := parse.Parse(f, path)
-		f.Close()
+		_ = f.Close()
 		switch {
 		case gapName.MatchString(name):
 			if perr == nil {

--- a/internal/survey/survey.go
+++ b/internal/survey/survey.go
@@ -31,13 +31,13 @@ func Run(names []string, w io.Writer) int {
 			// The diagnostic is emitted on its own line starting at column 0
 			// (no indent) so it begins with `path:line:col:` and stays
 			// greppable / consumable by editor problem matchers.
-			fmt.Fprintf(w, "FAIL %s\n%s\n", name, formatErr(name, err))
+			_, _ = fmt.Fprintf(w, "FAIL %s\n%s\n", name, formatErr(name, err))
 			continue
 		}
-		fmt.Fprintf(w, "OK   %s\n", name)
+		_, _ = fmt.Fprintf(w, "OK   %s\n", name)
 	}
 	total := len(names)
-	fmt.Fprintf(w, "\n%d file(s) surveyed, %d ok, %d failed\n", total, total-failed, failed)
+	_, _ = fmt.Fprintf(w, "\n%d file(s) surveyed, %d ok, %d failed\n", total, total-failed, failed)
 	if failed > 0 {
 		return 1
 	}
@@ -49,7 +49,7 @@ func surveyFile(name string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	_, err = parse.Parse(f, name)
 	return err
 }


### PR DESCRIPTION
## Summary

- Bump `.trunk/trunk.yaml` to a mutually compatible pin set: plugins ref
  `v1.10.2`, `go@1.24.11`, `node@22.16.0`, and every linter version to one
  those runtimes can actually build/run - including using the `golangci-lint2`
  linter id (not `golangci-lint`) for the v2.x release, since v2 uses a
  different Go import path than v1
- Fix the 8 `golangci-lint2` findings this newly-working linter surfaced:
  7 cosmetic unchecked-error acknowledgements (`Close()`/`Fprintf`), and one
  genuine dead-code deletion in `special_param_shadow.go` (an assignment to
  `numericArgument` that no code path could ever observe)
- Add `.gitattributes` so `*.go`'s tab indentation isn't flagged as a
  `git-diff-check` whitespace error under a contributor's
  `core.whitespace=tab-in-indent`

## Test plan

- [x] `trunk check --all` -> `Checked 103 files, ✔ No issues`
- [x] `go build -buildvcs=false ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass)

## References

- #101 (this issue - full triage/investigation notes and evidence)
- #100 (the non-mutation bugfix this deliberately does not bundle with,
  per that issue's own acceptance criteria)
- #102 (unrelated Trunk daemon deadlock found while relocating this work to
  its own branch)
