### PR TITLE
test(survey): add parser-gap fixtures for #104 and #105

### DIFF
--- a/internal/survey/testdata/corpus/gap-104-param-glob-toggle.zsh
+++ b/internal/survey/testdata/corpus/gap-104-param-glob-toggle.zsh
@@ -1,0 +1,7 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# Issue #104: parameter expansion glob-toggle ${~spec} does not
+# parse under LangZsh; minimized from real-world hostname glob matching.
+pattern='foo*'
+str='foobar'
+[[ "$str" == ${~pattern} ]] && print matched

--- a/internal/survey/testdata/corpus/gap-105-fd-var-redirect.zsh
+++ b/internal/survey/testdata/corpus/gap-105-fd-var-redirect.zsh
@@ -1,5 +1,7 @@
 # -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
 # vim: ft=zsh sw=2 ts=2 et
-# Issue #105: {varname} dynamic file-descriptor redirection (MULTIOS)
-# incorrectly rejected as bash-only under LangZsh; minimized from real-code socket handling.
+# Issue #105: the {varname} redirection form opens a new file descriptor and
+# stores its number in varname (zshmisc, REDIRECTION). This is dynamic
+# file-descriptor allocation, not the MULTIOS option. It is valid Zsh, but
+# LangZsh rejects it as bash-only; minimized from real-code socket handling.
 exec {fd}>&-

--- a/internal/survey/testdata/corpus/gap-105-fd-var-redirect.zsh
+++ b/internal/survey/testdata/corpus/gap-105-fd-var-redirect.zsh
@@ -1,0 +1,5 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# Issue #105: {varname} dynamic file-descriptor redirection (MULTIOS)
+# incorrectly rejected as bash-only under LangZsh; minimized from real-code socket handling.
+exec {fd}>&-


### PR DESCRIPTION
## What

Adds the two minimized parser-gap fixtures tracked by #104 and #105.

- `gap-104-param-glob-toggle.zsh` covers the `${~spec}` glob-toggle operator,
  minimized from real-world hostname glob matching.
- `gap-105-fd-var-redirect.zsh` covers `{varname}` dynamic file-descriptor
  redirection, minimized from real-code socket handling.

## Validation

Both directions required by `docs/project/parser-gap-workflow.md` were checked
before committing:

| Fixture   | `zsh -n`  | `zsh-lint-survey`                                                     |
| --------- | --------- | --------------------------------------------------------------------- |
| `gap-104` | passes    | fails: ``not a valid parameter expansion operator: `~` ``              |
| `gap-105` | passes    | fails: ``\`{varname}\` redirects are a bash feature; tried parsing as zsh`` |

`zsh -n` accepting them is the point: the constructs are real Zsh, so these are
genuine parser gaps rather than broken scripts. `TestMinimizedCorpus` holds each
gap open until the front end learns the construct, at which point the fixture
gets promoted to `ok-*` and the issue closes.

`go test ./...`, `gofmt -l`, `go vet ./...`, and `trunk check --all` all pass.

## Not closing the issues

These fixtures record the gaps; they do not fix them. #104 and #105 stay open
until the parser handles the constructs and the fixtures are renamed to `ok-*`
per step 5 of the parser-gap workflow.

Refs #104, #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
