### PR TITLE
ci(zsh-n): report on every pull request so the aggregate can be required

### DIFF
--- a/.github/workflows/zsh-n.yml
+++ b/.github/workflows/zsh-n.yml
@@ -10,11 +10,11 @@ on:
       - "**/*.zsh"
       - "legacy/functions/**"
       - ".github/workflows/zsh-n.yml"
-  pull_request:
-    paths:
-      - "**/*.zsh"
-      - "legacy/functions/**"
-      - ".github/workflows/zsh-n.yml"
+  # Deliberately unfiltered. A path-filtered pull_request trigger never reports
+  # on a pull request that touches no Zsh, and a required check that never
+  # reports leaves such pull requests permanently pending. Keeping this
+  # unfiltered is what makes the zsh-n-complete context safe to require.
+  pull_request: {}
   workflow_dispatch: {}
 
 permissions:

--- a/internal/workflowcontract/ci_release_test.go
+++ b/internal/workflowcontract/ci_release_test.go
@@ -405,6 +405,15 @@ func TestZshSyntaxExposesStableAggregateContext(t *testing.T) {
 		t.Fatalf("zsh-n.yml must retain the stable zsh-n-complete job ID exactly once; got %d", got)
 	}
 
+	// The aggregate is only safe to require if it reports on every pull
+	// request. A pull_request.paths filter would silence it on a pull request
+	// touching no Zsh, leaving that pull request permanently pending against a
+	// required check.
+	onBlock := workflowBlock(t, workflow, "on:", 0)
+	if values := directWorkflowMapping(onBlock, 2)["pull_request"]; len(values) != 1 || values[0] != "{}" {
+		t.Fatalf("zsh-n pull_request trigger must be unfiltered so the aggregate always reports; got %q", values)
+	}
+
 	fields := directWorkflowMapping(workflowBlock(t, workflow, "zsh-n-complete:", 2), 4)
 	for _, expected := range []workflowMappingField{
 		{name: "name", value: "Zsh Syntax Check Complete"},


### PR DESCRIPTION
## What

Removes the `pull_request.paths` filter from `zsh-n.yml` so
`Zsh Syntax Check Complete` reports on every pull request.

## Why

The aggregate job added in #107 gave the matrix a stable context name, which is
necessary but not sufficient. A required status check must also *report*
unconditionally. A path-filtered trigger produces no check at all on a pull
request touching no Zsh, and a required check that never reports leaves that
pull request permanently pending, which is the deadlock ADR-0013 and #90 both
warn about.

This is not hypothetical. PR #109 changed no Zsh files, and its entire check
list was `Analyze (actions)`, `Analyze (go)`, `CodeQL`, `Trunk Check`,
`Trunk Code Quality / Trunk Code Quality`, and `build-test`. Zero `zsh-n`
contexts appeared.

## Cost

The matrix now runs on every pull request. That is a deliberate trade for this
repository: it is a Zsh analyzer, so always syntax checking its own Zsh is
defensible, and Actions minutes are free on public repositories. The `push`
trigger keeps its paths filter; only `pull_request` needs to be unconditional.

## Verification

`TestZshSyntaxExposesStableAggregateContext` now also asserts the trigger is
unfiltered, mirroring `TestGoCIBuildTestReportsOnEveryPullRequest`. Verified by
mutation: restoring a paths filter fails the test. `trunk check --all` is clean
across 108 files and the full Go suite passes.

**This pull request is its own proof.** It changes no `.zsh` file, so under the
old configuration `Zsh Syntax Check Complete` would not have appeared here at
all. It should now report.

## Follow-up

Once merged, `Zsh Syntax Check Complete` can be added to the `main` ruleset's
`required_status_checks`. It is deliberately absent today.

Refs #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)
