### PR TITLE
test(release): add failed-tag publication probe

### DIFF
--- a/internal/workflowcontract/release_failure_probe_test.go
+++ b/internal/workflowcontract/release_failure_probe_test.go
@@ -1,0 +1,72 @@
+package workflowcontract
+
+import (
+	"os"
+	"testing"
+)
+
+func isFailedTagReleaseProbe(repository, refType, refName string) bool {
+	return repository == "z-shell/zsh-lint" &&
+		refType == "tag" &&
+		refName == "v0.0.0"
+}
+
+func TestIsFailedTagReleaseProbe(t *testing.T) {
+	tests := []struct {
+		name       string
+		repository string
+		refType    string
+		refName    string
+		want       bool
+	}{
+		{
+			name:       "exact sentinel",
+			repository: "z-shell/zsh-lint",
+			refType:    "tag",
+			refName:    "v0.0.0",
+			want:       true,
+		},
+		{name: "local environment"},
+		{
+			name:       "another repository",
+			repository: "fork/zsh-lint",
+			refType:    "tag",
+			refName:    "v0.0.0",
+		},
+		{
+			name:       "branch ref",
+			repository: "z-shell/zsh-lint",
+			refType:    "branch",
+			refName:    "v0.0.0",
+		},
+		{
+			name:       "future release tag",
+			repository: "z-shell/zsh-lint",
+			refType:    "tag",
+			refName:    "v1.0.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isFailedTagReleaseProbe(tt.repository, tt.refType, tt.refName)
+			if got != tt.want {
+				t.Fatalf("isFailedTagReleaseProbe() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFailedTagReleaseProbe intentionally fails only for the v0.0.0 exercise
+// tracked in https://github.com/z-shell/zsh-lint/issues/90.
+func TestFailedTagReleaseProbe(t *testing.T) {
+	if !isFailedTagReleaseProbe(
+		os.Getenv("GITHUB_REPOSITORY"),
+		os.Getenv("GITHUB_REF_TYPE"),
+		os.Getenv("GITHUB_REF_NAME"),
+	) {
+		return
+	}
+
+	t.Fatal("intentional z-shell/zsh-lint#90 release-gate probe: v0.0.0 must not publish")
+}


### PR DESCRIPTION
## Summary

- add a one-time failed-tag publication probe for https://github.com/z-shell/zsh-lint/issues/90
- require the exact GitHub environment tuple `GITHUB_REPOSITORY=z-shell/zsh-lint`, `GITHUB_REF_TYPE=tag`, and `GITHUB_REF_NAME=v0.0.0`
- leave the existing release workflow unchanged

## Verification

- ordinary probe tests: PASS
- exact `v0.0.0` sentinel simulation: FAIL with the intentional issue #90 message
- future `v1.0.1` tag simulation: PASS
- `go test -count=1 ./...`: PASS
- `go vet ./...`: PASS
- `go build -buildvcs=false ./...`: PASS
- `go mod tidy -diff`: PASS
- `gofmt` and `git diff --check`: PASS

No semantic tag or GitHub Release has been created. Tag creation remains a separate maintainer authorization boundary.