### PR TITLE
ci(zsh-n): expose a stable aggregate context and add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
+#
+# The reference `main` ruleset in z-shell/.github runbooks/branch-protection.md
+# requires code-owner review. That rule needs a CODEOWNERS file to resolve an
+# owner; without one it can never be satisfied.
+#
+# The sole entry is also the usual author of promotions, so the self-review
+# deadlock the runbook describes is expected here: the ruleset grants
+# OrganizationAdmin and the admin/maintain/write roles `bypass_mode: always`,
+# and `gh pr merge --admin` is the normal promotion path, not an escape hatch.
+* @ss-o

--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -64,3 +64,28 @@ jobs:
         run: |
           zsh -fc 'zcompile -- "$1"' zsh "$ZSH_FILE"; rc=$?
           ls -al -- "${ZSH_FILE}.zwc"; exit "$rc"
+  # The zsh-n job is a matrix over discovered files, so each leg reports as
+  # "zsh-n (<path>)". Those context names change whenever a Zsh file is added,
+  # renamed, or removed, which makes them unusable in a ruleset's
+  # required_status_checks list. This job collapses the matrix into one stable
+  # context name that a ruleset can require.
+  zsh-n-complete:
+    name: Zsh Syntax Check Complete
+    runs-on: ubuntu-latest
+    needs: [zsh-matrix, zsh-n]
+    if: always()
+    steps:
+      - name: Verify every syntax check succeeded
+        env:
+          MATRIX_RESULT: ${{ needs.zsh-matrix.result }}
+          SYNTAX_RESULT: ${{ needs.zsh-n.result }}
+        run: |
+          if [[ "${MATRIX_RESULT}" != "success" ]]; then
+            echo "::error::Matrix construction did not succeed (${MATRIX_RESULT})."
+            exit 1
+          fi
+          if [[ "${SYNTAX_RESULT}" != "success" ]]; then
+            echo "::error::At least one zsh -n or zcompile leg did not succeed (${SYNTAX_RESULT})."
+            exit 1
+          fi
+          echo "Every zsh -n and zcompile leg succeeded."

--- a/internal/workflowcontract/ci_release_test.go
+++ b/internal/workflowcontract/ci_release_test.go
@@ -391,6 +391,36 @@ func TestGoCIBuildTestReportsOnEveryPullRequest(t *testing.T) {
 	}
 }
 
+// A matrix job reports one check run per leg, so zsh-n's contexts are named
+// after the discovered file paths ("zsh-n (./path/to/file.zsh)") and change
+// whenever a Zsh file is added, renamed, or removed. A ruleset's
+// required_status_checks list cannot reference a moving name, so the workflow
+// must keep one aggregating job whose context name is stable. The `if:
+// always()` guard matters as much as the job itself: without it the aggregate
+// is skipped when a leg fails, and a skipped required check never reports.
+func TestZshSyntaxExposesStableAggregateContext(t *testing.T) {
+	workflow := zshSyntaxWorkflow(t)
+
+	if got := len(exactWorkflowLineSpans(workflow, "  zsh-n-complete:")); got != 1 {
+		t.Fatalf("zsh-n.yml must retain the stable zsh-n-complete job ID exactly once; got %d", got)
+	}
+
+	fields := directWorkflowMapping(workflowBlock(t, workflow, "zsh-n-complete:", 2), 4)
+	for _, expected := range []workflowMappingField{
+		{name: "name", value: "Zsh Syntax Check Complete"},
+		{name: "needs", value: "[zsh-matrix, zsh-n]"},
+		{name: "if", value: "always()"},
+	} {
+		values := fields[expected.name]
+		if len(values) != 1 || values[0] != expected.value {
+			t.Errorf(
+				"zsh-n-complete %s must be %q so the aggregate context always reports; got %q",
+				expected.name, expected.value, values,
+			)
+		}
+	}
+}
+
 const mainBranchGuardScript = `if [[ "${HEAD_REPOSITORY}" != "${REPOSITORY}" ]]; then
   echo "::error::Pull requests into main must come from this repository (got '${HEAD_REPOSITORY}')."
   exit 1


### PR DESCRIPTION
## What

Two prerequisites for the ADR-0013 class-2 settings baseline. Neither requires a
status check nor applies a ruleset.

### 1. A stable aggregate context for `zsh-n`

`zsh-n` is a matrix over files discovered at run time, so it reports one check
run per leg, named after the path:

```
zsh-n (./internal/survey/testdata/corpus/gap-13-multi-name-loop.zsh)
```

Those names move whenever a Zsh file is added, renamed, or removed, so they can
never be listed in a ruleset's `required_status_checks`. The fixtures in the
companion PR for #104 and #105 change the context set again, which makes this
concrete rather than theoretical.

`zsh-n-complete` depends on both existing jobs and fails when either did not
succeed, giving one context name a ruleset can reference. The `if: always()`
guard is load-bearing: without it the aggregate is skipped when a leg fails, and
a skipped required check never reports, which is exactly the deadlock ADR-0013
warns about.

`TestZshSyntaxExposesStableAggregateContext` locks the job ID, name, `needs`
list, and the `always()` guard, matching the existing
`TestGoCIBuildTestReportsOnEveryPullRequest` pattern. Verified by mutation:
dropping the guard and deleting the job each fail the test.

### 2. CODEOWNERS

The reference `main` ruleset in `runbooks/branch-protection.md` requires
code-owner review, and ADR-0013 marks that row required for class 2. The rule
needs a CODEOWNERS file to resolve an owner; with no file present it can never
be satisfied. Uses the same single-maintainer shape as `z-shell/zsh-eza`.

## Known limitation, deliberately left

`zsh-n.yml` still carries a `pull_request.paths` filter, so the new context is
now stably **named** but still does not **report** on a non-Zsh pull request.
Both properties are needed before it can be required. Removing the filter runs
the full matrix on every pull request, which is a cost tradeoff for the
maintainer to decide, so it is not bundled here. Do not add
`Zsh Syntax Check Complete` to `required_status_checks` while the filter remains.

`build-test` is currently the only check that is both stably named and always
reporting.

## Verification

`trunk check --all` (106 files, 0 issues), `go test ./...`, `gofmt -l`, and
`go vet ./...` all pass.

## Agent handoff

Phase 1 of the settings baseline only. Phases 2 and 3 (promotion to `main`,
observing context names, then the `main`/`next`/tag rulesets) are planned but
not started, and are gated on these checks reporting on a real pull request.
Issue #90 control 2 (tag protection) remains entirely unimplemented.

Refs #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)
