### PR TITLE
fix(parse): support nested conditional alternation

### DIFF
--- a/docs/project/parser-gap-workflow.md
+++ b/docs/project/parser-gap-workflow.md
@@ -60,3 +60,26 @@ fixture parse, the test fails loudly. Rename the fixture to `ok-<slug>.zsh`
 so it becomes permanent regression coverage, update `requiredFixtures`, and
 close the issue with a link to the survey run confirming the originating
 real file now parses.
+
+### Local compatibility adapters
+
+A narrowly scoped adapter in `internal/parse` may close a proven valid-Zsh gap
+without changing the selected parser dependency only when all of these hold:
+
+- the released Zsh manual and `zsh -f -n` establish the construct's validity;
+- the adapter activates for one exact parser error and one language construct;
+- the full-file retry has the same byte length as the original source;
+- every transformed byte is restored in the typed AST before analysis;
+- regression tests prove original AST text, diagnostic positions, suppression
+  behavior, and invalid-syntax rejection; and
+- the minimized fixture is `ok-*` only after the normal analyzer path passes.
+
+If recognition or restoration is uncertain, return the parser error. Do not
+use generic error suppression, recovery ASTs, or a compatibility adapter to
+absorb a second untracked language feature.
+
+A bounded local island may use source-mapped synthetic terminators only when
+the adapter verifies the original AST structure, invalid-syntax behavior, and
+every source position before returning the complete tree. This exception does
+not permit general source rewriting or consuming separators from the
+full-file retry.

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -78,6 +78,38 @@ func TestAnalyzerIndexesScopeForOptInRule(t *testing.T) {
 	}
 }
 
+func TestAnalyzerPositionsAfterNestedConditionalAlternation(t *testing.T) {
+	const code = "badcmd before\nline=foo\n[[ $line == ((a|b)|c) ]]\nbadcmd after\n"
+	file, err := parse.Parse(strings.NewReader(code), "test.zsh")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	diags := analyzer.New(&dummyRule{}).Analyze(file, "test.zsh")
+	if len(diags) != 2 {
+		t.Fatalf("diagnostic count = %d, want 2: %+v", len(diags), diags)
+	}
+	want := []struct {
+		line   int
+		column int
+		offset int
+	}{
+		{line: 1, column: 1, offset: 0},
+		{line: 4, column: 1, offset: 48},
+	}
+	if offset := strings.Index(code, "badcmd after"); offset != want[1].offset {
+		t.Fatalf("badcmd after offset = %d, want %d", offset, want[1].offset)
+	}
+	for i, diagnostic := range diags {
+		if diagnostic.Range.Start.Line != want[i].line ||
+			diagnostic.Range.Start.Column != want[i].column ||
+			diagnostic.Range.Start.Offset != want[i].offset {
+			t.Errorf("diagnostic[%d] start = %+v, want line=%d column=%d offset=%d",
+				i, diagnostic.Range.Start, want[i].line, want[i].column, want[i].offset)
+		}
+	}
+}
+
 func findByID(ds diag.Diagnostics, id diag.RuleID) []diag.Diagnostic {
 	var out []diag.Diagnostic
 	for _, d := range ds {
@@ -86,6 +118,90 @@ func findByID(ds diag.Diagnostics, id diag.RuleID) []diag.Diagnostic {
 		}
 	}
 	return out
+}
+
+func TestAnalyzerSuppressionAfterNestedConditionalAlternation(t *testing.T) {
+	const code = "line=foo\n[[ $line == ((a|b)|c) ]]\neval $x # zsh-lint disable=security/eval -- static table\n"
+	file, err := parse.Parse(strings.NewReader(code), "test.zsh")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	diags := analyzer.New(rules.Default()...).Analyze(file, "test.zsh")
+	if got := findByID(diags, "security/eval"); len(got) != 0 {
+		t.Errorf("security/eval finding survived suppression: %+v", got)
+	}
+	if got := findByID(diags, "quoting/unquoted-var"); len(got) != 1 {
+		t.Errorf("quoting/unquoted-var count = %d, want 1: %+v", len(got), got)
+	}
+	if got := findByID(diags, "meta/unused-suppression"); len(got) != 0 {
+		t.Errorf("used suppression reported stale: %+v", got)
+	}
+}
+
+func TestAnalyzerDiagnosticsAfterLegacyBacktickIsland(t *testing.T) {
+	tests := []struct {
+		name string
+		code string
+		want []struct {
+			ruleID diag.RuleID
+			offset int
+			line   int
+			column int
+		}
+	}{
+		{
+			name: "suppression on next line",
+			code: "print `[[ $line == ((a|b)|c) ]]`\n" +
+				"eval $x # zsh-lint disable=security/eval -- static table\n",
+			want: []struct {
+				ruleID diag.RuleID
+				offset int
+				line   int
+				column int
+			}{
+				{ruleID: "style/backquotes", offset: 6, line: 1, column: 7},
+				{ruleID: "quoting/unquoted-var", offset: 38, line: 2, column: 6},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			file, err := parse.Parse(strings.NewReader(test.code), "legacy-analyzer.zsh")
+			if err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+			diagnostics := analyzer.New(rules.Default()...).Analyze(file, "legacy-analyzer.zsh")
+			if got := findByID(diagnostics, "security/eval"); len(got) != 0 {
+				t.Errorf("security/eval finding survived suppression: %+v", got)
+			}
+			if got := findByID(diagnostics, "meta/unused-suppression"); len(got) != 0 {
+				t.Errorf("used suppression reported stale: %+v", got)
+			}
+			if len(diagnostics) != len(test.want) {
+				t.Fatalf("diagnostic count = %d, want %d: %+v", len(diagnostics), len(test.want), diagnostics)
+			}
+			for index, want := range test.want {
+				got := diagnostics[index]
+				if got.RuleID != want.ruleID || got.Range.Start.Offset != want.offset ||
+					got.Range.Start.Line != want.line || got.Range.Start.Column != want.column {
+					t.Errorf(
+						"diagnostic[%d] = rule %q offset %d line %d column %d, want %q/%d/%d/%d",
+						index,
+						got.RuleID,
+						got.Range.Start.Offset,
+						got.Range.Start.Line,
+						got.Range.Start.Column,
+						want.ruleID,
+						want.offset,
+						want.line,
+						want.column,
+					)
+				}
+			}
+		})
+	}
 }
 
 func TestAnalyzerAppliesSuppression(t *testing.T) {

--- a/internal/parse/nested_conditional_backtick.go
+++ b/internal/parse/nested_conditional_backtick.go
@@ -1,0 +1,403 @@
+package parse
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+type islandSourceMap struct {
+	originalOffsetByBoundary []int
+	syntheticOffsets         map[int]struct{}
+}
+
+type legacyBacktickWorkProbe func()
+
+type legacyBacktickTargetKey struct {
+	openOffset  int
+	closeOffset int
+}
+
+type legacyBacktickTargetIndexProbe func()
+
+func buildLegacyBacktickIsland(
+	masked, original []byte,
+	island legacyBacktickIsland,
+	probes ...legacyBacktickWorkProbe,
+) ([]byte, islandSourceMap, error) {
+	var inspect legacyBacktickWorkProbe
+	if len(probes) > 0 {
+		inspect = probes[0]
+	}
+	root := island.root
+	if len(masked) != len(original) || root == nil || root.openStart < 0 ||
+		root.openOffset < root.openStart || root.closeStart <= root.openOffset ||
+		root.closeOffset < root.closeStart || root.closeOffset >= len(original) {
+		return nil, islandSourceMap{}, fmt.Errorf("invalid legacy backtick island bounds")
+	}
+	if original[root.openOffset] != '`' || original[root.closeOffset] != '`' ||
+		masked[root.openOffset] != '`' || masked[root.closeOffset] != '`' {
+		return nil, islandSourceMap{}, fmt.Errorf("legacy backtick island delimiter mismatch")
+	}
+
+	marked := append([]*legacyBacktickSpan(nil), island.markedClosures...)
+	sort.Slice(marked, func(i, j int) bool {
+		return marked[i].closeStart < marked[j].closeStart
+	})
+	markedByCloseStart := make(map[int]*legacyBacktickSpan, len(marked))
+	previousCloseStart := -1
+	for _, span := range marked {
+		if span == nil || span.closeStart <= root.openOffset ||
+			span.closeOffset > root.closeOffset || span.closeStart <= previousCloseStart ||
+			span.closeOffset < span.closeStart || original[span.closeOffset] != '`' {
+			return nil, islandSourceMap{}, fmt.Errorf("invalid marked legacy backtick closure")
+		}
+		previousCloseStart = span.closeStart
+		markedByCloseStart[span.closeStart] = span
+	}
+
+	transformed := make([]byte, 0, root.closeOffset-root.openStart+1+len(marked)+2)
+	sourceMap := islandSourceMap{
+		originalOffsetByBoundary: []int{root.openStart},
+		syntheticOffsets:         make(map[int]struct{}, len(marked)+2),
+	}
+	appendSynthetic := func(b byte, originalBoundary int) {
+		offset := len(transformed)
+		transformed = append(transformed, b)
+		sourceMap.originalOffsetByBoundary = append(sourceMap.originalOffsetByBoundary, originalBoundary)
+		sourceMap.syntheticOffsets[offset] = struct{}{}
+		if inspect != nil {
+			inspect()
+		}
+	}
+	appendOriginal := func(originalOffset int) error {
+		if sourceMap.originalOffsetByBoundary[len(sourceMap.originalOffsetByBoundary)-1] != originalOffset {
+			return fmt.Errorf("non-monotonic source traversal at byte %d", originalOffset)
+		}
+		transformed = append(transformed, masked[originalOffset])
+		sourceMap.originalOffsetByBoundary = append(sourceMap.originalOffsetByBoundary, originalOffset+1)
+		if inspect != nil {
+			inspect()
+		}
+		return nil
+	}
+
+	if root.doubleQuotedParent {
+		appendSynthetic('"', root.openStart)
+	}
+	for originalOffset := root.openStart; originalOffset <= root.closeOffset; originalOffset++ {
+		if _, ok := markedByCloseStart[originalOffset]; ok {
+			appendSynthetic('\n', originalOffset)
+		}
+		if err := appendOriginal(originalOffset); err != nil {
+			return nil, islandSourceMap{}, err
+		}
+	}
+	if root.doubleQuotedParent {
+		appendSynthetic('"', root.closeOffset+1)
+	}
+	if len(sourceMap.originalOffsetByBoundary) != len(transformed)+1 {
+		return nil, islandSourceMap{}, fmt.Errorf("legacy backtick source-map width mismatch")
+	}
+	if err := validateIslandSourceMap(sourceMap, len(transformed), root); err != nil {
+		return nil, islandSourceMap{}, err
+	}
+	return transformed, sourceMap, nil
+}
+
+func validateIslandSourceMap(
+	sourceMap islandSourceMap,
+	transformedLen int,
+	root *legacyBacktickSpan,
+) error {
+	if root == nil || transformedLen < 0 ||
+		len(sourceMap.originalOffsetByBoundary) != transformedLen+1 {
+		return fmt.Errorf("invalid legacy backtick source map width")
+	}
+	for offset := range sourceMap.syntheticOffsets {
+		if offset < 0 || offset >= transformedLen {
+			return fmt.Errorf("synthetic offset %d is outside transformed island", offset)
+		}
+	}
+	for offset := 0; offset < transformedLen; offset++ {
+		start := sourceMap.originalOffsetByBoundary[offset]
+		end := sourceMap.originalOffsetByBoundary[offset+1]
+		if start < root.openStart || start > root.closeOffset+1 ||
+			end < root.openStart || end > root.closeOffset+1 || end < start {
+			return fmt.Errorf("non-monotonic legacy backtick source map at byte %d", offset)
+		}
+		_, synthetic := sourceMap.syntheticOffsets[offset]
+		if synthetic {
+			if end != start {
+				return fmt.Errorf("synthetic byte %d advances original source", offset)
+			}
+			continue
+		}
+		if end != start+1 {
+			return fmt.Errorf("original byte %d does not advance source exactly once", offset)
+		}
+	}
+	return nil
+}
+
+func parseAndGraftLegacyBacktickIslands(
+	tree *syntax.File,
+	masked, original []byte,
+	name string,
+	islands []legacyBacktickIsland,
+	parse func([]byte, string) (*syntax.File, error),
+	probes ...legacyBacktickWorkProbe,
+) error {
+	if tree == nil || parse == nil || len(masked) != len(original) {
+		return fmt.Errorf("invalid legacy backtick graft input")
+	}
+	if err := validateLegacyBacktickIslandOrder(islands, len(original)); err != nil {
+		return err
+	}
+	// Index the placeholder substitutions once. Looking them up during each
+	// island graft would rescan the full retry AST and make sibling islands
+	// quadratic in the number of source statements.
+	graftTargets := indexLegacyBacktickGraftTargets(tree)
+	lineStarts := originalLineStarts(original)
+	for _, island := range islands {
+		transformed, sourceMap, err := buildLegacyBacktickIsland(masked, original, island, probes...)
+		if err != nil {
+			return err
+		}
+		islandTree, err := parse(transformed, name)
+		if err != nil {
+			return err
+		}
+		root := island.root
+		openOffset, ok := transformedOffsetForOriginalByte(transformed, sourceMap, original, root.openOffset)
+		if !ok {
+			return fmt.Errorf("legacy backtick open at byte %d is not mapped", root.openOffset)
+		}
+		closeOffset, ok := transformedOffsetForOriginalByte(transformed, sourceMap, original, root.closeOffset)
+		if !ok {
+			return fmt.Errorf("legacy backtick close at byte %d is not mapped", root.closeOffset)
+		}
+
+		var selected []*syntax.CmdSubst
+		syntax.Walk(islandTree, func(node syntax.Node) bool {
+			substitution, ok := node.(*syntax.CmdSubst)
+			if ok && substitution.Backquotes && int(substitution.Left.Offset()) == openOffset &&
+				int(substitution.Right.Offset()) == closeOffset {
+				selected = append(selected, substitution)
+			}
+			return true
+		})
+		if len(selected) != 1 {
+			return fmt.Errorf(
+				"legacy backtick island at byte %d matched %d parsed substitutions",
+				root.openOffset,
+				len(selected),
+			)
+		}
+		if err := rejectSyntheticSemicolons(selected[0], sourceMap); err != nil {
+			return err
+		}
+		if err := rebaseLegacyBacktickBody(selected[0], sourceMap, lineStarts, root); err != nil {
+			return err
+		}
+
+		targets := graftTargets[legacyBacktickTargetKey{
+			openOffset:  root.openOffset,
+			closeOffset: root.closeOffset,
+		}]
+		if len(targets) != 1 {
+			return fmt.Errorf(
+				"legacy backtick island at byte %d matched %d graft targets",
+				root.openOffset,
+				len(targets),
+			)
+		}
+		targets[0].Stmts = selected[0].Stmts
+		targets[0].Last = selected[0].Last
+	}
+	return nil
+}
+
+func indexLegacyBacktickGraftTargets(
+	tree *syntax.File,
+	probes ...legacyBacktickTargetIndexProbe,
+) map[legacyBacktickTargetKey][]*syntax.CmdSubst {
+	var inspect legacyBacktickTargetIndexProbe
+	if len(probes) > 0 {
+		inspect = probes[0]
+	}
+	targets := make(map[legacyBacktickTargetKey][]*syntax.CmdSubst)
+	if tree == nil {
+		return targets
+	}
+	syntax.Walk(tree, func(node syntax.Node) bool {
+		if inspect != nil {
+			inspect()
+		}
+		substitution, ok := node.(*syntax.CmdSubst)
+		if !ok || !substitution.Backquotes {
+			return true
+		}
+		key := legacyBacktickTargetKey{
+			openOffset:  int(substitution.Left.Offset()),
+			closeOffset: int(substitution.Right.Offset()),
+		}
+		targets[key] = append(targets[key], substitution)
+		return true
+	})
+	return targets
+}
+
+func validateLegacyBacktickIslandOrder(islands []legacyBacktickIsland, sourceLen int) error {
+	previousClose := -1
+	for _, island := range islands {
+		root := island.root
+		if root == nil || root.openStart <= previousClose || root.openOffset < root.openStart ||
+			root.closeStart <= root.openOffset || root.closeOffset < root.closeStart ||
+			root.closeOffset >= sourceLen {
+			return fmt.Errorf("legacy backtick islands are not sorted and disjoint")
+		}
+		previousClose = root.closeOffset
+	}
+	return nil
+}
+
+func transformedOffsetForOriginalByte(
+	transformed []byte,
+	sourceMap islandSourceMap,
+	original []byte,
+	originalOffset int,
+) (int, bool) {
+	for offset := 0; offset < len(transformed); offset++ {
+		if _, synthetic := sourceMap.syntheticOffsets[offset]; synthetic {
+			continue
+		}
+		if sourceMap.originalOffsetByBoundary[offset] == originalOffset &&
+			sourceMap.originalOffsetByBoundary[offset+1] == originalOffset+1 &&
+			originalOffset >= 0 && originalOffset < len(original) &&
+			transformed[offset] == original[originalOffset] {
+			return offset, true
+		}
+	}
+	return 0, false
+}
+
+func rejectSyntheticSemicolons(substitution *syntax.CmdSubst, sourceMap islandSourceMap) error {
+	var found error
+	syntax.Walk(substitution, func(node syntax.Node) bool {
+		if found != nil {
+			return false
+		}
+		stmt, ok := node.(*syntax.Stmt)
+		if !ok || !stmt.Semicolon.IsValid() {
+			return true
+		}
+		if _, synthetic := sourceMap.syntheticOffsets[int(stmt.Semicolon.Offset())]; synthetic {
+			found = fmt.Errorf("synthetic terminator became a statement semicolon at byte %d", stmt.Semicolon.Offset())
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func rebaseLegacyBacktickBody(
+	substitution *syntax.CmdSubst,
+	sourceMap islandSourceMap,
+	lineStarts []int,
+	root *legacyBacktickSpan,
+) error {
+	for _, stmt := range substitution.Stmts {
+		if err := rebaseLegacyBacktickPositions(reflect.ValueOf(stmt), sourceMap, lineStarts, root); err != nil {
+			return err
+		}
+	}
+	if err := rebaseLegacyBacktickPositions(reflect.ValueOf(&substitution.Last), sourceMap, lineStarts, root); err != nil {
+		return err
+	}
+	return nil
+}
+
+var syntaxPosType = reflect.TypeOf(syntax.Pos{})
+
+func rebaseLegacyBacktickPositions(
+	value reflect.Value,
+	sourceMap islandSourceMap,
+	lineStarts []int,
+	root *legacyBacktickSpan,
+) error {
+	if !value.IsValid() {
+		return nil
+	}
+	if value.Type() == syntaxPosType {
+		if !value.CanSet() {
+			return fmt.Errorf("syntax position is not settable")
+		}
+		position := value.Interface().(syntax.Pos)
+		if !position.IsValid() {
+			return nil
+		}
+		transformedOffset := int(position.Offset())
+		if transformedOffset < 0 || transformedOffset >= len(sourceMap.originalOffsetByBoundary) {
+			return fmt.Errorf("transformed position %d is outside island source map", transformedOffset)
+		}
+		originalOffset := sourceMap.originalOffsetByBoundary[transformedOffset]
+		if originalOffset <= root.openOffset || originalOffset > root.closeOffset {
+			return fmt.Errorf("mapped position %d is outside legacy backtick body", originalOffset)
+		}
+		lineIndex := sort.Search(len(lineStarts), func(index int) bool {
+			return lineStarts[index] > originalOffset
+		}) - 1
+		if lineIndex < 0 {
+			return fmt.Errorf("mapped position %d has no source line", originalOffset)
+		}
+		value.Set(reflect.ValueOf(syntax.NewPos(
+			uint(originalOffset),
+			uint(lineIndex+1),
+			uint(originalOffset-lineStarts[lineIndex]+1),
+		)))
+		return nil
+	}
+
+	switch value.Kind() {
+	case reflect.Pointer:
+		if value.IsNil() {
+			return nil
+		}
+		return rebaseLegacyBacktickPositions(value.Elem(), sourceMap, lineStarts, root)
+	case reflect.Interface:
+		if value.IsNil() {
+			return nil
+		}
+		return rebaseLegacyBacktickPositions(value.Elem(), sourceMap, lineStarts, root)
+	case reflect.Struct:
+		for index := 0; index < value.NumField(); index++ {
+			field := value.Field(index)
+			if !field.CanSet() {
+				continue
+			}
+			if err := rebaseLegacyBacktickPositions(field, sourceMap, lineStarts, root); err != nil {
+				return err
+			}
+		}
+	case reflect.Array, reflect.Slice:
+		for index := 0; index < value.Len(); index++ {
+			if err := rebaseLegacyBacktickPositions(value.Index(index), sourceMap, lineStarts, root); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func originalLineStarts(src []byte) []int {
+	starts := []int{0}
+	for offset, b := range src {
+		if b == '\n' && offset+1 < len(src) {
+			starts = append(starts, offset+1)
+		}
+	}
+	return starts
+}

--- a/internal/parse/nested_conditional_backtick_test.go
+++ b/internal/parse/nested_conditional_backtick_test.go
@@ -1,0 +1,769 @@
+package parse
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+func TestParseNestedConditionalAlternationPreservesBacktickStatements(t *testing.T) {
+	tests := []struct {
+		name      string
+		src       string
+		wantStmts int
+	}{
+		{
+			name:      "following ordinary statement",
+			src:       "print `[[ $line == ((a|b)|c) ]]`\nprint second\n",
+			wantStmts: 2,
+		},
+		{
+			name:      "two affected statements",
+			src:       "print `[[ $line == ((a|b)|c) ]]`\nprint `[[ $other == ((d|e)|f) ]]`\n",
+			wantStmts: 2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			file, err := Parse(strings.NewReader(test.src), "backtick-statements.zsh")
+			if err != nil {
+				t.Fatalf("Parse() error: %v", err)
+			}
+			if got := len(file.AST().Stmts); got != test.wantStmts {
+				t.Errorf("statement count = %d, want %d", got, test.wantStmts)
+			}
+		})
+	}
+}
+
+func TestParseNestedConditionalAlternationPreservesBacktickWords(t *testing.T) {
+	const src = "print before `[[ $line == ((a|b)|c) ]]` after\nprint second\n"
+	file, err := Parse(strings.NewReader(src), "backtick-words.zsh")
+	if err != nil {
+		t.Fatalf("Parse() error: %v", err)
+	}
+	if got := len(file.AST().Stmts); got != 2 {
+		t.Fatalf("statement count = %d, want 2", got)
+	}
+	call, ok := file.AST().Stmts[0].Cmd.(*syntax.CallExpr)
+	if !ok {
+		t.Fatalf("first statement command = %T, want *syntax.CallExpr", file.AST().Stmts[0].Cmd)
+	}
+	if got := len(call.Args); got != 4 {
+		t.Errorf("first statement argument count = %d, want 4", got)
+	}
+}
+
+func TestParseNestedConditionalAlternationSupportsBacktickBoundaries(t *testing.T) {
+	tests := []string{
+		"print `[[ $line == ((a|b)|c) ]]`",
+		"print `[[ $line == ((a|b)|c) ]]`suffix\n",
+		"print \"`[[ $line == ((a|b)|c) ]]`suffix\"\n",
+	}
+
+	for _, src := range tests {
+		t.Run(src, func(t *testing.T) {
+			file, err := Parse(strings.NewReader(src), "backtick-boundary.zsh")
+			if err != nil {
+				t.Fatalf("Parse() error: %v", err)
+			}
+			patterns := patternWords(t, file.AST())
+			if len(patterns) != 1 || patterns[0] != "((a|b)|c)" {
+				t.Fatalf("patterns = %q, want [((a|b)|c)]", patterns)
+			}
+			wantOpen := strings.IndexByte(src, '`')
+			wantClose := strings.LastIndexByte(src, '`')
+			matches := 0
+			syntax.Walk(file.AST(), func(node syntax.Node) bool {
+				substitution, ok := node.(*syntax.CmdSubst)
+				if !ok || !substitution.Backquotes {
+					return true
+				}
+				matches++
+				if got := int(substitution.Left.Offset()); got != wantOpen {
+					t.Errorf("backtick open offset = %d, want %d", got, wantOpen)
+				}
+				if got := int(substitution.Right.Offset()); got != wantClose {
+					t.Errorf("backtick close offset = %d, want %d", got, wantClose)
+				}
+				return true
+			})
+			if matches != 1 {
+				t.Errorf("backtick substitution count = %d, want 1", matches)
+			}
+		})
+	}
+}
+
+func TestParseNestedConditionalAlternationClosesBacktickAfterEscapedBackslash(t *testing.T) {
+	const src = "print `[[ $line == ((a|b)|c) ]]; print \\\\`suffix\n"
+	file, err := Parse(strings.NewReader(src), "backtick-even-backslashes.zsh")
+	if err != nil {
+		t.Fatalf("Parse() error: %v", err)
+	}
+	patterns := patternWords(t, file.AST())
+	if len(patterns) != 1 || patterns[0] != "((a|b)|c)" {
+		t.Fatalf("patterns = %q, want [((a|b)|c)]", patterns)
+	}
+
+	wantOpen := strings.IndexByte(src, '`')
+	wantClose := strings.LastIndexByte(src, '`')
+	matches := 0
+	syntax.Walk(file.AST(), func(node syntax.Node) bool {
+		substitution, ok := node.(*syntax.CmdSubst)
+		if !ok || !substitution.Backquotes {
+			return true
+		}
+		matches++
+		if got := int(substitution.Left.Offset()); got != wantOpen {
+			t.Errorf("backtick open offset = %d, want %d", got, wantOpen)
+		}
+		if got := int(substitution.Right.Offset()); got != wantClose {
+			t.Errorf("backtick close offset = %d, want %d", got, wantClose)
+		}
+		return true
+	})
+	if matches != 1 {
+		t.Errorf("backtick substitution count = %d, want 1", matches)
+	}
+}
+
+func TestLegacyBacktickEscapeStateMatchesNestedParserConsumption(t *testing.T) {
+	tests := []struct {
+		name                 string
+		rawBackslashes       int
+		wantEscapeDepth      int
+		wantDelimiterEscapes int
+	}{
+		{name: "unescaped", rawBackslashes: 0, wantEscapeDepth: 0, wantDelimiterEscapes: 0},
+		{name: "depth one", rawBackslashes: 1, wantEscapeDepth: 1, wantDelimiterEscapes: 1},
+		{name: "escaped backslash", rawBackslashes: 2, wantEscapeDepth: 0, wantDelimiterEscapes: 0},
+		{name: "depth two", rawBackslashes: 3, wantEscapeDepth: 2, wantDelimiterEscapes: 3},
+		{name: "two escaped backslashes", rawBackslashes: 4, wantEscapeDepth: 0, wantDelimiterEscapes: 0},
+		{name: "escaped pairs then depth one", rawBackslashes: 5, wantEscapeDepth: 1, wantDelimiterEscapes: 1},
+		{name: "three escaped backslashes", rawBackslashes: 6, wantEscapeDepth: 0, wantDelimiterEscapes: 0},
+		{name: "depth three", rawBackslashes: 7, wantEscapeDepth: 3, wantDelimiterEscapes: 7},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			src := []byte(strings.Repeat("\\", test.rawBackslashes) + "`")
+			gotDepth, gotDelimiterEscapes := legacyBacktickEscapeStateBefore(src, len(src)-1)
+			if gotDepth != test.wantEscapeDepth || gotDelimiterEscapes != test.wantDelimiterEscapes {
+				t.Errorf(
+					"legacyBacktickEscapeStateBefore() = depth %d delimiter escapes %d, want %d/%d",
+					gotDepth,
+					gotDelimiterEscapes,
+					test.wantEscapeDepth,
+					test.wantDelimiterEscapes,
+				)
+			}
+		})
+	}
+}
+
+func TestParseNestedConditionalAlternationRejectsLeadingAndAfterBacktick(t *testing.T) {
+	const src = "print `[[ $line == ((a|b)|c) ]]`\n&& print second\n"
+	if _, err := Parse(strings.NewReader(src), "backtick-leading-and.zsh"); err == nil {
+		t.Fatal("Parse() unexpectedly accepted native-invalid leading &&")
+	}
+}
+
+func TestParseNestedConditionalAlternationResumesAfterBacktickSuffix(t *testing.T) {
+	const src = "print `[[ $line == ((a|b)|c) ]]`#tag; [[ $other == ((d|e)|f) ]]\n"
+	file, err := Parse(strings.NewReader(src), "backtick-suffix-resume.zsh")
+	if err != nil {
+		t.Fatalf("Parse() error: %v", err)
+	}
+	want := []string{"((a|b)|c)", "((d|e)|f)"}
+	patterns := patternWords(t, file.AST())
+	if len(patterns) != len(want) {
+		t.Fatalf("pattern count = %d, want %d: %q", len(patterns), len(want), patterns)
+	}
+	for index := range want {
+		if patterns[index] != want[index] {
+			t.Errorf("pattern[%d] = %q, want %q", index, patterns[index], want[index])
+		}
+	}
+}
+
+func TestLegacyBacktickSpansPreserveNestedDelimiterDepth(t *testing.T) {
+	tests := []struct {
+		name          string
+		src           string
+		wantSpanCount int
+		wantMarked    int
+	}{
+		{
+			name:          "depth one",
+			src:           "print `[[ $line == ((a|b)|c) ]]`\n",
+			wantSpanCount: 1,
+			wantMarked:    1,
+		},
+		{
+			name:          "escaped depth two",
+			src:           "print `print \\`[[ $line == ((a|b)|c) ]]\\``\n",
+			wantSpanCount: 2,
+			wantMarked:    2,
+		},
+		{
+			name:          "affected nested and outer",
+			src:           "print `print \\`[[ $inner == ((d|e)|f) ]]\\`; [[ $outer == ((a|b)|c) ]]`\n",
+			wantSpanCount: 2,
+			wantMarked:    2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			src := []byte(test.src)
+			_, firstErr := parseTree(src, "backtick-spans.zsh")
+			var parseErr syntax.ParseError
+			if !errors.As(firstErr, &parseErr) || parseErr.Text != invalidAlternationOperator {
+				t.Fatalf("parseTree() error = %v, want %q", firstErr, invalidAlternationOperator)
+			}
+			batch, ok := nestedPatternBatch(src, int(parseErr.Pos.Offset()))
+			if !ok {
+				t.Fatal("nestedPatternBatch() rejected affected legacy backticks")
+			}
+			if len(batch.backtickIslands) != 1 {
+				t.Fatalf("island count = %d, want 1", len(batch.backtickIslands))
+			}
+			island := batch.backtickIslands[0]
+			if got := countLegacyBacktickSpans(island.root); got != test.wantSpanCount {
+				t.Errorf("span count = %d, want %d", got, test.wantSpanCount)
+			}
+			if got := len(island.markedClosures); got != test.wantMarked {
+				t.Errorf("marked closure count = %d, want %d", got, test.wantMarked)
+			}
+
+			wantOuterOpen := strings.IndexByte(test.src, '`')
+			wantOuterClose := strings.LastIndexByte(test.src, '`')
+			if island.root.openOffset != wantOuterOpen {
+				t.Errorf("outer open offset = %d, want %d", island.root.openOffset, wantOuterOpen)
+			}
+			if island.root.closeStart != wantOuterClose || island.root.closeOffset != wantOuterClose {
+				t.Errorf("outer close = start %d offset %d, want %d", island.root.closeStart, island.root.closeOffset, wantOuterClose)
+			}
+			if test.wantSpanCount == 2 {
+				if len(island.root.children) != 1 {
+					t.Fatalf("outer child count = %d, want 1", len(island.root.children))
+				}
+				child := island.root.children[0]
+				innerOpenSpelling := strings.Index(test.src[wantOuterOpen+1:], "\\`") + wantOuterOpen + 1
+				innerCloseSpelling := strings.LastIndex(test.src[:wantOuterClose], "\\`")
+				if child.openOffset != innerOpenSpelling+1 {
+					t.Errorf("inner open offset = %d, want %d", child.openOffset, innerOpenSpelling+1)
+				}
+				if child.closeStart != innerCloseSpelling || child.closeOffset != innerCloseSpelling+1 {
+					t.Errorf("inner close = start %d offset %d, want start %d offset %d", child.closeStart, child.closeOffset, innerCloseSpelling, innerCloseSpelling+1)
+				}
+			}
+		})
+	}
+}
+
+func countLegacyBacktickSpans(span *legacyBacktickSpan) int {
+	if span == nil {
+		return 0
+	}
+	count := 1
+	for _, child := range span.children {
+		count += countLegacyBacktickSpans(child)
+	}
+	return count
+}
+
+func TestApplyLegacyBacktickPlaceholdersIsSameWidth(t *testing.T) {
+	const src = "print before `print one\n[[ $line == ((a|b)|c) ]]` after\nprint second\n"
+	original := []byte(src)
+	_, firstErr := parseTree(original, "backtick-placeholder.zsh")
+	var parseErr syntax.ParseError
+	if !errors.As(firstErr, &parseErr) || parseErr.Text != invalidAlternationOperator {
+		t.Fatalf("parseTree() error = %v, want %q", firstErr, invalidAlternationOperator)
+	}
+	batch, ok := nestedPatternBatch(original, int(parseErr.Pos.Offset()))
+	if !ok || len(batch.backtickIslands) != 1 {
+		t.Fatalf("nestedPatternBatch() islands = %+v, ok = %v, want one", batch.backtickIslands, ok)
+	}
+
+	masked := bytes.Clone(original)
+	for _, edit := range batch.edits {
+		masked[edit.offset] = edit.replacement
+	}
+	if err := applyLegacyBacktickPlaceholders(masked, original, batch.backtickIslands); err != nil {
+		t.Fatalf("applyLegacyBacktickPlaceholders() error: %v", err)
+	}
+	if len(masked) != len(original) {
+		t.Fatalf("masked length = %d, want %d", len(masked), len(original))
+	}
+	root := batch.backtickIslands[0].root
+	if !bytes.Equal(masked[:root.openOffset+1], original[:root.openOffset+1]) {
+		t.Errorf("bytes before island body changed: %q", masked[:root.openOffset+1])
+	}
+	if !bytes.Equal(masked[root.closeStart:], original[root.closeStart:]) {
+		t.Errorf("bytes after island body changed: %q", masked[root.closeStart:])
+	}
+	for offset, b := range original {
+		if b == '\n' && masked[offset] != '\n' {
+			t.Errorf("newline at byte %d changed to %q", offset, masked[offset])
+		}
+		if b == '`' && masked[offset] != '`' {
+			t.Errorf("backtick at byte %d changed to %q", offset, masked[offset])
+		}
+	}
+	body := masked[root.openOffset+1 : root.closeStart]
+	if !bytes.Contains(body, []byte(":")) {
+		t.Fatalf("placeholder body %q does not contain neutral ':'", body)
+	}
+	placeholderTree, err := parseTree(masked, "backtick-placeholder.zsh")
+	if err != nil {
+		t.Fatalf("parseTree(placeholder) error: %v", err)
+	}
+	if len(placeholderTree.Stmts) != 2 {
+		t.Errorf("placeholder statement count = %d, want 2", len(placeholderTree.Stmts))
+	}
+}
+
+func legacyBatchForTest(t *testing.T, src string) ([]byte, nestedPatternCompatibilityBatch) {
+	t.Helper()
+	original := []byte(src)
+	_, firstErr := parseTree(original, "legacy-island.zsh")
+	var parseErr syntax.ParseError
+	if !errors.As(firstErr, &parseErr) || parseErr.Text != invalidAlternationOperator {
+		t.Fatalf("parseTree() error = %v, want %q", firstErr, invalidAlternationOperator)
+	}
+	batch, ok := nestedPatternBatch(original, int(parseErr.Pos.Offset()))
+	if !ok {
+		t.Fatal("nestedPatternBatch() rejected affected legacy backticks")
+	}
+	if len(batch.backtickIslands) != 1 {
+		t.Fatalf("island count = %d, want 1", len(batch.backtickIslands))
+	}
+	return original, batch
+}
+
+func maskedPatternSource(t *testing.T, original []byte, edits []patternEdit) []byte {
+	t.Helper()
+	masked := bytes.Clone(original)
+	for _, edit := range edits {
+		if edit.offset < 0 || edit.offset >= len(masked) || masked[edit.offset] != edit.original {
+			t.Fatalf("pattern edit %+v does not match source", edit)
+		}
+		masked[edit.offset] = edit.replacement
+	}
+	return masked
+}
+
+func TestBuildLegacyBacktickIslandMapsNestedTerminators(t *testing.T) {
+	const src = "print `print \\`[[ $line == ((a|b)|c) ]]\\``\n"
+	original, batch := legacyBatchForTest(t, src)
+	masked := maskedPatternSource(t, original, batch.edits)
+	transformed, sourceMap, err := buildLegacyBacktickIsland(masked, original, batch.backtickIslands[0])
+	if err != nil {
+		t.Fatalf("buildLegacyBacktickIsland() error: %v", err)
+	}
+	if !bytes.Contains(transformed, []byte("\n\\`")) {
+		t.Errorf("transformed island %q lacks newline before complete nested close", transformed)
+	}
+	if got := bytes.Count(transformed, []byte("`")); got != 4 {
+		t.Errorf("transformed backtick count = %d, want 4", got)
+	}
+	if len(sourceMap.originalOffsetByBoundary) != len(transformed)+1 {
+		t.Fatalf("source-map boundary count = %d, want %d", len(sourceMap.originalOffsetByBoundary), len(transformed)+1)
+	}
+	root := batch.backtickIslands[0].root
+	delimiterOffsets := []int{
+		root.openOffset,
+		root.children[0].openOffset,
+		root.children[0].closeStart,
+		root.children[0].closeOffset,
+		root.closeOffset,
+	}
+	for _, originalOffset := range delimiterOffsets {
+		mapped := false
+		for transformedOffset := 0; transformedOffset < len(transformed); transformedOffset++ {
+			if sourceMap.originalOffsetByBoundary[transformedOffset] == originalOffset &&
+				sourceMap.originalOffsetByBoundary[transformedOffset+1] == originalOffset+1 &&
+				transformed[transformedOffset] == original[originalOffset] {
+				mapped = true
+				break
+			}
+		}
+		if !mapped {
+			t.Errorf("original delimiter byte %d was not mapped exactly", originalOffset)
+		}
+	}
+}
+
+func TestGraftLegacyBacktickIslandRestoresOriginalPositions(t *testing.T) {
+	const src = "print pre\nprint `[[ $line == ((a|b)|c) ]]` suffix\nprint post\n"
+	file, err := Parse(strings.NewReader(src), "legacy-graft.zsh")
+	if err != nil {
+		t.Fatalf("Parse() error: %v", err)
+	}
+	if got := len(file.AST().Stmts); got != 3 {
+		t.Fatalf("statement count = %d, want 3", got)
+	}
+
+	wantOpen := strings.IndexByte(src, '`')
+	wantClose := strings.LastIndexByte(src, '`')
+	var outer *syntax.CmdSubst
+	syntax.Walk(file.AST(), func(node syntax.Node) bool {
+		substitution, ok := node.(*syntax.CmdSubst)
+		if ok && substitution.Backquotes && int(substitution.Left.Offset()) == wantOpen {
+			outer = substitution
+		}
+		return true
+	})
+	if outer == nil {
+		t.Fatal("grafted outer legacy CmdSubst not found")
+	}
+	if got := int(outer.Right.Offset()); got != wantClose {
+		t.Errorf("outer close offset = %d, want %d", got, wantClose)
+	}
+	if outer.Left.Line() != 2 || outer.Left.Col() != 7 {
+		t.Errorf("outer open position = line %d column %d, want line 2 column 7", outer.Left.Line(), outer.Left.Col())
+	}
+	if outer.Right.Line() != 2 || outer.Right.Col() != 32 {
+		t.Errorf("outer close position = line %d column %d, want line 2 column 32", outer.Right.Line(), outer.Right.Col())
+	}
+
+	syntax.Walk(outer, func(node syntax.Node) bool {
+		lit, ok := node.(*syntax.Lit)
+		if !ok {
+			return true
+		}
+		start := int(lit.ValuePos.Offset())
+		end := int(lit.ValueEnd.Offset())
+		if start < 0 || end < start || end > len(src) {
+			t.Fatalf("literal span %d:%d is outside source", start, end)
+		}
+		if got := src[start:end]; got != lit.Value {
+			t.Errorf("literal at %d:%d = %q, want source slice %q", start, end, lit.Value, got)
+		}
+		return true
+	})
+
+	testClause, ok := outer.Stmts[0].Cmd.(*syntax.TestClause)
+	if !ok {
+		t.Fatalf("grafted command = %T, want *syntax.TestClause", outer.Stmts[0].Cmd)
+	}
+	if got := int(testClause.Pos().Offset()); got != 17 || testClause.Pos().Line() != 2 || testClause.Pos().Col() != 8 {
+		t.Errorf("test-clause position = offset %d line %d column %d, want 17/2/8", got, testClause.Pos().Line(), testClause.Pos().Col())
+	}
+	if got := int(file.AST().Stmts[2].Pos().Offset()); got != 50 || file.AST().Stmts[2].Pos().Line() != 3 || file.AST().Stmts[2].Pos().Col() != 1 {
+		t.Errorf("final statement position = offset %d line %d column %d, want 50/3/1", got, file.AST().Stmts[2].Pos().Line(), file.AST().Stmts[2].Pos().Col())
+	}
+}
+
+func TestLegacyBacktickIslandAddsNoSyntheticSemicolon(t *testing.T) {
+	tests := []string{
+		"print `[[ $line == ((a|b)|c) ]]`\n",
+		"print `print \\`[[ $inner == ((d|e)|f) ]]\\`; [[ $outer == ((a|b)|c) ]]`\n",
+	}
+	for _, src := range tests {
+		t.Run(src, func(t *testing.T) {
+			original, batch := legacyBatchForTest(t, src)
+			masked := maskedPatternSource(t, original, batch.edits)
+			transformed, sourceMap, err := buildLegacyBacktickIsland(masked, original, batch.backtickIslands[0])
+			if err != nil {
+				t.Fatalf("buildLegacyBacktickIsland() error: %v", err)
+			}
+			tree, err := parseTree(transformed, "synthetic-semicolon.zsh")
+			if err != nil {
+				t.Fatalf("parseTree(island) error: %v", err)
+			}
+			syntax.Walk(tree, func(node syntax.Node) bool {
+				stmt, ok := node.(*syntax.Stmt)
+				if !ok || !stmt.Semicolon.IsValid() {
+					return true
+				}
+				if _, synthetic := sourceMap.syntheticOffsets[int(stmt.Semicolon.Offset())]; synthetic {
+					t.Errorf("statement semicolon is valid at synthetic byte %d", stmt.Semicolon.Offset())
+				}
+				return true
+			})
+		})
+	}
+}
+
+func TestLegacyBacktickIslandPreservesDoubleQuotedParentSignature(t *testing.T) {
+	const affected = "print \"prefix `[[ $line == ((a|b)|c) ]]` suffix\"\n"
+	const control = "print \"prefix `[[ $line == foo ]]; :` suffix\"\n"
+
+	affectedFile, err := Parse(strings.NewReader(affected), "affected-quoted-parent.zsh")
+	if err != nil {
+		t.Fatalf("Parse(affected) error: %v", err)
+	}
+	controlTree, err := parseTree([]byte(control), "control-quoted-parent.zsh")
+	if err != nil {
+		t.Fatalf("parseTree(control) error: %v", err)
+	}
+
+	signature := func(t *testing.T, tree *syntax.File) ([]string, int) {
+		t.Helper()
+		var quoted *syntax.DblQuoted
+		syntax.Walk(tree, func(node syntax.Node) bool {
+			if quoted == nil {
+				quoted, _ = node.(*syntax.DblQuoted)
+			}
+			return true
+		})
+		if quoted == nil {
+			t.Fatal("double-quoted parent not found")
+		}
+		var literals []string
+		backquotes := 0
+		for _, part := range quoted.Parts {
+			switch part := part.(type) {
+			case *syntax.Lit:
+				literals = append(literals, part.Value)
+			case *syntax.CmdSubst:
+				if part.Backquotes {
+					backquotes++
+				}
+			}
+		}
+		return literals, backquotes
+	}
+
+	wantLiterals, wantBackquotes := signature(t, controlTree)
+	gotLiterals, gotBackquotes := signature(t, affectedFile.AST())
+	if strings.Join(gotLiterals, "|") != strings.Join(wantLiterals, "|") {
+		t.Errorf("double-quoted literal signature = %q, want %q", gotLiterals, wantLiterals)
+	}
+	if gotBackquotes != wantBackquotes || gotBackquotes != 1 {
+		t.Errorf("nested legacy CmdSubst count = %d, want control count %d and literal 1", gotBackquotes, wantBackquotes)
+	}
+}
+
+func TestLegacyBacktickIslandRejectsHiddenInvalidSyntax(t *testing.T) {
+	tests := []string{
+		"print `[[ $line == ((a|b)|c) ]]; then`\n",
+		"print `[[ $line == ((a|b)|c) ]]`\n&& print second\n",
+	}
+	for _, src := range tests {
+		t.Run(src, func(t *testing.T) {
+			if _, err := Parse(strings.NewReader(src), "hidden-invalid.zsh"); err == nil {
+				t.Fatal("Parse() unexpectedly accepted native-invalid source")
+			}
+		})
+	}
+}
+
+func TestLegacyBacktickIslandWorkIsLinearForSiblings(t *testing.T) {
+	measure := func(t *testing.T, siblingCount int) (work, fullFileParses, islandParses int) {
+		t.Helper()
+		src := []byte(strings.Repeat("print `[[ $line == ((a|b)|c) ]]`\n", siblingCount))
+		_, firstErr := parseTree(src, "legacy-siblings.zsh")
+		var parseErr syntax.ParseError
+		if !errors.As(firstErr, &parseErr) || parseErr.Text != invalidAlternationOperator {
+			t.Fatalf("parseTree() error = %v, want %q", firstErr, invalidAlternationOperator)
+		}
+		tree, err := parseNestedConditionalAlternationWithParser(
+			src,
+			"legacy-siblings.zsh",
+			firstErr,
+			func(candidate []byte, name string) (*syntax.File, error) {
+				if len(candidate) == len(src) {
+					fullFileParses++
+				} else {
+					islandParses++
+				}
+				return parseTree(candidate, name)
+			},
+			func() { work++ },
+		)
+		if err != nil {
+			t.Fatalf("parseNestedConditionalAlternationWithParser() error: %v", err)
+		}
+		if got := len(tree.Stmts); got != siblingCount {
+			t.Fatalf("statement count = %d, want %d", got, siblingCount)
+		}
+		if fullFileParses != 1 {
+			t.Errorf("full-file compatibility parse count = %d, want 1", fullFileParses)
+		}
+		if islandParses != siblingCount {
+			t.Errorf("island parse count = %d, want %d", islandParses, siblingCount)
+		}
+		return work, fullFileParses, islandParses
+	}
+
+	smallWork, _, _ := measure(t, 256)
+	largeWork, _, _ := measure(t, 512)
+	if smallWork == 0 || largeWork == 0 {
+		t.Fatalf("island work = %d/%d, want production observations", smallWork, largeWork)
+	}
+	const fixedAllowance = 128
+	if largeWork > 2*smallWork+fixedAllowance {
+		t.Errorf("doubling siblings changed island work from %d to %d, want at most %d", smallWork, largeWork, 2*smallWork+fixedAllowance)
+	}
+}
+
+func TestLegacyBacktickGraftTargetIndexIsLinearForSiblings(t *testing.T) {
+	measure := func(t *testing.T, siblingCount int) (inspections int) {
+		t.Helper()
+		src := []byte(strings.Repeat("print `[[ $line == ((a|b)|c) ]]`\n", siblingCount))
+		_, firstErr := parseTree(src, "legacy-target-index.zsh")
+		var parseErr syntax.ParseError
+		if !errors.As(firstErr, &parseErr) || parseErr.Text != invalidAlternationOperator {
+			t.Fatalf("parseTree() error = %v, want %q", firstErr, invalidAlternationOperator)
+		}
+		batch, ok := nestedPatternBatch(src, int(parseErr.Pos.Offset()))
+		if !ok || len(batch.backtickIslands) != siblingCount {
+			t.Fatalf("nestedPatternBatch() island count = %d, ok = %v, want %d", len(batch.backtickIslands), ok, siblingCount)
+		}
+		patternMasked := maskedPatternSource(t, src, batch.edits)
+		placeholder := bytes.Clone(patternMasked)
+		if err := applyLegacyBacktickPlaceholders(placeholder, src, batch.backtickIslands); err != nil {
+			t.Fatalf("applyLegacyBacktickPlaceholders() error: %v", err)
+		}
+		tree, err := parseTree(placeholder, "legacy-target-index.zsh")
+		if err != nil {
+			t.Fatalf("parseTree(placeholder) error: %v", err)
+		}
+		index := indexLegacyBacktickGraftTargets(tree, func() { inspections++ })
+		if len(index) != siblingCount {
+			t.Fatalf("target index size = %d, want %d", len(index), siblingCount)
+		}
+		for _, island := range batch.backtickIslands {
+			key := legacyBacktickTargetKey{
+				openOffset:  island.root.openOffset,
+				closeOffset: island.root.closeOffset,
+			}
+			if got := len(index[key]); got != 1 {
+				t.Errorf("target count for %+v = %d, want 1", key, got)
+			}
+		}
+		return inspections
+	}
+
+	smallInspections := measure(t, 256)
+	largeInspections := measure(t, 512)
+	if smallInspections == 0 || largeInspections == 0 {
+		t.Fatalf("target-index inspections = %d/%d, want production observations", smallInspections, largeInspections)
+	}
+	const fixedAllowance = 128
+	if largeInspections > 2*smallInspections+fixedAllowance {
+		t.Errorf(
+			"doubling siblings changed target-index inspections from %d to %d, want at most %d",
+			smallInspections,
+			largeInspections,
+			2*smallInspections+fixedAllowance,
+		)
+	}
+}
+
+func placeholderTreeForLegacyTest(
+	t *testing.T,
+	src string,
+) (*syntax.File, []byte, []byte, nestedPatternCompatibilityBatch) {
+	t.Helper()
+	original, batch := legacyBatchForTest(t, src)
+	patternMasked := maskedPatternSource(t, original, batch.edits)
+	placeholder := bytes.Clone(patternMasked)
+	if err := applyLegacyBacktickPlaceholders(placeholder, original, batch.backtickIslands); err != nil {
+		t.Fatalf("applyLegacyBacktickPlaceholders() error: %v", err)
+	}
+	tree, err := parseTree(placeholder, "legacy-integrity.zsh")
+	if err != nil {
+		t.Fatalf("parseTree(placeholder) error: %v", err)
+	}
+	return tree, patternMasked, original, batch
+}
+
+func TestLegacyBacktickIslandRejectsIntegrityFailures(t *testing.T) {
+	const src = "print `[[ $line == ((a|b)|c) ]]`\n"
+
+	t.Run("placeholder delimiter mismatch", func(t *testing.T) {
+		_, masked, original, batch := placeholderTreeForLegacyTest(t, src)
+		root := batch.backtickIslands[0].root
+		masked[root.openOffset] = 'x'
+		if err := applyLegacyBacktickPlaceholders(masked, original, batch.backtickIslands); err == nil {
+			t.Fatal("applyLegacyBacktickPlaceholders() accepted a delimiter mismatch")
+		}
+	})
+
+	t.Run("overlapping island", func(t *testing.T) {
+		tree, masked, original, batch := placeholderTreeForLegacyTest(t, src)
+		islands := []legacyBacktickIsland{batch.backtickIslands[0], batch.backtickIslands[0]}
+		if err := parseAndGraftLegacyBacktickIslands(tree, masked, original, "overlap.zsh", islands, parseTree); err == nil {
+			t.Fatal("parseAndGraftLegacyBacktickIslands() accepted overlapping islands")
+		}
+	})
+
+	t.Run("missing graft target", func(t *testing.T) {
+		_, masked, original, batch := placeholderTreeForLegacyTest(t, src)
+		if err := parseAndGraftLegacyBacktickIslands(&syntax.File{}, masked, original, "missing.zsh", batch.backtickIslands, parseTree); err == nil {
+			t.Fatal("parseAndGraftLegacyBacktickIslands() accepted a missing target")
+		}
+	})
+
+	t.Run("two graft targets", func(t *testing.T) {
+		tree, masked, original, batch := placeholderTreeForLegacyTest(t, src)
+		tree.Stmts = append(tree.Stmts, tree.Stmts[0])
+		if err := parseAndGraftLegacyBacktickIslands(tree, masked, original, "duplicate.zsh", batch.backtickIslands, parseTree); err == nil {
+			t.Fatal("parseAndGraftLegacyBacktickIslands() accepted two targets")
+		}
+	})
+
+	t.Run("non-monotonic source map", func(t *testing.T) {
+		_, _, _, batch := placeholderTreeForLegacyTest(t, src)
+		sourceMap := islandSourceMap{
+			originalOffsetByBoundary: []int{8, 7},
+			syntheticOffsets:         map[int]struct{}{},
+		}
+		if err := validateIslandSourceMap(sourceMap, 1, batch.backtickIslands[0].root); err == nil {
+			t.Fatal("validateIslandSourceMap() accepted a non-monotonic map")
+		}
+	})
+
+	t.Run("mapped offset outside original span", func(t *testing.T) {
+		_, _, _, batch := placeholderTreeForLegacyTest(t, src)
+		stmt := &syntax.Stmt{Position: syntax.NewPos(0, 1, 1)}
+		sourceMap := islandSourceMap{
+			originalOffsetByBoundary: []int{0},
+			syntheticOffsets:         map[int]struct{}{},
+		}
+		if err := rebaseLegacyBacktickPositions(
+			reflect.ValueOf(stmt),
+			sourceMap,
+			[]int{0},
+			batch.backtickIslands[0].root,
+		); err == nil {
+			t.Fatal("rebaseLegacyBacktickPositions() accepted an outside mapping")
+		}
+	})
+
+	t.Run("synthetic semicolon", func(t *testing.T) {
+		substitution := &syntax.CmdSubst{Stmts: []*syntax.Stmt{{
+			Semicolon: syntax.NewPos(1, 1, 2),
+		}}}
+		sourceMap := islandSourceMap{syntheticOffsets: map[int]struct{}{1: {}}}
+		if err := rejectSyntheticSemicolons(substitution, sourceMap); err == nil {
+			t.Fatal("rejectSyntheticSemicolons() accepted an injected synthetic semicolon")
+		}
+	})
+
+	t.Run("island parser error", func(t *testing.T) {
+		tree, masked, original, batch := placeholderTreeForLegacyTest(t, src)
+		wantErr := errors.New("injected island parse failure")
+		err := parseAndGraftLegacyBacktickIslands(
+			tree,
+			masked,
+			original,
+			"parse-error.zsh",
+			batch.backtickIslands,
+			func([]byte, string) (*syntax.File, error) { return nil, wantErr },
+		)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("parseAndGraftLegacyBacktickIslands() error = %v, want %v", err, wantErr)
+		}
+	})
+}

--- a/internal/parse/nested_conditional_pattern.go
+++ b/internal/parse/nested_conditional_pattern.go
@@ -1,0 +1,1438 @@
+package parse
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sort"
+	"unicode/utf8"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+const invalidAlternationOperator = "not a valid test operator: `|`"
+const nestedPatternMask byte = 'x'
+
+type patternEdit struct {
+	offset      int
+	original    byte
+	replacement byte
+}
+
+type indexedPatternEdit struct {
+	originalIndex int
+	edit          patternEdit
+}
+
+type patternRestoreProbe func()
+
+type patternBatchProbe func()
+
+type activeLegacyLookupProbe func()
+
+type activeSourceQuote uint8
+
+const (
+	activeSourceUnquoted activeSourceQuote = iota
+	activeSourceSingleQuoted
+	activeSourceANSICQuoted
+	activeSourceDoubleQuoted
+)
+
+type activeSourceFrameKind uint8
+
+const (
+	activeSourceRootFrame activeSourceFrameKind = iota
+	activeSourceCommandSubstitutionFrame
+	activeSourceProcessSubstitutionFrame
+	activeSourceBacktickSubstitutionFrame
+)
+
+type activeCasePhase uint8
+
+const (
+	activeCaseSubject activeCasePhase = iota
+	activeCaseAwaitingIn
+	activeCasePattern
+	activeCaseBody
+)
+
+type activeCaseContext struct {
+	phase             activeCasePhase
+	patternParenDepth int
+	inBracketPattern  bool
+}
+
+type pendingHeredoc struct {
+	delimiter string
+	stripTabs bool
+}
+
+type activeSourceFrame struct {
+	kind            activeSourceFrameKind
+	quote           activeSourceQuote
+	escaped         bool
+	groupDepth      int
+	arithmeticDepth int
+	conditional     *activeConditionalContext
+	inComment       bool
+	atWordStart     bool
+	atCommandStart  bool
+	heredocs        []pendingHeredoc
+	caseContexts    []activeCaseContext
+	adaptedPattern  bool
+	// legacyBacktick and legacyBacktickDepth describe the nearest active
+	// legacy substitution at this frame. Command and process children inherit
+	// them; quote and arithmetic states remain on their owning frame.
+	legacyBacktick      *legacyBacktickSpan
+	legacyBacktickDepth int
+}
+
+type patternPair struct {
+	open  int
+	close int
+	depth int
+}
+
+type patternCandidate struct {
+	conditionalStart int
+	rhsStart         int
+	rhsEnd           int
+	edits            []patternEdit
+	seed             bool
+}
+
+type activeConditionalContext struct {
+	start   int
+	pattern *activePatternState
+}
+
+type activePatternState struct {
+	rhsStart            int
+	openings            []int
+	pairs               []patternPair
+	inBracketExpression bool
+	numericRangeEnd     int
+	nestedAlternation   bool
+	seed                bool
+	invalid             bool
+}
+
+type legacyBacktickSpan struct {
+	openStart          int
+	openOffset         int
+	closeStart         int
+	closeOffset        int
+	doubleQuotedParent bool
+	affected           bool
+	children           []*legacyBacktickSpan
+}
+
+type legacyBacktickIsland struct {
+	root           *legacyBacktickSpan
+	markedClosures []*legacyBacktickSpan
+}
+
+type nestedPatternCompatibilityBatch struct {
+	edits           []patternEdit
+	backtickIslands []legacyBacktickIsland
+}
+
+func parseNestedConditionalAlternation(src []byte, name string, firstErr error) (*syntax.File, error) {
+	return parseNestedConditionalAlternationWithParser(src, name, firstErr, parseTree)
+}
+
+func parseNestedConditionalAlternationWithParser(
+	src []byte,
+	name string,
+	firstErr error,
+	parse func([]byte, string) (*syntax.File, error),
+	probes ...legacyBacktickWorkProbe,
+) (*syntax.File, error) {
+	var parseErr syntax.ParseError
+	if !errors.As(firstErr, &parseErr) || parseErr.Text != invalidAlternationOperator {
+		return nil, firstErr
+	}
+	batch, ok := nestedPatternBatch(src, int(parseErr.Pos.Offset()))
+	if !ok {
+		return nil, firstErr
+	}
+	masked := bytes.Clone(src)
+	for _, edit := range batch.edits {
+		if edit.offset < 0 || edit.offset >= len(masked) || masked[edit.offset] != edit.original {
+			return nil, fmt.Errorf("%s: nested-pattern edit no longer matches source at byte %d", name, edit.offset)
+		}
+		masked[edit.offset] = edit.replacement
+	}
+	patternMasked := bytes.Clone(masked)
+	if err := applyLegacyBacktickPlaceholders(masked, src, batch.backtickIslands); err != nil {
+		return nil, fmt.Errorf("%s: applying legacy backtick placeholders: %w", name, err)
+	}
+
+	tree, err := parse(masked, name)
+	if err != nil {
+		return nil, err
+	}
+	if err := parseAndGraftLegacyBacktickIslands(
+		tree,
+		patternMasked,
+		src,
+		name,
+		batch.backtickIslands,
+		parse,
+		probes...,
+	); err != nil {
+		return nil, fmt.Errorf("%s: parsing legacy backtick islands: %w", name, err)
+	}
+	if err := restorePatternEdits(tree, src, batch.edits); err != nil {
+		return nil, fmt.Errorf("%s: restoring nested conditional pattern: %w", name, err)
+	}
+	return tree, nil
+}
+
+func nestedPatternBatchEdits(
+	src []byte,
+	seedOffset int,
+	probes ...patternBatchProbe,
+) ([]patternEdit, bool) {
+	batch, ok := nestedPatternBatch(src, seedOffset, probes...)
+	if !ok {
+		return nil, false
+	}
+	return batch.edits, true
+}
+
+func nestedPatternBatch(
+	src []byte,
+	seedOffset int,
+	probes ...patternBatchProbe,
+) (nestedPatternCompatibilityBatch, bool) {
+	var inspect patternBatchProbe
+	if len(probes) > 0 {
+		inspect = probes[0]
+	}
+	candidates, backtickIslands, ok := collectNestedPatternCandidates(src, seedOffset, inspect)
+	if !ok {
+		return nestedPatternCompatibilityBatch{}, false
+	}
+	seedRecognized := false
+	editCount := 0
+	for _, candidate := range candidates {
+		if inspect != nil {
+			inspect()
+		}
+		if candidate.seed {
+			seedRecognized = true
+		}
+		editCount += len(candidate.edits)
+	}
+	if !seedRecognized {
+		return nestedPatternCompatibilityBatch{}, false
+	}
+
+	edits := make([]patternEdit, 0, editCount)
+	seenOffsets := make(map[int]bool, editCount)
+	for _, candidate := range candidates {
+		for _, edit := range candidate.edits {
+			if seenOffsets[edit.offset] {
+				return nestedPatternCompatibilityBatch{}, false
+			}
+			seenOffsets[edit.offset] = true
+			edits = append(edits, edit)
+		}
+	}
+	return nestedPatternCompatibilityBatch{
+		edits:           edits,
+		backtickIslands: backtickIslands,
+	}, true
+}
+
+func collectNestedPatternCandidates(
+	src []byte,
+	seedOffset int,
+	inspect patternBatchProbe,
+	legacyLookupProbes ...activeLegacyLookupProbe,
+) ([]patternCandidate, []legacyBacktickIsland, bool) {
+	var candidates []patternCandidate
+	var backtickRoots []*legacyBacktickSpan
+	var inspectLegacyLookup activeLegacyLookupProbe
+	if len(legacyLookupProbes) > 0 {
+		inspectLegacyLookup = legacyLookupProbes[0]
+	}
+	frames := []activeSourceFrame{newActiveSourceFrame(activeSourceRootFrame, nil)}
+
+	for i := 0; i < len(src); i++ {
+		if inspect != nil {
+			inspect()
+		}
+		b := src[i]
+		frame := &frames[len(frames)-1]
+		if frame.escaped {
+			frame.escaped = false
+			if frame.kind != activeSourceBacktickSubstitutionFrame ||
+				frame.quote != activeSourceUnquoted || b != '`' {
+				continue
+			}
+		}
+
+		switch frame.quote {
+		case activeSourceSingleQuoted:
+			if b == '\'' {
+				frame.quote = activeSourceUnquoted
+			}
+			continue
+		case activeSourceANSICQuoted:
+			if b == '\\' {
+				frame.escaped = true
+				continue
+			}
+			if b == '\'' {
+				frame.quote = activeSourceUnquoted
+			}
+			continue
+		case activeSourceDoubleQuoted:
+			if b == '$' && i+1 < len(src) && src[i+1] == '(' &&
+				(i+2 >= len(src) || src[i+2] != '(') {
+				invalidateActivePattern(frame, i)
+				frames = append(frames, newActiveSourceFrame(activeSourceCommandSubstitutionFrame, frame))
+				i++
+				continue
+			}
+			if b == '`' {
+				invalidateActivePattern(frame, i)
+				pushLegacyBacktickFrame(&frames, &backtickRoots, src, i, true, inspectLegacyLookup)
+				continue
+			}
+			if b == '\\' {
+				frame.escaped = activeSourceDoubleQuoteEscapes(src, i)
+				continue
+			}
+			if b == '"' {
+				frame.quote = activeSourceUnquoted
+			}
+			continue
+		}
+
+		if b == '\n' && frame.arithmeticDepth == 0 && len(frame.heredocs) > 0 {
+			next, ok := consumeHeredocBodies(src, i+1, frame.heredocs)
+			if !ok {
+				return nil, nil, false
+			}
+			frame.heredocs = nil
+			frame.inComment = false
+			frame.atWordStart = true
+			frame.atCommandStart = true
+			i = next - 1
+			continue
+		}
+		if frame.inComment {
+			if b == '\n' {
+				frame.inComment = false
+				frame.atWordStart = true
+				frame.atCommandStart = true
+			}
+			continue
+		}
+
+		if frame.arithmeticDepth > 0 {
+			if b == '$' && i+1 < len(src) && src[i+1] == '(' &&
+				(i+2 >= len(src) || src[i+2] != '(') {
+				invalidateActivePattern(frame, i)
+				frames = append(frames, newActiveSourceFrame(activeSourceCommandSubstitutionFrame, frame))
+				i++
+				continue
+			}
+			if b == '`' {
+				invalidateActivePattern(frame, i)
+				pushLegacyBacktickFrame(&frames, &backtickRoots, src, i, false, inspectLegacyLookup)
+				continue
+			}
+			if b == '\\' {
+				frame.escaped = activeSourceBackslashEscapes(frame, src, i)
+				continue
+			}
+			if b == '$' && i+1 < len(src) && src[i+1] == '\'' {
+				frame.quote = activeSourceANSICQuoted
+				i++
+				continue
+			}
+			switch b {
+			case '\'':
+				frame.quote = activeSourceSingleQuoted
+			case '"':
+				frame.quote = activeSourceDoubleQuoted
+			case '(':
+				frame.arithmeticDepth++
+			case ')':
+				frame.arithmeticDepth--
+				continue
+			}
+			continue
+		}
+
+		if frame.kind == activeSourceBacktickSubstitutionFrame && b == '`' {
+			depth := activeLegacyBacktickDepth(frame, inspectLegacyLookup)
+			escapeDepth, delimiterEscapes := legacyBacktickEscapeStateBefore(src, i)
+			if escapeDepth == depth {
+				invalidateActivePattern(frame, i)
+				pushLegacyBacktickFrame(&frames, &backtickRoots, src, i, false, inspectLegacyLookup)
+				continue
+			}
+			if escapeDepth != depth-1 {
+				return nil, nil, false
+			}
+			if !activeSourceFrameCanClose(frame) {
+				return nil, nil, false
+			}
+			frame.legacyBacktick.closeStart = i - delimiterEscapes
+			frame.legacyBacktick.closeOffset = i
+			frame.legacyBacktick.affected = frame.adaptedPattern
+			adaptedPattern := frame.adaptedPattern
+			frames = frames[:len(frames)-1]
+			if adaptedPattern {
+				frames[len(frames)-1].adaptedPattern = true
+			}
+			continue
+		}
+
+		var currentCase *activeCaseContext
+		if len(frame.caseContexts) > 0 {
+			currentCase = &frame.caseContexts[len(frame.caseContexts)-1]
+		}
+		if frame.conditional == nil && frame.atWordStart && frame.atCommandStart &&
+			(currentCase == nil || currentCase.phase == activeCaseBody) &&
+			activeSourceWordAt(src, i, "case") {
+			frame.caseContexts = append(frame.caseContexts, activeCaseContext{phase: activeCaseSubject})
+			i += len("case") - 1
+			frame.atWordStart = false
+			frame.atCommandStart = false
+			continue
+		}
+		if currentCase != nil {
+			switch currentCase.phase {
+			case activeCaseSubject:
+				if !shellSpace(b) {
+					currentCase.phase = activeCaseAwaitingIn
+				}
+			case activeCaseAwaitingIn:
+				if frame.atWordStart && activeSourceWordAt(src, i, "in") {
+					currentCase.phase = activeCasePattern
+					i += len("in") - 1
+					frame.atWordStart = false
+					frame.atCommandStart = false
+					continue
+				}
+			case activeCasePattern:
+				wordEnd := i + len("esac")
+				if frame.atWordStart && activeSourceWordAt(src, i, "esac") &&
+					(wordEnd >= len(src) || src[wordEnd] != ')') {
+					frame.caseContexts = frame.caseContexts[:len(frame.caseContexts)-1]
+					i += len("esac") - 1
+					frame.atWordStart = false
+					frame.atCommandStart = false
+					continue
+				}
+			case activeCaseBody:
+				if frame.atWordStart && frame.atCommandStart && activeSourceWordAt(src, i, "esac") {
+					frame.caseContexts = frame.caseContexts[:len(frame.caseContexts)-1]
+					i += len("esac") - 1
+					frame.atWordStart = false
+					frame.atCommandStart = false
+					continue
+				}
+				if b == ';' && i+1 < len(src) &&
+					(src[i+1] == ';' || src[i+1] == '&' || src[i+1] == '|') {
+					currentCase.phase = activeCasePattern
+					currentCase.patternParenDepth = 0
+					currentCase.inBracketPattern = false
+					i++
+					frame.atWordStart = true
+					frame.atCommandStart = true
+					continue
+				}
+			}
+		}
+
+		if frame.conditional != nil && frame.conditional.pattern == nil {
+			if operatorEnd, ok := activePatternOperatorEnd(src, i); ok {
+				frame.conditional.pattern = &activePatternState{rhsStart: -1}
+				i = operatorEnd - 1
+				frame.atWordStart = false
+				frame.atCommandStart = false
+				continue
+			}
+		}
+		if frame.conditional != nil && frame.conditional.pattern != nil {
+			if activePatternByteConsumed(frame, src, i, seedOffset, &candidates) {
+				frame.atWordStart = false
+				frame.atCommandStart = false
+				continue
+			}
+		}
+
+		if b == '\\' {
+			frame.escaped = activeSourceBackslashEscapes(frame, src, i)
+			frame.atWordStart = false
+			frame.atCommandStart = false
+			continue
+		}
+		if b == '$' && i+1 < len(src) && src[i+1] == '\'' {
+			frame.quote = activeSourceANSICQuoted
+			i++
+			frame.atWordStart = false
+			frame.atCommandStart = false
+			continue
+		}
+		if b == '\'' {
+			frame.quote = activeSourceSingleQuoted
+			frame.atWordStart = false
+			frame.atCommandStart = false
+			continue
+		}
+		if b == '"' {
+			frame.quote = activeSourceDoubleQuoted
+			frame.atWordStart = false
+			frame.atCommandStart = false
+			continue
+		}
+		if b == '`' {
+			invalidateActivePattern(frame, i)
+			frame.atWordStart = false
+			frame.atCommandStart = false
+			pushLegacyBacktickFrame(&frames, &backtickRoots, src, i, false, inspectLegacyLookup)
+			continue
+		}
+		if b == '$' && i+2 < len(src) && src[i+1] == '(' && src[i+2] == '(' {
+			invalidateActivePattern(frame, i)
+			frame.arithmeticDepth = 2
+			i += 2
+			frame.atWordStart = false
+			frame.atCommandStart = false
+			continue
+		}
+		if frame.conditional == nil && b == '(' && i+1 < len(src) && src[i+1] == '(' {
+			frame.arithmeticDepth = 2
+			i++
+			frame.atWordStart = false
+			frame.atCommandStart = false
+			continue
+		}
+		if b == '$' && i+1 < len(src) && src[i+1] == '(' {
+			invalidateActivePattern(frame, i)
+			frame.atWordStart = false
+			frame.atCommandStart = false
+			frames = append(frames, newActiveSourceFrame(activeSourceCommandSubstitutionFrame, frame))
+			i++
+			continue
+		}
+		if (b == '<' || b == '>' || b == '=') && i+1 < len(src) && src[i+1] == '(' {
+			invalidateActivePattern(frame, i)
+			frame.atWordStart = false
+			frame.atCommandStart = false
+			frames = append(frames, newActiveSourceFrame(activeSourceProcessSubstitutionFrame, frame))
+			i++
+			continue
+		}
+		if currentCase != nil && currentCase.phase == activeCasePattern {
+			if currentCase.inBracketPattern {
+				if b == ']' {
+					currentCase.inBracketPattern = false
+				}
+				frame.atWordStart = false
+				frame.atCommandStart = false
+				continue
+			}
+			switch b {
+			case '[':
+				currentCase.inBracketPattern = true
+				frame.atWordStart = false
+				frame.atCommandStart = false
+				continue
+			case '(':
+				currentCase.patternParenDepth++
+				frame.atWordStart = false
+				frame.atCommandStart = false
+				continue
+			case ')':
+				if currentCase.patternParenDepth > 0 {
+					currentCase.patternParenDepth--
+					frame.atWordStart = false
+					frame.atCommandStart = false
+				} else {
+					currentCase.phase = activeCaseBody
+					frame.atWordStart = true
+					frame.atCommandStart = true
+				}
+				continue
+			}
+			if shellSpace(b) {
+				frame.atWordStart = true
+				if b == '\n' {
+					frame.atCommandStart = true
+				}
+			} else {
+				frame.atWordStart = false
+				frame.atCommandStart = false
+			}
+			continue
+		}
+		if b == '(' {
+			frame.groupDepth++
+			if frame.conditional != nil {
+				frame.atWordStart = false
+				frame.atCommandStart = false
+			} else {
+				frame.atWordStart = true
+				frame.atCommandStart = true
+			}
+			continue
+		}
+		if b == ')' {
+			if frame.groupDepth > 0 {
+				frame.groupDepth--
+				frame.atWordStart = false
+				frame.atCommandStart = false
+				continue
+			}
+			if frame.kind == activeSourceRootFrame {
+				frame.atWordStart = false
+				frame.atCommandStart = false
+				continue
+			}
+			if !activeSourceFrameCanClose(frame) {
+				return nil, nil, false
+			}
+			adaptedPattern := frame.adaptedPattern
+			frames = frames[:len(frames)-1]
+			if adaptedPattern {
+				frames[len(frames)-1].adaptedPattern = true
+			}
+			continue
+		}
+		if b == '#' && frame.atWordStart && frame.conditional == nil {
+			frame.inComment = true
+			continue
+		}
+		if frame.conditional == nil && b == '<' && i+1 < len(src) && src[i+1] == '<' {
+			if i+2 < len(src) && src[i+2] == '<' {
+				i += 2
+				frame.atWordStart = true
+				continue
+			}
+			stripTabs := i+2 < len(src) && src[i+2] == '-'
+			delimiterStart := i + 2
+			if stripTabs {
+				delimiterStart++
+			}
+			delimiter, end, ok := parseHeredocDelimiter(src, delimiterStart)
+			if !ok {
+				return nil, nil, false
+			}
+			frame.heredocs = append(frame.heredocs, pendingHeredoc{
+				delimiter: delimiter,
+				stripTabs: stripTabs,
+			})
+			i = end - 1
+			frame.atWordStart = false
+			continue
+		}
+		if frame.conditional == nil && b == '[' && i+1 < len(src) && src[i+1] == '[' {
+			frame.conditional = &activeConditionalContext{start: i}
+			i++
+			frame.atWordStart = false
+			frame.atCommandStart = false
+			continue
+		}
+		if frame.conditional != nil && b == ']' && i+1 < len(src) && src[i+1] == ']' {
+			finalizeActivePattern(frame, i, &candidates)
+			frame.conditional = nil
+			i++
+			frame.atWordStart = false
+			frame.atCommandStart = false
+			continue
+		}
+		if shellSpace(b) {
+			frame.atWordStart = true
+			if b == '\n' {
+				frame.atCommandStart = true
+			}
+			continue
+		}
+		switch b {
+		case ';', '&', '|':
+			frame.atWordStart = true
+			frame.atCommandStart = true
+		default:
+			frame.atWordStart = false
+			frame.atCommandStart = false
+		}
+	}
+
+	if len(frames) == 1 && frames[0].conditional != nil {
+		finalizeActivePattern(&frames[0], len(src), &candidates)
+	}
+	if len(frames) != 1 || !activeSourceRootFrameComplete(&frames[0]) {
+		return nil, nil, false
+	}
+	islands, ok := affectedLegacyBacktickIslands(backtickRoots)
+	if !ok {
+		return nil, nil, false
+	}
+	return candidates, islands, true
+}
+
+func activePatternOperatorEnd(src []byte, start int) (int, bool) {
+	if start < 0 || start >= len(src) {
+		return 0, false
+	}
+	if start+2 <= len(src) {
+		operator := string(src[start : start+2])
+		if (operator == "==" || operator == "!=") && separated(src, start, start+2) {
+			return start + 2, true
+		}
+	}
+	if src[start] == '=' && (start+1 >= len(src) || src[start+1] != '~') &&
+		separated(src, start, start+1) {
+		return start + 1, true
+	}
+	return 0, false
+}
+
+func activePatternByteConsumed(
+	frame *activeSourceFrame,
+	src []byte,
+	offset int,
+	seedOffset int,
+	candidates *[]patternCandidate,
+) bool {
+	pattern := frame.conditional.pattern
+	b := src[offset]
+	if offset < pattern.numericRangeEnd {
+		return true
+	}
+	if pattern.inBracketExpression {
+		if b == ']' {
+			pattern.inBracketExpression = false
+		}
+		return true
+	}
+	if pattern.rhsStart < 0 && shellSpace(b) {
+		return false
+	}
+	if len(pattern.openings) == 0 {
+		if shellSpace(b) ||
+			(offset+1 < len(src) &&
+				(string(src[offset:offset+2]) == "&&" ||
+					string(src[offset:offset+2]) == "||" ||
+					string(src[offset:offset+2]) == "]]")) {
+			finalizeActivePattern(frame, offset, candidates)
+			return false
+		}
+	}
+	if pattern.rhsStart < 0 {
+		pattern.rhsStart = offset
+	}
+	if b == '[' {
+		pattern.inBracketExpression = true
+		return true
+	}
+	if b == '<' {
+		if end, ok := activeNumericRangeEnd(src, offset); ok {
+			pattern.numericRangeEnd = end
+			return true
+		}
+	}
+	switch b {
+	case '&', ';', '<', '>':
+		pattern.invalid = true
+	case '(':
+		pattern.openings = append(pattern.openings, offset)
+	case ')':
+		if len(pattern.openings) == 0 {
+			pattern.invalid = true
+			break
+		}
+		depth := len(pattern.openings)
+		open := pattern.openings[depth-1]
+		pattern.openings = pattern.openings[:depth-1]
+		if depth >= 2 {
+			pattern.pairs = append(pattern.pairs, patternPair{
+				open:  open,
+				close: offset,
+				depth: depth,
+			})
+		}
+	case '|':
+		if len(pattern.openings) > 0 {
+			pattern.nestedAlternation = true
+			if offset == seedOffset {
+				pattern.seed = true
+			}
+		}
+	}
+	return false
+}
+
+func activeNumericRangeEnd(src []byte, start int) (int, bool) {
+	if start < 0 || start >= len(src) || src[start] != '<' {
+		return 0, false
+	}
+	end := start + 1
+	for end < len(src) && src[end] >= '0' && src[end] <= '9' {
+		end++
+	}
+	if end >= len(src) || src[end] != '-' {
+		return 0, false
+	}
+	end++
+	for end < len(src) && src[end] >= '0' && src[end] <= '9' {
+		end++
+	}
+	if end >= len(src) || src[end] != '>' {
+		return 0, false
+	}
+	return end + 1, true
+}
+
+func finalizeActivePattern(
+	frame *activeSourceFrame,
+	rhsEnd int,
+	candidates *[]patternCandidate,
+) {
+	if frame.conditional == nil || frame.conditional.pattern == nil {
+		return
+	}
+	pattern := frame.conditional.pattern
+	frame.conditional.pattern = nil
+	if pattern.invalid || pattern.rhsStart < 0 || pattern.inBracketExpression ||
+		len(pattern.openings) != 0 || !pattern.nestedAlternation || len(pattern.pairs) == 0 {
+		return
+	}
+	edits := make([]patternEdit, 0, len(pattern.pairs)*2)
+	for _, pair := range pattern.pairs {
+		edits = append(edits,
+			patternEdit{offset: pair.open, original: '(', replacement: nestedPatternMask},
+			patternEdit{offset: pair.close, original: ')', replacement: nestedPatternMask},
+		)
+	}
+	*candidates = append(*candidates, patternCandidate{
+		conditionalStart: frame.conditional.start,
+		rhsStart:         pattern.rhsStart,
+		rhsEnd:           rhsEnd,
+		edits:            edits,
+		seed:             pattern.seed,
+	})
+	frame.adaptedPattern = true
+}
+
+func invalidateActivePattern(frame *activeSourceFrame, offset int) {
+	if frame.conditional == nil || frame.conditional.pattern == nil {
+		return
+	}
+	pattern := frame.conditional.pattern
+	if pattern.rhsStart < 0 {
+		pattern.rhsStart = offset
+	}
+	pattern.invalid = true
+}
+
+func activeSourceBackslashEscapes(frame *activeSourceFrame, src []byte, offset int) bool {
+	if offset+1 >= len(src) {
+		return false
+	}
+	if frame.kind != activeSourceBacktickSubstitutionFrame {
+		return true
+	}
+	switch src[offset+1] {
+	case '$', '`', '\\', '\n':
+		return true
+	default:
+		return false
+	}
+}
+
+func activeSourceDoubleQuoteEscapes(src []byte, offset int) bool {
+	if offset+1 >= len(src) {
+		return false
+	}
+	switch src[offset+1] {
+	case '$', '`', '"', '\\', '\n':
+		return true
+	default:
+		return false
+	}
+}
+
+func pushLegacyBacktickFrame(
+	frames *[]activeSourceFrame,
+	roots *[]*legacyBacktickSpan,
+	src []byte,
+	openOffset int,
+	doubleQuotedParent bool,
+	inspect activeLegacyLookupProbe,
+) {
+	_, delimiterEscapes := legacyBacktickEscapeStateBefore(src, openOffset)
+	parentFrame := &(*frames)[len(*frames)-1]
+	if inspect != nil {
+		inspect()
+	}
+	parentSpan := parentFrame.legacyBacktick
+	parentDepth := parentFrame.legacyBacktickDepth
+	span := &legacyBacktickSpan{
+		openStart:          openOffset - delimiterEscapes,
+		openOffset:         openOffset,
+		closeStart:         -1,
+		closeOffset:        -1,
+		doubleQuotedParent: doubleQuotedParent,
+	}
+	if parentSpan != nil {
+		parentSpan.children = append(parentSpan.children, span)
+	} else {
+		*roots = append(*roots, span)
+	}
+	frame := newActiveSourceFrame(activeSourceBacktickSubstitutionFrame, parentFrame)
+	frame.legacyBacktick = span
+	frame.legacyBacktickDepth = parentDepth + 1
+	*frames = append(*frames, frame)
+}
+
+func activeLegacyBacktickDepth(frame *activeSourceFrame, inspect activeLegacyLookupProbe) int {
+	if inspect != nil {
+		inspect()
+	}
+	return frame.legacyBacktickDepth
+}
+
+func legacyBacktickEscapeStateBefore(src []byte, offset int) (depth, delimiterEscapes int) {
+	rawBackslashes := 0
+	for index := offset - 1; index >= 0 && src[index] == '\\'; index-- {
+		rawBackslashes++
+	}
+	// Each legacy-backtick nesting layer consumes one quoting backslash after
+	// escaped-backslash pairs have collapsed. The selected parser records that
+	// surviving layer count in lastBquoteEsc and compares it with openBquotes.
+	// In the raw run this is the number of trailing one bits: even runs leave an
+	// unescaped delimiter, while 1, 3, and 7 backslashes encode depths 1, 2, and 3.
+	for remaining := rawBackslashes; remaining&1 == 1; remaining >>= 1 {
+		depth++
+		delimiterEscapes = delimiterEscapes*2 + 1
+	}
+	return depth, delimiterEscapes
+}
+
+func affectedLegacyBacktickIslands(roots []*legacyBacktickSpan) ([]legacyBacktickIsland, bool) {
+	islands := make([]legacyBacktickIsland, 0, len(roots))
+	previousClose := -1
+	for _, root := range roots {
+		if root == nil || root.openOffset < 0 || root.closeStart <= root.openOffset ||
+			root.closeOffset < root.closeStart || root.openStart < 0 ||
+			root.openStart <= previousClose {
+			return nil, false
+		}
+		previousClose = root.closeOffset
+		if !root.affected {
+			continue
+		}
+		island := legacyBacktickIsland{root: root}
+		if !appendAffectedLegacyClosures(root, &island.markedClosures) {
+			return nil, false
+		}
+		islands = append(islands, island)
+	}
+	return islands, true
+}
+
+func appendAffectedLegacyClosures(span *legacyBacktickSpan, marked *[]*legacyBacktickSpan) bool {
+	if span == nil || span.openOffset < 0 || span.closeStart <= span.openOffset ||
+		span.closeOffset < span.closeStart {
+		return false
+	}
+	previousClose := span.openOffset
+	for _, child := range span.children {
+		if child == nil || child.openStart <= previousClose || child.closeOffset >= span.closeStart ||
+			!appendAffectedLegacyClosures(child, marked) {
+			return false
+		}
+		previousClose = child.closeOffset
+	}
+	if span.affected {
+		*marked = append(*marked, span)
+	}
+	return true
+}
+
+func applyLegacyBacktickPlaceholders(
+	masked []byte,
+	original []byte,
+	islands []legacyBacktickIsland,
+) error {
+	if len(masked) != len(original) {
+		return fmt.Errorf("placeholder source length %d does not match original length %d", len(masked), len(original))
+	}
+	previousClose := -1
+	for _, island := range islands {
+		root := island.root
+		if root == nil || root.openStart <= previousClose || root.openOffset < root.openStart ||
+			root.closeStart <= root.openOffset || root.closeOffset < root.closeStart ||
+			root.closeOffset >= len(original) {
+			return fmt.Errorf("invalid or overlapping legacy backtick island")
+		}
+		previousClose = root.closeOffset
+		preserved := make(map[int]struct{})
+		if !markLegacyBacktickDelimiters(root, masked, original, preserved) {
+			return fmt.Errorf("legacy backtick delimiter mismatch at byte %d", root.openOffset)
+		}
+		colonOffset := -1
+		for offset := root.openOffset + 1; offset < root.closeStart; offset++ {
+			if original[offset] == '\n' {
+				masked[offset] = '\n'
+				continue
+			}
+			if _, ok := preserved[offset]; ok {
+				masked[offset] = original[offset]
+				continue
+			}
+			masked[offset] = ' '
+			if colonOffset < 0 {
+				colonOffset = offset
+			}
+		}
+		if colonOffset < 0 {
+			return fmt.Errorf("legacy backtick island at byte %d has no usable body byte", root.openOffset)
+		}
+		masked[colonOffset] = ':'
+	}
+	return nil
+}
+
+func markLegacyBacktickDelimiters(
+	span *legacyBacktickSpan,
+	masked []byte,
+	original []byte,
+	preserved map[int]struct{},
+) bool {
+	if span == nil || span.openStart < 0 || span.openOffset < span.openStart ||
+		span.closeStart <= span.openOffset || span.closeOffset < span.closeStart ||
+		span.closeOffset >= len(original) || original[span.openOffset] != '`' ||
+		original[span.closeOffset] != '`' {
+		return false
+	}
+	for offset := span.openStart; offset <= span.openOffset; offset++ {
+		if masked[offset] != original[offset] {
+			return false
+		}
+		preserved[offset] = struct{}{}
+	}
+	for offset := span.closeStart; offset <= span.closeOffset; offset++ {
+		if masked[offset] != original[offset] {
+			return false
+		}
+		preserved[offset] = struct{}{}
+	}
+	for _, child := range span.children {
+		if !markLegacyBacktickDelimiters(child, masked, original, preserved) {
+			return false
+		}
+	}
+	return true
+}
+
+func newActiveSourceFrame(kind activeSourceFrameKind, parent *activeSourceFrame) activeSourceFrame {
+	frame := activeSourceFrame{
+		kind:           kind,
+		atWordStart:    true,
+		atCommandStart: true,
+	}
+	if parent != nil {
+		frame.legacyBacktick = parent.legacyBacktick
+		frame.legacyBacktickDepth = parent.legacyBacktickDepth
+	}
+	return frame
+}
+
+func activeSourceFrameCanClose(frame *activeSourceFrame) bool {
+	return frame.kind != activeSourceRootFrame &&
+		frame.quote == activeSourceUnquoted && !frame.escaped &&
+		frame.groupDepth == 0 && frame.arithmeticDepth == 0 &&
+		frame.conditional == nil && !frame.inComment &&
+		len(frame.heredocs) == 0 && len(frame.caseContexts) == 0
+}
+
+func activeSourceRootFrameComplete(frame *activeSourceFrame) bool {
+	// Root conditional and grouping balance remains parser-owned so the single
+	// compatibility retry can surface a later syntax error. Lexical states that
+	// can hide candidate positions still fail closed here.
+	return frame.kind == activeSourceRootFrame &&
+		frame.quote == activeSourceUnquoted && !frame.escaped &&
+		frame.arithmeticDepth == 0 &&
+		len(frame.heredocs) == 0 && len(frame.caseContexts) == 0
+}
+
+func activeSourceWordAt(src []byte, start int, word string) bool {
+	end := start + len(word)
+	if start < 0 || end > len(src) || string(src[start:end]) != word {
+		return false
+	}
+	return end == len(src) || activeSourceWordBoundary(src[end])
+}
+
+func activeSourceWordBoundary(b byte) bool {
+	if shellSpace(b) {
+		return true
+	}
+	switch b {
+	case ';', '&', '|', '(', ')', '<', '>':
+		return true
+	default:
+		return false
+	}
+}
+
+func parseHeredocDelimiter(src []byte, start int) (string, int, bool) {
+	for start < len(src) && (src[start] == ' ' || src[start] == '\t') {
+		start++
+	}
+	var delimiter []byte
+	consumed := false
+	for i := start; i < len(src); {
+		b := src[i]
+		if heredocWordTerminator(b) {
+			if !consumed {
+				return "", 0, false
+			}
+			return string(delimiter), i, true
+		}
+		if b == '$' && i+1 < len(src) && src[i+1] == '\'' {
+			decoded, end, ok := parseANSICQuotedHeredocSegment(src, i)
+			if !ok {
+				return "", 0, false
+			}
+			delimiter = append(delimiter, decoded...)
+			i = end
+			consumed = true
+			continue
+		}
+		switch b {
+		case '\\':
+			if i+1 >= len(src) || src[i+1] == '\n' {
+				return "", 0, false
+			}
+			delimiter = append(delimiter, src[i+1])
+			i += 2
+			consumed = true
+		case '\'':
+			consumed = true
+			i++
+			for {
+				if i >= len(src) || src[i] == '\n' {
+					return "", 0, false
+				}
+				if src[i] == '\'' {
+					i++
+					break
+				}
+				delimiter = append(delimiter, src[i])
+				i++
+			}
+		case '"':
+			consumed = true
+			i++
+			for {
+				if i >= len(src) || src[i] == '\n' {
+					return "", 0, false
+				}
+				if src[i] == '"' {
+					i++
+					break
+				}
+				if src[i] == '\\' && i+1 < len(src) {
+					next := src[i+1]
+					switch next {
+					case '$', '`', '"', '\\':
+						delimiter = append(delimiter, next)
+						i += 2
+						continue
+					}
+				}
+				delimiter = append(delimiter, src[i])
+				i++
+			}
+		default:
+			delimiter = append(delimiter, b)
+			i++
+			consumed = true
+		}
+	}
+	if !consumed {
+		return "", 0, false
+	}
+	return string(delimiter), len(src), true
+}
+
+func parseANSICQuotedHeredocSegment(src []byte, start int) ([]byte, int, bool) {
+	if start+1 >= len(src) || src[start] != '$' || src[start+1] != '\'' {
+		return nil, 0, false
+	}
+	decoded := make([]byte, 0, 8)
+	for i := start + 2; i < len(src); {
+		b := src[i]
+		if b == '\n' {
+			return nil, 0, false
+		}
+		if b == '\'' {
+			return decoded, i + 1, true
+		}
+		if b != '\\' {
+			decoded = append(decoded, b)
+			i++
+			continue
+		}
+		if i+1 >= len(src) || src[i+1] == '\n' {
+			return nil, 0, false
+		}
+		escaped := src[i+1]
+		if escaped >= '0' && escaped <= '7' {
+			value, end, ok := parseANSICDigits(src, i+1, 3, 8)
+			if !ok || value == 0 || value > 0xff {
+				return nil, 0, false
+			}
+			decoded = append(decoded, byte(value))
+			i = end
+			continue
+		}
+		switch escaped {
+		case 'a':
+			decoded = append(decoded, '\a')
+			i += 2
+		case 'b':
+			decoded = append(decoded, '\b')
+			i += 2
+		case 'e', 'E':
+			decoded = append(decoded, 0x1b)
+			i += 2
+		case 'f':
+			decoded = append(decoded, '\f')
+			i += 2
+		case 'n':
+			return nil, 0, false
+		case 'r':
+			decoded = append(decoded, '\r')
+			i += 2
+		case 't':
+			decoded = append(decoded, '\t')
+			i += 2
+		case 'v':
+			decoded = append(decoded, '\v')
+			i += 2
+		case 'x':
+			value, end, ok := parseANSICDigits(src, i+2, 2, 16)
+			if !ok || value == 0 {
+				return nil, 0, false
+			}
+			decoded = append(decoded, byte(value))
+			i = end
+		case 'u', 'U':
+			maxDigits := 4
+			if escaped == 'U' {
+				maxDigits = 8
+			}
+			value, end, ok := parseANSICDigits(src, i+2, maxDigits, 16)
+			r := rune(value)
+			if !ok || value == 0 || r == '\n' || !utf8.ValidRune(r) {
+				return nil, 0, false
+			}
+			decoded = utf8.AppendRune(decoded, r)
+			i = end
+		case 'c', 'C', 'M':
+			return nil, 0, false
+		default:
+			decoded = append(decoded, escaped)
+			i += 2
+		}
+	}
+	return nil, 0, false
+}
+
+func parseANSICDigits(src []byte, start, maxDigits, base int) (int, int, bool) {
+	value := 0
+	end := start
+	for end < len(src) && end-start < maxDigits {
+		digit, ok := ansiCDigitValue(src[end])
+		if !ok || digit >= base {
+			break
+		}
+		value = value*base + digit
+		end++
+	}
+	return value, end, end > start
+}
+
+func ansiCDigitValue(b byte) (int, bool) {
+	switch {
+	case b >= '0' && b <= '9':
+		return int(b - '0'), true
+	case b >= 'a' && b <= 'f':
+		return int(b-'a') + 10, true
+	case b >= 'A' && b <= 'F':
+		return int(b-'A') + 10, true
+	default:
+		return 0, false
+	}
+}
+
+func heredocWordTerminator(b byte) bool {
+	if shellSpace(b) {
+		return true
+	}
+	switch b {
+	case ';', '&', '|', '<', '>', '(', ')':
+		return true
+	default:
+		return false
+	}
+}
+
+func consumeHeredocBodies(src []byte, start int, heredocs []pendingHeredoc) (int, bool) {
+	offset := start
+	for _, heredoc := range heredocs {
+		for {
+			if offset > len(src) {
+				return 0, false
+			}
+			newline := bytes.IndexByte(src[offset:], '\n')
+			lineEnd := len(src)
+			if newline >= 0 {
+				lineEnd = offset + newline
+			}
+			contentStart := offset
+			if heredoc.stripTabs {
+				for contentStart < lineEnd && src[contentStart] == '\t' {
+					contentStart++
+				}
+			}
+			if string(src[contentStart:lineEnd]) == heredoc.delimiter {
+				if newline >= 0 {
+					offset = lineEnd + 1
+				} else {
+					offset = lineEnd
+				}
+				break
+			}
+			if newline < 0 {
+				return 0, false
+			}
+			offset = lineEnd + 1
+		}
+	}
+	return offset, true
+}
+
+func shellSpace(b byte) bool {
+	switch b {
+	case ' ', '\t', '\r', '\n':
+		return true
+	default:
+		return false
+	}
+}
+
+func separated(src []byte, start, end int) bool {
+	return start > 0 && end < len(src) && shellSpace(src[start-1]) && shellSpace(src[end])
+}
+
+func lowerBoundPatternEdit(edits []indexedPatternEdit, offset int) (index int, probes int) {
+	low, high := 0, len(edits)
+	for low < high {
+		probes++
+		middle := low + (high-low)/2
+		if edits[middle].edit.offset < offset {
+			low = middle + 1
+		} else {
+			high = middle
+		}
+	}
+	return low, probes
+}
+
+func restorePatternEdits(
+	tree *syntax.File,
+	original []byte,
+	edits []patternEdit,
+	probes ...patternRestoreProbe,
+) error {
+	var inspectCandidate patternRestoreProbe
+	if len(probes) > 0 {
+		inspectCandidate = probes[0]
+	}
+	indexed := make([]indexedPatternEdit, len(edits))
+	for i, edit := range edits {
+		indexed[i] = indexedPatternEdit{originalIndex: i, edit: edit}
+	}
+	sort.Slice(indexed, func(i, j int) bool {
+		return indexed[i].edit.offset < indexed[j].edit.offset
+	})
+	for i := 1; i < len(indexed); i++ {
+		if indexed[i-1].edit.offset == indexed[i].edit.offset {
+			return fmt.Errorf("duplicate edit offset at byte %d", indexed[i].edit.offset)
+		}
+	}
+
+	restored := make([]int, len(edits))
+	var restoreErr error
+
+	syntax.Walk(tree, func(node syntax.Node) bool {
+		if restoreErr != nil {
+			return false
+		}
+		lit, ok := node.(*syntax.Lit)
+		if !ok {
+			return true
+		}
+		start := int(lit.ValuePos.Offset())
+		end := int(lit.ValueEnd.Offset())
+		index, searchProbes := lowerBoundPatternEdit(indexed, start)
+		if inspectCandidate != nil {
+			for range searchProbes {
+				inspectCandidate()
+			}
+		}
+		if index >= len(indexed) || indexed[index].edit.offset >= end {
+			return true
+		}
+		if end-start != len(lit.Value) {
+			restoreErr = fmt.Errorf("literal span %d:%d does not map byte-for-byte to its value", start, end)
+			return false
+		}
+		value := []byte(lit.Value)
+		for index < len(indexed) && indexed[index].edit.offset < end {
+			if inspectCandidate != nil {
+				inspectCandidate()
+			}
+			indexedEdit := indexed[index]
+			edit := indexedEdit.edit
+			if edit.offset >= len(original) || original[edit.offset] != edit.original {
+				restoreErr = fmt.Errorf("original source mismatch at byte %d", edit.offset)
+				return false
+			}
+			relative := edit.offset - start
+			if value[relative] != edit.replacement {
+				restoreErr = fmt.Errorf("mask mismatch at byte %d", edit.offset)
+				return false
+			}
+			value[relative] = edit.original
+			restored[indexedEdit.originalIndex]++
+			index++
+		}
+		lit.Value = string(value)
+		return true
+	})
+	if restoreErr != nil {
+		return restoreErr
+	}
+	for i, count := range restored {
+		if count != 1 {
+			return fmt.Errorf("edit at byte %d restored %d times", edits[i].offset, count)
+		}
+	}
+	return nil
+}

--- a/internal/parse/nested_conditional_pattern_test.go
+++ b/internal/parse/nested_conditional_pattern_test.go
@@ -1,0 +1,1124 @@
+package parse
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+func parsedPatternWords(t *testing.T, src string) []string {
+	t.Helper()
+	f, err := Parse(strings.NewReader(src), "nested-pattern.zsh")
+	if err != nil {
+		t.Fatalf("Parse() error: %v", err)
+	}
+	return patternWords(t, f.AST())
+}
+
+func patternWords(t *testing.T, tree *syntax.File) []string {
+	t.Helper()
+	var patterns []string
+	syntax.Walk(tree, func(node syntax.Node) bool {
+		binary, ok := node.(*syntax.BinaryTest)
+		if !ok {
+			return true
+		}
+		switch binary.Op {
+		case syntax.TsMatchShort, syntax.TsMatch, syntax.TsNoMatch:
+		default:
+			return true
+		}
+		word, ok := binary.Y.(*syntax.Word)
+		if !ok {
+			t.Fatalf("pattern operand type = %T, want *syntax.Word", binary.Y)
+		}
+		patterns = append(patterns, word.Lit())
+		return true
+	})
+	return patterns
+}
+
+func renderedPatternWords(t *testing.T, tree *syntax.File) []string {
+	t.Helper()
+	var patterns []string
+	syntax.Walk(tree, func(node syntax.Node) bool {
+		binary, ok := node.(*syntax.BinaryTest)
+		if !ok {
+			return true
+		}
+		switch binary.Op {
+		case syntax.TsMatchShort, syntax.TsMatch, syntax.TsNoMatch:
+		default:
+			return true
+		}
+		word, ok := binary.Y.(*syntax.Word)
+		if !ok {
+			t.Fatalf("pattern operand type = %T, want *syntax.Word", binary.Y)
+		}
+		var rendered strings.Builder
+		if err := syntax.NewPrinter().Print(&rendered, word); err != nil {
+			t.Fatalf("print pattern operand: %v", err)
+		}
+		patterns = append(patterns, rendered.String())
+		return true
+	})
+	return patterns
+}
+
+func TestParseNestedConditionalAlternationBatchesCompatibilityParse(t *testing.T) {
+	const comparisonCount = 32
+	const pattern = "((a|b)|c)"
+	src := []byte(strings.Repeat(
+		"print -r -- unrelated\n[[ $line == "+pattern+" ]]\n",
+		comparisonCount,
+	))
+
+	_, firstErr := parseTree(src, "many-nested-patterns.zsh")
+	if firstErr == nil {
+		t.Fatal("parseTree() unexpectedly accepted the original source")
+	}
+
+	fullFileParses := 0
+	islandParses := 0
+	tree, err := parseNestedConditionalAlternationWithParser(
+		src,
+		"many-nested-patterns.zsh",
+		firstErr,
+		func(masked []byte, name string) (*syntax.File, error) {
+			if len(masked) == len(src) {
+				fullFileParses++
+			} else {
+				islandParses++
+			}
+			return parseTree(masked, name)
+		},
+	)
+	if err != nil {
+		t.Fatalf("parseNestedConditionalAlternationWithParser() error: %v", err)
+	}
+	if fullFileParses != 1 {
+		t.Errorf("full-file compatibility parse count = %d, want 1", fullFileParses)
+	}
+	if islandParses != 0 {
+		t.Errorf("ordinary non-backtick island parse count = %d, want 0", islandParses)
+	}
+
+	patterns := patternWords(t, tree)
+	if len(patterns) != comparisonCount {
+		t.Fatalf("pattern count = %d, want %d", len(patterns), comparisonCount)
+	}
+	for i, got := range patterns {
+		if got != pattern {
+			t.Errorf("pattern[%d] = %q, want %q", i, got, pattern)
+		}
+	}
+}
+
+func TestNestedPatternBatchEditsUsesLinearCandidateInspections(t *testing.T) {
+	collect := func(t *testing.T, pipelineCount int) (sourceBytes, inspections int) {
+		t.Helper()
+		src := []byte(
+			"[[ $line == ((a|b)|c) ]]\n" +
+				strings.Repeat("print left | print right\n", pipelineCount),
+		)
+		_, firstErr := parseTree(src, "batch-work-bound.zsh")
+		var parseErr syntax.ParseError
+		if !errors.As(firstErr, &parseErr) || parseErr.Text != invalidAlternationOperator {
+			t.Fatalf("parseTree() error = %v, want %q", firstErr, invalidAlternationOperator)
+		}
+		edits, ok := nestedPatternBatchEdits(src, int(parseErr.Pos.Offset()), func() {
+			inspections++
+		})
+		if !ok {
+			t.Fatal("nestedPatternBatchEdits() rejected the recognized seed")
+		}
+		if len(edits) != 2 {
+			t.Fatalf("edit count = %d, want 2: %+v", len(edits), edits)
+		}
+		return len(src), inspections
+	}
+
+	smallBytes, smallInspections := collect(t, 256)
+	largeBytes, largeInspections := collect(t, 512)
+	for _, result := range []struct {
+		name        string
+		sourceBytes int
+		inspections int
+	}{
+		{name: "small", sourceBytes: smallBytes, inspections: smallInspections},
+		{name: "large", sourceBytes: largeBytes, inspections: largeInspections},
+	} {
+		t.Run(result.name, func(t *testing.T) {
+			// The production collector charges one observation per forward-scan
+			// iteration and one per emitted candidate. Skipped token bytes only
+			// reduce this upper bound.
+			maxInspections := result.sourceBytes + 1
+			if result.inspections == 0 {
+				t.Fatal("candidate inspections = 0, want production observations")
+			}
+			if result.inspections > maxInspections {
+				t.Errorf(
+					"candidate inspections = %d, want at most %d for %d source bytes",
+					result.inspections,
+					maxInspections,
+					result.sourceBytes,
+				)
+			}
+		})
+	}
+	if largeInspections > 2*smallInspections {
+		t.Errorf(
+			"doubling pipeline input changed inspections from %d to %d, want at most %d",
+			smallInspections,
+			largeInspections,
+			2*smallInspections,
+		)
+	}
+}
+
+func TestNestedPatternBatchUsesConstantLegacyDelimiterLookups(t *testing.T) {
+	collect := func(t *testing.T, scale int) int {
+		t.Helper()
+		var src strings.Builder
+		for range scale {
+			src.WriteString("print $(")
+		}
+		for range scale {
+			src.WriteString(" `[[ x == ((a|b)|c) ]]`")
+		}
+		for range scale {
+			src.WriteByte(')')
+		}
+		src.WriteByte('\n')
+
+		original := []byte(src.String())
+		_, firstErr := parseTree(original, "legacy-delimiter-work.zsh")
+		var parseErr syntax.ParseError
+		if !errors.As(firstErr, &parseErr) || parseErr.Text != invalidAlternationOperator {
+			t.Fatalf("parseTree() error = %v, want %q", firstErr, invalidAlternationOperator)
+		}
+		lookups := 0
+		candidates, islands, ok := collectNestedPatternCandidates(
+			original,
+			int(parseErr.Pos.Offset()),
+			nil,
+			func() { lookups++ },
+		)
+		if !ok {
+			t.Fatal("collectNestedPatternCandidates() rejected native-valid legacy substitutions")
+		}
+		if len(candidates) != scale {
+			t.Fatalf("candidate count = %d, want %d", len(candidates), scale)
+		}
+		if len(islands) != scale {
+			t.Fatalf("legacy island count = %d, want %d", len(islands), scale)
+		}
+		if lookups == 0 {
+			t.Fatal("legacy delimiter lookups = 0, want production observations")
+		}
+		maxLookups := 2 * scale
+		if lookups > maxLookups {
+			t.Errorf(
+				"legacy delimiter lookups = %d, want at most %d for depth and sibling count %d",
+				lookups,
+				maxLookups,
+				scale,
+			)
+		}
+		return lookups
+	}
+
+	smallLookups := collect(t, 256)
+	largeLookups := collect(t, 512)
+	t.Logf("legacy delimiter lookups at scale 256/512: %d/%d", smallLookups, largeLookups)
+	if largeLookups > 2*smallLookups {
+		t.Errorf(
+			"doubling depth and sibling count changed legacy delimiter lookups from %d to %d, want at most %d",
+			smallLookups,
+			largeLookups,
+			2*smallLookups,
+		)
+	}
+}
+
+func TestParseNestedConditionalAlternationRejectsActivePatternOperators(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{name: "ampersand", src: "[[ $line == ((a&b)|c) ]]\n"},
+		{name: "double ampersand", src: "[[ $line == ((a&&b)|c) ]]\n"},
+		{name: "semicolon", src: "[[ $line == ((a;b)|c) ]]\n"},
+		{name: "less than", src: "[[ $line == ((a<b)|c) ]]\n"},
+		{name: "greater than", src: "[[ $line == ((a>b)|c) ]]\n"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, firstErr := parseTree([]byte(test.src), "active-pattern-operator.zsh")
+			var parseErr syntax.ParseError
+			if !errors.As(firstErr, &parseErr) || parseErr.Text != invalidAlternationOperator {
+				t.Fatalf("parseTree() error = %v, want %q", firstErr, invalidAlternationOperator)
+			}
+			if _, err := Parse(strings.NewReader(test.src), "active-pattern-operator.zsh"); err == nil {
+				t.Fatal("Parse() unexpectedly accepted native-invalid active pattern operator")
+			}
+		})
+	}
+}
+
+func TestParseNestedConditionalAlternationAllowsNumericRangeAtoms(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "bounded range",
+			src:  "[[ x == ((a|<1-3>)|b) ]]\n",
+			want: "((a|<1-3>)|b)",
+		},
+		{
+			name: "omitted lower bound",
+			src:  "[[ x == ((a|<-3>)|b) ]]\n",
+			want: "((a|<-3>)|b)",
+		},
+		{
+			name: "omitted upper bound",
+			src:  "[[ x == ((a|<1->)|b) ]]\n",
+			want: "((a|<1->)|b)",
+		},
+		{
+			name: "both bounds omitted",
+			src:  "[[ x == ((a|<->)|b) ]]\n",
+			want: "((a|<->)|b)",
+		},
+		{
+			name: "leading zero bounds",
+			src:  "[[ x == ((a|<0001-0003>)|b) ]]\n",
+			want: "((a|<0001-0003>)|b)",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, firstErr := parseTree([]byte(test.src), "numeric-range-pattern.zsh")
+			var parseErr syntax.ParseError
+			if !errors.As(firstErr, &parseErr) || parseErr.Text != invalidAlternationOperator {
+				t.Fatalf("parseTree() error = %v, want %q", firstErr, invalidAlternationOperator)
+			}
+			file, err := Parse(strings.NewReader(test.src), "numeric-range-pattern.zsh")
+			if err != nil {
+				t.Fatalf("Parse() error: %v", err)
+			}
+			patterns := patternWords(t, file.AST())
+			if len(patterns) != 1 {
+				t.Fatalf("pattern count = %d, want 1: %q", len(patterns), patterns)
+			}
+			if patterns[0] != test.want {
+				t.Errorf("pattern = %q, want %q", patterns[0], test.want)
+			}
+		})
+	}
+}
+
+func TestParseNestedConditionalAlternationRejectsMalformedNumericRangeAtoms(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{name: "missing closing angle", src: "[[ x == ((a|<1-3)|b) ]]\n"},
+		{name: "missing opening angle", src: "[[ x == ((a|1-3>)|b) ]]\n"},
+		{name: "missing separator", src: "[[ x == ((a|<1>)|b) ]]\n"},
+		{name: "non-decimal lower bound", src: "[[ x == ((a|<a-3>)|b) ]]\n"},
+		{name: "non-decimal upper bound", src: "[[ x == ((a|<1-b>)|b) ]]\n"},
+		{name: "doubled separator", src: "[[ x == ((a|<1--3>)|b) ]]\n"},
+		{name: "empty angle pair", src: "[[ x == ((a|<>)|b) ]]\n"},
+		{name: "signed lower bound", src: "[[ x == ((a|<+1-3>)|b) ]]\n"},
+		{name: "signed upper bound", src: "[[ x == ((a|<1-+3>)|b) ]]\n"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, firstErr := parseTree([]byte(test.src), "malformed-numeric-range-pattern.zsh")
+			var parseErr syntax.ParseError
+			if !errors.As(firstErr, &parseErr) || parseErr.Text != invalidAlternationOperator {
+				t.Fatalf("parseTree() error = %v, want %q", firstErr, invalidAlternationOperator)
+			}
+			if _, err := Parse(strings.NewReader(test.src), "malformed-numeric-range-pattern.zsh"); err == nil {
+				t.Fatal("Parse() unexpectedly accepted a native-invalid numeric range")
+			}
+		})
+	}
+}
+
+func TestParseNestedConditionalAlternationAllowsQuotedOrEscapedOperatorBytes(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{name: "escaped ampersand", src: "[[ $line == ((a\\&b)|c) ]]\n"},
+		{name: "escaped less than", src: "[[ $line == ((a\\<b)|c) ]]\n"},
+		{name: "quoted ampersand", src: "[[ $line == (('a&b'|d)|c) ]]\n"},
+		{name: "quoted semicolon", src: "[[ $line == (('a;b'|d)|c) ]]\n"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, firstErr := parseTree([]byte(test.src), "quoted-pattern-operator.zsh")
+			var parseErr syntax.ParseError
+			if !errors.As(firstErr, &parseErr) || parseErr.Text != invalidAlternationOperator {
+				t.Fatalf("parseTree() error = %v, want %q", firstErr, invalidAlternationOperator)
+			}
+			if _, err := Parse(strings.NewReader(test.src), "quoted-pattern-operator.zsh"); err != nil {
+				t.Fatalf("Parse() error: %v", err)
+			}
+		})
+	}
+}
+
+func TestParseNestedConditionalAlternationUsesLexicalBoundaries(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "quoted conditional start lookalike",
+			src:  "[[ \"[[ = fake\" == ((a|b)|c) ]]\n",
+			want: "((a|b)|c)",
+		},
+		{
+			name: "raw operator lookalike inside group",
+			src:  "[[ $line == ((a = b)|c) ]]\n",
+			want: "((a = b)|c)",
+		},
+		{
+			name: "quoted operator lookalike inside pattern",
+			src:  "[[ $line == (' = '((a|b)|c)) ]]\n",
+			want: "(' = '((a|b)|c))",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, firstErr := parseTree([]byte(test.src), "lexical-boundary.zsh")
+			var parseErr syntax.ParseError
+			if !errors.As(firstErr, &parseErr) || parseErr.Text != invalidAlternationOperator {
+				t.Fatalf("parseTree() error = %v, want %q", firstErr, invalidAlternationOperator)
+			}
+			file, err := Parse(strings.NewReader(test.src), "lexical-boundary.zsh")
+			if err != nil {
+				t.Fatalf("Parse() error: %v", err)
+			}
+			patterns := renderedPatternWords(t, file.AST())
+			if len(patterns) != 1 {
+				t.Fatalf("pattern count = %d, want 1: %q", len(patterns), patterns)
+			}
+			if patterns[0] != test.want {
+				t.Errorf("pattern = %q, want %q", patterns[0], test.want)
+			}
+		})
+	}
+}
+
+func TestParseNestedConditionalAlternationInsideBacktickFrame(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "unquoted parent",
+			src:  "print `[[ $line == ((a|b)|c) ]]`\n",
+		},
+		{
+			name: "double quoted parent resumes",
+			src:  "print \"`[[ $line == ((a|b)|c) ]]`\"\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, firstErr := parseTree([]byte(test.src), "backtick-frame.zsh")
+			var parseErr syntax.ParseError
+			if !errors.As(firstErr, &parseErr) || parseErr.Text != invalidAlternationOperator {
+				t.Fatalf("parseTree() error = %v, want %q", firstErr, invalidAlternationOperator)
+			}
+			file, err := Parse(strings.NewReader(test.src), "backtick-frame.zsh")
+			if err != nil {
+				t.Fatalf("Parse() error: %v", err)
+			}
+			patterns := patternWords(t, file.AST())
+			if len(patterns) != 1 {
+				t.Fatalf("pattern count = %d, want 1: %q", len(patterns), patterns)
+			}
+			if patterns[0] != "((a|b)|c)" {
+				t.Errorf("pattern = %q, want %q", patterns[0], "((a|b)|c)")
+			}
+			wantBacktick := strings.LastIndexByte(test.src, '`')
+			wantOpeningBacktick := strings.IndexByte(test.src, '`')
+			backtickSubstitutions := 0
+			syntax.Walk(file.AST(), func(node syntax.Node) bool {
+				substitution, ok := node.(*syntax.CmdSubst)
+				if !ok || !substitution.Backquotes {
+					return true
+				}
+				backtickSubstitutions++
+				if got := int(substitution.Left.Offset()); got != wantOpeningBacktick {
+					t.Errorf("backtick open offset = %d, want %d", got, wantOpeningBacktick)
+				}
+				if got := int(substitution.Right.Offset()); got != wantBacktick {
+					t.Errorf("backtick close offset = %d, want %d", got, wantBacktick)
+				}
+				return true
+			})
+			if backtickSubstitutions != 1 {
+				t.Errorf("backtick substitution count = %d, want 1", backtickSubstitutions)
+			}
+			if test.name == "double quoted parent resumes" {
+				wantOpeningQuote := strings.IndexByte(test.src, '"')
+				wantQuote := strings.LastIndexByte(test.src, '"')
+				doubleQuotes := 0
+				syntax.Walk(file.AST(), func(node syntax.Node) bool {
+					quoted, ok := node.(*syntax.DblQuoted)
+					if !ok {
+						return true
+					}
+					doubleQuotes++
+					if got := int(quoted.Left.Offset()); got != wantOpeningQuote {
+						t.Errorf("double-quote open offset = %d, want %d", got, wantOpeningQuote)
+					}
+					if got := int(quoted.Right.Offset()); got != wantQuote {
+						t.Errorf("double-quote close offset = %d, want %d", got, wantQuote)
+					}
+					return true
+				})
+				if doubleQuotes != 1 {
+					t.Errorf("double-quoted node count = %d, want 1", doubleQuotes)
+				}
+			}
+		})
+	}
+}
+
+func TestLowerBoundPatternEdit(t *testing.T) {
+	const editCount = 65_536
+	const maxProbes = 17
+	edits := make([]indexedPatternEdit, editCount)
+	for i := range edits {
+		edits[i] = indexedPatternEdit{
+			originalIndex: i,
+			edit:          patternEdit{offset: i * 2},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		offset    int
+		wantIndex int
+	}{
+		{name: "beginning", offset: 0, wantIndex: 0},
+		{name: "middle", offset: editCount, wantIndex: editCount / 2},
+		{name: "end", offset: (editCount - 1) * 2, wantIndex: editCount - 1},
+		{name: "beyond final", offset: editCount * 2, wantIndex: editCount},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			index, probes := lowerBoundPatternEdit(edits, test.offset)
+			if index != test.wantIndex {
+				t.Errorf("index = %d, want %d", index, test.wantIndex)
+			}
+			if probes > maxProbes {
+				t.Errorf("probes = %d, want at most %d", probes, maxProbes)
+			}
+		})
+	}
+}
+
+func TestRestorePatternEditsUsesBoundedCandidateInspections(t *testing.T) {
+	const comparisonCount = 32
+	const pattern = "((a|b)|c)"
+	original := []byte(strings.Repeat(
+		"print -r -- unrelated\n[[ $line == "+pattern+" ]]\n",
+		comparisonCount,
+	))
+	_, firstErr := parseTree(original, "restore-probe.zsh")
+	var parseErr syntax.ParseError
+	if !errors.As(firstErr, &parseErr) || parseErr.Text != invalidAlternationOperator {
+		t.Fatalf("parseTree() error = %v, want %q", firstErr, invalidAlternationOperator)
+	}
+	edits, ok := nestedPatternBatchEdits(original, int(parseErr.Pos.Offset()))
+	if !ok {
+		t.Fatal("nestedPatternBatchEdits() rejected the restoration probe source")
+	}
+
+	masked := append([]byte(nil), original...)
+	for _, edit := range edits {
+		masked[edit.offset] = edit.replacement
+	}
+	tree, err := parseTree(masked, "restore-probe.zsh")
+	if err != nil {
+		t.Fatalf("parseTree(masked) error: %v", err)
+	}
+
+	literalCount := 0
+	syntax.Walk(tree, func(node syntax.Node) bool {
+		if _, ok := node.(*syntax.Lit); ok {
+			literalCount++
+		}
+		return true
+	})
+	candidateInspections := 0
+	err = restorePatternEdits(tree, original, edits, func() {
+		candidateInspections++
+	})
+	if err != nil {
+		t.Fatalf("restorePatternEdits() error: %v", err)
+	}
+
+	maxSearchProbes := 0
+	for width := len(edits); width > 0; width /= 2 {
+		maxSearchProbes++
+	}
+	maxInspections := literalCount*maxSearchProbes + len(edits)
+	if candidateInspections == 0 {
+		t.Fatal("candidate inspections = 0, want production restoration observations")
+	}
+	if candidateInspections > maxInspections {
+		t.Errorf(
+			"candidate inspections = %d, want at most %d for %d literals and %d edits",
+			candidateInspections,
+			maxInspections,
+			literalCount,
+			len(edits),
+		)
+	}
+
+	patterns := patternWords(t, tree)
+	if len(patterns) != comparisonCount {
+		t.Fatalf("pattern count = %d, want %d", len(patterns), comparisonCount)
+	}
+	for i, got := range patterns {
+		if got != pattern {
+			t.Errorf("pattern[%d] = %q, want %q", i, got, pattern)
+		}
+	}
+}
+
+func TestParseNestedConditionalAlternationWithShellDelimiters(t *testing.T) {
+	const pattern = "((a|b)|c)"
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "here string before affected comparison",
+			src:  "cat <<< \"$line\"\n[[ $line == ((a|b)|c) ]]\n",
+		},
+		{
+			name: "arithmetic shift before affected comparison",
+			src:  "(( shifted = 8 << 1 ))\n[[ $line == ((a|b)|c) ]]\n",
+		},
+		{
+			name: "ANSI-C escaped apostrophe before affected comparison",
+			src:  "print -r -- $'can\\'t'\n[[ $line == ((a|b)|c) ]]\n",
+		},
+		{
+			name: "quoted heredoc body lookalike before affected comparison",
+			src:  "cat <<'DATA'\n[[ body == ((x|y)|z) ]]\nDATA\n[[ $line == ((a|b)|c) ]]\n",
+		},
+		{
+			name: "tab stripping heredoc body lookalike before affected comparison",
+			src:  "cat <<-DATA\n\t[[ body == ((x|y)|z) ]]\n\tDATA\n[[ $line == ((a|b)|c) ]]\n",
+		},
+		{
+			name: "queued heredoc bodies before affected comparison",
+			src:  "cat <<ONE <<'TWO'\n[[ first == ((x|y)|z) ]]\nONE\n[[ second == ((q|r)|s) ]]\nTWO\n[[ $line == ((a|b)|c) ]]\n",
+		},
+		{
+			name: "arithmetic expansion shift before affected comparison",
+			src:  "print -r -- $(( 8 << 1 ))\n[[ $line == ((a|b)|c) ]]\n",
+		},
+		{
+			name: "ordinary single quote keeps backslash literal",
+			src:  "print -r -- 'can\\'\n[[ $line == ((a|b)|c) ]]\n",
+		},
+		{
+			name: "double quoted heredoc delimiter",
+			src:  "cat <<\"DATA\"\n[[ body == ((x|y)|z) ]]\nDATA\n[[ $line == ((a|b)|c) ]]\n",
+		},
+		{
+			name: "backslash quoted heredoc delimiter",
+			src:  "cat <<D\\ATA\n[[ body == ((x|y)|z) ]]\nDATA\n[[ $line == ((a|b)|c) ]]\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			patterns := parsedPatternWords(t, test.src)
+			if len(patterns) != 1 {
+				t.Fatalf("pattern count = %d, want 1: %q", len(patterns), patterns)
+			}
+			if patterns[0] != pattern {
+				t.Errorf("pattern = %q, want %q", patterns[0], pattern)
+			}
+		})
+	}
+}
+
+func TestParseNestedConditionalAlternationBeforeOuterHeredocBody(t *testing.T) {
+	const pattern = "((a|b)|c)"
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "command substitution argument",
+			src:  "cat <<EOF $(\n[[ $line == ((a|b)|c) ]]\n)\nbody\nEOF\n",
+		},
+		{
+			name: "process substitution argument",
+			src:  "cat <<EOF <(\n[[ $line == ((a|b)|c) ]]\n)\nbody\nEOF\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			patterns := parsedPatternWords(t, test.src)
+			if len(patterns) != 1 {
+				t.Fatalf("pattern count = %d, want 1: %q", len(patterns), patterns)
+			}
+			if patterns[0] != pattern {
+				t.Errorf("pattern = %q, want %q", patterns[0], pattern)
+			}
+		})
+	}
+}
+
+func TestParseNestedConditionalAlternationBeforeOuterHeredocBodyAcrossCaseArm(t *testing.T) {
+	const pattern = "((a|b)|c)"
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "command substitution",
+			src:  "cat <<EOF $(\ncase x in\n  x) : ;;\nesac\n[[ $line == ((a|b)|c) ]]\n)\nbody\nEOF\n",
+		},
+		{
+			name: "process substitution",
+			src:  "cat <<EOF <(\ncase x in\n  x) : ;;\nesac\n[[ $line == ((a|b)|c) ]]\n)\nbody\nEOF\n",
+		},
+		{
+			name: "alternating case pattern in command substitution",
+			src:  "cat <<EOF $(\ncase x in\n  x|y) : ;;\nesac\n[[ $line == ((a|b)|c) ]]\n)\nbody\nEOF\n",
+		},
+		{
+			name: "nested command substitution in case pattern",
+			src:  "cat <<EOF $(\ncase x in\n  $(print x)) : ;;\nesac\n[[ $line == ((a|b)|c) ]]\n)\nbody\nEOF\n",
+		},
+		{
+			name: "nested process substitution in case pattern",
+			src:  "cat <<EOF $(\ncase x in\n  <(print x)) : ;;\nesac\n[[ $line == ((a|b)|c) ]]\n)\nbody\nEOF\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			patterns := parsedPatternWords(t, test.src)
+			if len(patterns) != 1 {
+				t.Fatalf("pattern count = %d, want 1: %q", len(patterns), patterns)
+			}
+			if patterns[0] != pattern {
+				t.Errorf("pattern = %q, want %q", patterns[0], pattern)
+			}
+		})
+	}
+}
+
+func TestParseNestedConditionalAlternationWithDepthScopedFrames(t *testing.T) {
+	const pattern = "((a|b)|c)"
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "case command in conditional child substitution",
+			src: "cat <<EOF $(\n" +
+				"[[ foo == $(case x in\n" +
+				"  x) print ok ;;\n" +
+				"esac\n" +
+				") ]]\n" +
+				"[[ $line == ((a|b)|c) ]]\n" +
+				")\nbody\nEOF\n",
+		},
+		{
+			name: "affected conditional in double quoted child substitution",
+			src: "cat <<EOF $(\n" +
+				"print \"$(\n" +
+				"[[ $line == ((a|b)|c) ]]\n" +
+				")\"\n" +
+				")\nbody\nEOF\n",
+		},
+		{
+			name: "inner heredoc resumes before outer heredoc body",
+			src: "cat <<OUTER $(\n" +
+				"cat <<INNER\n" +
+				"[[ body == ((x|y)|z) ]]\n" +
+				"INNER\n" +
+				"[[ $line == ((a|b)|c) ]]\n" +
+				")\nbody\nOUTER\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			patterns := parsedPatternWords(t, test.src)
+			restored := 0
+			for _, got := range patterns {
+				if got == pattern {
+					restored++
+				}
+				if got == "((x|y)|z)" {
+					t.Errorf("heredoc body lookalike became an active pattern: %q", patterns)
+				}
+			}
+			if restored != 1 {
+				t.Errorf("restored pattern count = %d, want 1: %q", restored, patterns)
+			}
+		})
+	}
+}
+
+func TestParseNestedConditionalAlternationClosesRootCaseAtEsac(t *testing.T) {
+	const pattern = "((a|b)|c)"
+	const src = "case x in\n" +
+		"  x) :\n" +
+		"esac\n" +
+		"[[ $line == ((a|b)|c) ]]\n"
+
+	patterns := parsedPatternWords(t, src)
+	if len(patterns) != 1 {
+		t.Fatalf("pattern count = %d, want 1: %q", len(patterns), patterns)
+	}
+	if patterns[0] != pattern {
+		t.Errorf("pattern = %q, want %q", patterns[0], pattern)
+	}
+}
+
+func TestParseNestedConditionalAlternationFindsCommandSubstitutionInsideArithmetic(t *testing.T) {
+	const pattern = "((a|b)|c)"
+	const src = "cat <<EOF $(\n" +
+		"(( value = $(\n" +
+		"  [[ $line == ((a|b)|c) ]]\n" +
+		"  print 1\n" +
+		") ))\n" +
+		")\n" +
+		"body\n" +
+		"EOF\n"
+
+	patterns := parsedPatternWords(t, src)
+	if len(patterns) != 1 {
+		t.Fatalf("pattern count = %d, want 1: %q", len(patterns), patterns)
+	}
+	if patterns[0] != pattern {
+		t.Errorf("pattern = %q, want %q", patterns[0], pattern)
+	}
+}
+
+func TestParseNestedConditionalAlternationDoesNotTreatCaseOperandAsCommand(t *testing.T) {
+	const src = "print $(\n[[ foo == bar || case == case ]]\n)\n[[ $line == ((a|b)|c) ]]\n"
+	want := []string{"bar", "case", "((a|b)|c)"}
+	got := parsedPatternWords(t, src)
+	if len(got) != len(want) {
+		t.Fatalf("pattern count = %d, want %d: %q", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("pattern[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestParseNestedConditionalAlternationWithANSICHeredocDelimiter(t *testing.T) {
+	const pattern = "((a|b)|c)"
+	src := "[[ $seed == ((a|b)|c) ]]\ncat <<$'EOF'\nbody\nEOF\n"
+	patterns := parsedPatternWords(t, src)
+	if len(patterns) != 1 {
+		t.Fatalf("pattern count = %d, want 1: %q", len(patterns), patterns)
+	}
+	if patterns[0] != pattern {
+		t.Errorf("pattern = %q, want %q", patterns[0], pattern)
+	}
+}
+
+func TestNestedPatternBatchEditsSkipsANSICHeredocBodyLookalike(t *testing.T) {
+	src := []byte(
+		"[[ $seed == ((a|b)|c) ]]\n" +
+			"cat <<$'E\\x4fF'\n" +
+			"$E\\x4fF\n" +
+			"[[ $fake == ((d|e)|f) ]]\n" +
+			"EOF\n",
+	)
+	_, firstErr := parseTree(src, "ansi-c-heredoc.zsh")
+	var parseErr syntax.ParseError
+	if !errors.As(firstErr, &parseErr) || parseErr.Text != invalidAlternationOperator {
+		t.Fatalf("parseTree() error = %v, want %q", firstErr, invalidAlternationOperator)
+	}
+
+	edits, ok := nestedPatternBatchEdits(src, int(parseErr.Pos.Offset()))
+	if !ok {
+		t.Fatal("nestedPatternBatchEdits() rejected a classified ANSI-C heredoc")
+	}
+	if len(edits) != 2 {
+		t.Fatalf("edit count = %d, want 2: %+v", len(edits), edits)
+	}
+}
+
+func TestNestedPatternBatchEditsSkipsProactiveLookalikes(t *testing.T) {
+	const seed = "[[ $line == ((a|b)|c) ]]\n"
+	tests := []struct {
+		name   string
+		suffix string
+	}{
+		{name: "single-quoted command word", suffix: "print '[[ $fake == ((d|e)|f) ]]'\n"},
+		{name: "double-quoted command word", suffix: "print \"[[ $fake == ((d|e)|f) ]]\"\n"},
+		{name: "comment", suffix: "# [[ $fake == ((d|e)|f) ]]\n"},
+		{name: "quoted RHS", suffix: "[[ $fake == \"((d|e)|f)\" ]]\n"},
+		{name: "escaped RHS", suffix: "[[ $fake == \\(\\(d\\|e\\)\\|f\\) ]]\n"},
+		{name: "bracket expression", suffix: "[[ $fake == [d|e] ]]\n"},
+		{name: "command substitution", suffix: "[[ $fake == $(print '((d|e)|f)') ]]\n"},
+		{name: "process substitution", suffix: "[[ $fake == <(print '((d|e)|f)') ]]\n"},
+		{name: "different operator", suffix: "[[ $fake =~ ((d|e)|f) ]]\n"},
+		{name: "unbalanced pattern", suffix: "[[ $fake == ((d|e)|f ]]\n"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			src := []byte(seed + test.suffix)
+			_, firstErr := parseTree(src, "proactive-lookalike.zsh")
+			var parseErr syntax.ParseError
+			if !errors.As(firstErr, &parseErr) || parseErr.Text != invalidAlternationOperator {
+				t.Fatalf("parseTree() error = %v, want %q", firstErr, invalidAlternationOperator)
+			}
+
+			edits, ok := nestedPatternBatchEdits(src, int(parseErr.Pos.Offset()))
+			if !ok {
+				t.Fatal("nestedPatternBatchEdits() rejected the recognized seed")
+			}
+			if len(edits) != 2 {
+				t.Fatalf("edit count = %d, want 2: %+v", len(edits), edits)
+			}
+			for _, edit := range edits {
+				if edit.offset >= len(seed) {
+					t.Errorf("proactive edit escaped the seed at byte %d", edit.offset)
+				}
+			}
+		})
+	}
+}
+
+func TestNestedPatternBatchEditsRequiresRecognizedSeed(t *testing.T) {
+	src := []byte("[[ a | b ]]\n[[ $line == ((d|e)|f) ]]\n")
+	_, firstErr := parseTree(src, "unrecognized-seed.zsh")
+	var parseErr syntax.ParseError
+	if !errors.As(firstErr, &parseErr) || parseErr.Text != invalidAlternationOperator {
+		t.Fatalf("parseTree() error = %v, want %q", firstErr, invalidAlternationOperator)
+	}
+	if edits, ok := nestedPatternBatchEdits(src, int(parseErr.Pos.Offset())); ok {
+		t.Fatalf("nestedPatternBatchEdits() = %+v, want rejected seed", edits)
+	}
+}
+
+func TestNestedPatternBatchEditsSkipsHeredocLookalike(t *testing.T) {
+	src := []byte("[[ $line == ((a|b)|c) ]]\ncat <<'EOF'\n[[ $fake == ((d|e)|f) ]]\nEOF\n")
+	_, firstErr := parseTree(src, "heredoc-lookalike.zsh")
+	var parseErr syntax.ParseError
+	if !errors.As(firstErr, &parseErr) || parseErr.Text != invalidAlternationOperator {
+		t.Fatalf("parseTree() error = %v, want %q", firstErr, invalidAlternationOperator)
+	}
+	edits, ok := nestedPatternBatchEdits(src, int(parseErr.Pos.Offset()))
+	if !ok {
+		t.Fatal("nestedPatternBatchEdits() rejected a classified heredoc")
+	}
+	if len(edits) != 2 {
+		t.Fatalf("edit count = %d, want 2: %+v", len(edits), edits)
+	}
+}
+
+func TestNestedConditionalAlternationBatchReturnsLaterParserError(t *testing.T) {
+	src := []byte("[[ $line == ((a|b)|c) ]]\n[[ $other == ((d|e)|f) ]\n")
+	_, firstErr := parseTree(src, "later-error.zsh")
+	if firstErr == nil {
+		t.Fatal("parseTree() unexpectedly accepted the original source")
+	}
+
+	compatibilityParses := 0
+	tree, err := parseNestedConditionalAlternationWithParser(
+		src,
+		"later-error.zsh",
+		firstErr,
+		func(masked []byte, name string) (*syntax.File, error) {
+			compatibilityParses++
+			return parseTree(masked, name)
+		},
+	)
+	if err == nil {
+		t.Fatalf("parseNestedConditionalAlternationWithParser() = %#v, want parser error", tree)
+	}
+	if compatibilityParses != 1 {
+		t.Errorf("compatibility parse count = %d, want 1", compatibilityParses)
+	}
+}
+
+func TestNestedConditionalAlternationRetryReturnsUnmatchedRootCloseError(t *testing.T) {
+	src := []byte("[[ $line == ((a|b)|c) ]]\n)\n")
+	_, firstErr := parseTree(src, "unmatched-root-close.zsh")
+	var firstParseErr syntax.ParseError
+	if !errors.As(firstErr, &firstParseErr) || firstParseErr.Text != invalidAlternationOperator {
+		t.Fatalf("parseTree() error = %v, want line-1 %q", firstErr, invalidAlternationOperator)
+	}
+
+	compatibilityParses := 0
+	tree, err := parseNestedConditionalAlternationWithParser(
+		src,
+		"unmatched-root-close.zsh",
+		firstErr,
+		func(masked []byte, name string) (*syntax.File, error) {
+			compatibilityParses++
+			return parseTree(masked, name)
+		},
+	)
+	if err == nil {
+		t.Fatalf("parseNestedConditionalAlternationWithParser() = %#v, want parser error", tree)
+	}
+	if compatibilityParses != 1 {
+		t.Errorf("compatibility parse count = %d, want 1", compatibilityParses)
+	}
+	var parseErr syntax.ParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("error type = %T, want syntax.ParseError: %v", err, err)
+	}
+	if line, column := parseErr.Pos.Line(), parseErr.Pos.Col(); line != 2 || column != 1 {
+		t.Errorf("error position = %d:%d, want 2:1", line, column)
+	}
+	const wantText = "`)` can only be used to close a subshell"
+	if parseErr.Text != wantText {
+		t.Errorf("error text = %q, want %q", parseErr.Text, wantText)
+	}
+}
+
+func TestParseNestedConditionalAlternation(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			name: "double equals",
+			src:  "line=foo\n[[ $line == ((a|b)|c) ]]\n",
+			want: []string{"((a|b)|c)"},
+		},
+		{
+			name: "single equals",
+			src:  "[[ $line = ((a|b)|c) ]]\n",
+			want: []string{"((a|b)|c)"},
+		},
+		{
+			name: "not equals",
+			src:  "[[ $line != ((a|b)|c) ]]\n",
+			want: []string{"((a|b)|c)"},
+		},
+		{
+			name: "work buffer reproduction",
+			src:  "while [[ $___workbuf = (#b)...((...)|...)(*) ]]; do :; done\n",
+			want: []string{"(#b)...((...)|...)(*)"},
+		},
+		{
+			name: "secret token reproduction",
+			src:  "[[ $line == (#i)*((token|password|secret|api_key|apikey|private_key)=|Bearer )* ]] && return 2\n",
+			want: []string{"(#i)*((token|password|secret|api_key|apikey|private_key)=|Bearer )*"},
+		},
+		{
+			name: "triple nesting",
+			src:  "[[ $line == (((a|b)|c)|d) ]]\n",
+			want: []string{"(((a|b)|c)|d)"},
+		},
+		{
+			name: "two affected comparisons",
+			src:  "[[ $a == ((a|b)|c) ]]\n[[ $b != ((d|e)|f) ]]\n",
+			want: []string{"((a|b)|c)", "((d|e)|f)"},
+		},
+		{
+			name: "short parameter expansion",
+			src:  "[[ $line == (($prefix|a)|b) ]]\n",
+			want: []string{"(($prefix|a)|b)"},
+		},
+		{
+			name: "multibyte prefix",
+			src:  "print 'λ'\n[[ $line == ((a|b)|c) ]]\nprint after\n",
+			want: []string{"((a|b)|c)"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := parsedPatternWords(t, test.src)
+			if len(got) != len(test.want) {
+				t.Fatalf("pattern count = %d, want %d: %q", len(got), len(test.want), got)
+			}
+			for i := range test.want {
+				if got[i] != test.want[i] {
+					t.Errorf("pattern[%d] = %q, want %q", i, got[i], test.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestNestedConditionalAlternationFailsClosed(t *testing.T) {
+	tests := []string{
+		"[[ a | b ]]\n",
+		"[[ $line == ((a|b)|c) ]\n",
+		"[[ $line == [abc|] ]]\n",
+	}
+	for _, src := range tests {
+		if _, err := Parse(strings.NewReader(src), "invalid.zsh"); err == nil {
+			t.Errorf("Parse(%q) unexpectedly succeeded", src)
+		}
+	}
+}
+
+func TestNestedConditionalAlternationBypassesExistingValidSyntax(t *testing.T) {
+	tests := []string{
+		"[[ $line == $((1 | 2)) ]]\n",
+		"[[ $line == $(print '(a|b)') ]]\n",
+		"[[ $line == <(print '(a|b)') ]]\n",
+		"[[ $line == \"((a|b)|c)\" ]]\n",
+		"[[ $line == \\(\\(a\\|b\\)\\|c\\) ]]\n",
+		"[[ ( $line == (a|b) ) || $line == c ]]\n",
+	}
+	for _, src := range tests {
+		if _, err := Parse(strings.NewReader(src), "valid-control.zsh"); err != nil {
+			t.Errorf("Parse(%q) error: %v", src, err)
+		}
+	}
+}
+
+func TestRestorePatternEditsRejectsMaskMismatch(t *testing.T) {
+	original := []byte("[[ $line == ((a|b)|c) ]]\n")
+	masked := []byte("[[ $line == (xa|bx|c) ]]\n")
+	tree, err := parseTree(masked, "masked.zsh")
+	if err != nil {
+		t.Fatalf("parseTree() error: %v", err)
+	}
+
+	offset := strings.IndexByte(string(masked), 'x')
+	edit := patternEdit{offset: offset, original: '(', replacement: 'y'}
+	if err := restorePatternEdits(tree, original, []patternEdit{edit}); err == nil {
+		t.Fatal("restorePatternEdits() unexpectedly succeeded")
+	}
+}

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -3,9 +3,13 @@
 // The front end uses mvdan/sh's Zsh dialect (LangZsh, available since
 // v3.13.x), which on the documented survey corpus parses roughly twice as
 // many real Z-Shell files as the Bash variant the reboot started with
-// (issues #11, #53). Remaining Zsh gaps are tracked as corpus fixtures (see
-// issues #12, #13, #15 and docs/project/parser-gap-workflow.md). Isolating
-// the front end here lets it be swapped without touching callers.
+// (issues #11, #53). Isolating the front end here lets it be swapped without
+// touching callers. Remaining Zsh gaps are tracked as corpus fixtures. Narrow
+// compatibility adapters may live at this boundary only when native Zsh and
+// the released manual prove the syntax valid, the adapter is gated to one
+// parser failure, source positions remain unchanged, and original AST content
+// is restored before callers receive the file. See issue #112 and
+// docs/project/parser-gap-workflow.md.
 package parse
 
 import (
@@ -37,20 +41,27 @@ func (f *File) Lines() []string {
 	return f.lines
 }
 
+func parseTree(src []byte, name string) (*syntax.File, error) {
+	parser := syntax.NewParser(
+		syntax.KeepComments(true),
+		syntax.Variant(syntax.LangZsh),
+	)
+	return parser.Parse(bytes.NewReader(src), name)
+}
+
 // Parse parses a single Zsh source read from r, using name in error
-// messages. It returns the parsed source or the first parse error.
+// messages. It returns the parsed source or a parse error.
 func Parse(r io.Reader, name string) (*File, error) {
 	src, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
-	parser := syntax.NewParser(
-		syntax.KeepComments(true),
-		syntax.Variant(syntax.LangZsh),
-	)
-	tree, err := parser.Parse(bytes.NewReader(src), name)
+	tree, err := parseTree(src, name)
 	if err != nil {
-		return nil, err
+		tree, err = parseNestedConditionalAlternation(src, name, err)
+		if err != nil {
+			return nil, err
+		}
 	}
 	text := strings.TrimSuffix(string(src), "\n")
 	return &File{tree: tree, lines: strings.Split(text, "\n")}, nil

--- a/internal/survey/corpus_test.go
+++ b/internal/survey/corpus_test.go
@@ -19,6 +19,7 @@ var requiredFixtures = []string{
 	"ok-baseline.zsh",
 	"ok-brace-termination.zsh",
 	"ok-glob-patterns.zsh",
+	"ok-nested-conditional-alternation.zsh",
 	"ok-nested-param-expansion.zsh",
 	"ok-param-expansion-flags.zsh",
 }

--- a/internal/survey/testdata/corpus/ok-nested-conditional-alternation.zsh
+++ b/internal/survey/testdata/corpus/ok-nested-conditional-alternation.zsh
@@ -1,0 +1,10 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# Issue #112: zsh-lint locally preserves nested pattern-alternation groups on
+# conditional pattern operands while retaining original AST text and positions.
+line=foo
+[[ $line == ((a|b)|c) ]] && print matched
+print `[[ $line == ((a|b)|c) ]]`suffix
+print "`[[ $line == ((a|b)|c) ]]`suffix"
+print `print \`[[ $line == ((d|e)|f) ]]\``
+print `[[ $line == ((a|b)|c) ]]`


### PR DESCRIPTION
## Summary

- add a narrowly error-gated zsh-lint compatibility path for native-valid nested pattern alternation in `[[ ... = ... ]]`, `[[ ... == ... ]]`, and `[[ ... != ... ]]`
- preserve original source spelling, byte positions, comments, and public parser APIs through same-width masking, mapped legacy-backtick islands, structural grafting, and indexed exact-once restoration
- cover analyzer behavior, the minimized survey corpus, heredocs, substitutions, numeric ranges, sibling and nested legacy backticks, malformed controls, and bounded work
- document the local parser-gap workflow

The implementation retains `mvdan/sh` LangZsh as the primary parser. It does not change, fork, vendor, replace, update, or propose changes to mvdan/sh.

## Verification

- `go test ./... -count=1`
- `go vet ./...`
- `go build -buildvcs=false ./...`
- `go mod tidy -diff`
- native Zsh 5.9.2 positive and invalid syntax matrices
- analyzer and survey CLI checks
- `gofmt -d`
- `git diff --check`
- independent final review: 0 Critical, 0 Important, 0 Minor findings

## Related issues

- Closes #112
- #120 tracks unmatched nested pattern groups accepted on the primary parser success path
- #122 tracks escaped ANSI-C heredoc delimiters
- #123 tracks grouped Zsh case patterns

The related gaps remain separate and are not implemented in this PR.
