### PR TITLE
fix(parse): support Zsh try/always blocks (#12)

### DIFF
--- a/docs/project/2026-08-16-survey.md
+++ b/docs/project/2026-08-16-survey.md
@@ -1,0 +1,51 @@
+# Parser Survey Run, 2026-08-16
+
+## Scope
+
+This run evaluates the documented [parser evaluation corpus](corpus.md) after
+the local issue #12 compatibility adapter for Zsh `try/always` blocks. It is
+parser-front-end evidence only. It does not claim that the remaining source
+files are free of semantic-rule diagnostics.
+
+The run was performed from the uncommitted
+`code/issue-12-try-always-hardening` worktree, based on `next` commit
+`09cb9b23666fab0df32666168f300611aa8959dc`. The implementation and this
+record must be committed together before this becomes a durable baseline.
+
+## Environment
+
+| Component        | Value                                      |
+| ---------------- | ------------------------------------------ |
+| Zsh              | `zsh 5.9.2 (x86_64-pc-linux-gnu)`          |
+| Go               | `go1.26.6-X:nodwarf5 linux/amd64`          |
+| `mvdan.cc/sh/v3` | `v3.13.1`                                  |
+| zsh-lint base    | `09cb9b23666fab0df32666168f300611aa8959dc` |
+
+## Result
+
+```text
+19 file(s) surveyed, 15 ok, 4 failed
+```
+
+The issue #12 origin files now parse through their former `} always {`
+boundaries:
+
+- `repos/core/src/public/zsh/init.zsh`
+- `repos/plugins/zsh-fancy-completions/zsh-fancy-completions.plugin.zsh`
+
+The remaining first parser failures are separate language features:
+
+| Corpus source                                                           | First diagnostic                                                  | Tracking                                                                                      |
+| ----------------------------------------------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `z-a-meta-plugins/functions/.za-meta-plugins-before-load-handler:54:21` | `ternary operator missing ? before :`                             | No issue yet. Create one before implementation.                                               |
+| `zsh-eza/zsh-eza.plugin.zsh:24:16`                                      | `[` must be followed by an expression                             | [Issue #61, leading-dot associative subscript](https://github.com/z-shell/zsh-lint/issues/61) |
+| `zsh-fancy-completions/functions/.man_glob:21:13`                       | `this expansion operator is a bash feature; tried parsing as zsh` | [Issue #60, rc-expand caret](https://github.com/z-shell/zsh-lint/issues/60)                   |
+| `zsh-fancy-completions/lib/completion.zsh:110:87`                       | `*` must follow an expression                                     | [Issue #15, reverse-subscript pattern](https://github.com/z-shell/zsh-lint/issues/15)         |
+
+## Interpretation
+
+This run supersedes the issue #12 observations in the 2026-08-14 survey
+record. It does not supersede that report's historical revision and
+environment details. The four remaining failures need independent
+feature-level issues and compatibility designs; they are not covered by the
+issue #12 adapter.

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -64,7 +64,10 @@ func Parse(r io.Reader, name string) (*File, error) {
 			if err != nil {
 				tree, err = parseMultiNameFor(src, name, err)
 				if err != nil {
-					return nil, err
+					tree, err = parseTryAlways(src, name, err)
+					if err != nil {
+						return nil, err
+					}
 				}
 			}
 		}

--- a/internal/parse/try_always.go
+++ b/internal/parse/try_always.go
@@ -72,17 +72,19 @@ func scanTryAlwaysEdits(src []byte, seedOffset int) ([]tryAlwaysEdit, bool) {
 			continue
 		}
 		if inDoubleQuote {
-			if b == '\\' {
+			switch b {
+			case '\\':
 				escaped = true
-			} else if b == '"' {
+			case '"':
 				inDoubleQuote = false
 			}
 			continue
 		}
 		if inANSICQuote {
-			if b == '\\' {
+			switch b {
+			case '\\':
 				escaped = true
-			} else if b == '\'' {
+			case '\'':
 				inANSICQuote = false
 			}
 			continue

--- a/internal/parse/try_always.go
+++ b/internal/parse/try_always.go
@@ -1,0 +1,215 @@
+package parse
+
+import (
+	"errors"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+const tryAlwaysParseError = "statements must be separated by &, ; or a newline"
+
+// parseTryAlways retries the primary parser only for the documented Zsh
+// try/always boundary. The fixed-width transformation keeps every original
+// byte offset valid for the returned syntax tree.
+func parseTryAlways(src []byte, name string, firstErr error) (*syntax.File, error) {
+	return parseTryAlwaysWithParser(src, name, firstErr, parseTree)
+}
+
+func parseTryAlwaysWithParser(
+	src []byte,
+	name string,
+	firstErr error,
+	parse func([]byte, string) (*syntax.File, error),
+) (*syntax.File, error) {
+	var parseErr syntax.ParseError
+	if !errors.As(firstErr, &parseErr) || parseErr.Text != tryAlwaysParseError {
+		return nil, firstErr
+	}
+
+	edits, ok := scanTryAlwaysEdits(src, int(parseErr.Pos.Offset()))
+	if !ok {
+		return nil, firstErr
+	}
+
+	transformed := applyTryAlwaysEdits(src, edits)
+	if len(transformed) != len(src) {
+		return nil, firstErr
+	}
+	return parse(transformed, name)
+}
+
+type tryAlwaysEdit struct {
+	separator  int
+	alwaysFrom int
+	alwaysTo   int
+}
+
+// scanTryAlwaysEdits recognizes only `}` followed by horizontal whitespace,
+// `always`, horizontal whitespace, and `{` in syntactically active source.
+// Newlines and semicolons are intentionally excluded because native Zsh
+// rejects them between the try block and the always keyword.
+func scanTryAlwaysEdits(src []byte, seedOffset int) ([]tryAlwaysEdit, bool) {
+	var edits []tryAlwaysEdit
+	seedRecognized := false
+	inSingleQuote := false
+	inDoubleQuote := false
+	inANSICQuote := false
+	escaped := false
+	inComment := false
+	var heredocs []pendingHeredoc
+	arithmeticDepth := 0
+
+	for i := 0; i < len(src); i++ {
+		b := src[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if inSingleQuote {
+			if b == '\'' {
+				inSingleQuote = false
+			}
+			continue
+		}
+		if inDoubleQuote {
+			if b == '\\' {
+				escaped = true
+			} else if b == '"' {
+				inDoubleQuote = false
+			}
+			continue
+		}
+		if inANSICQuote {
+			if b == '\\' {
+				escaped = true
+			} else if b == '\'' {
+				inANSICQuote = false
+			}
+			continue
+		}
+		if inComment {
+			if b == '\n' {
+				inComment = false
+			}
+			continue
+		}
+		if b == '\n' && len(heredocs) > 0 {
+			next, ok := consumeHeredocBodies(src, i+1, heredocs)
+			if !ok {
+				return nil, false
+			}
+			heredocs = nil
+			i = next - 1
+			continue
+		}
+		if b == '(' && i+1 < len(src) && src[i+1] == '(' {
+			arithmeticDepth++
+			i++
+			continue
+		}
+		if arithmeticDepth > 0 && b == ')' && i+1 < len(src) && src[i+1] == ')' {
+			arithmeticDepth--
+			i++
+			continue
+		}
+
+		switch b {
+		case '\\':
+			escaped = true
+			continue
+		case '\'':
+			inSingleQuote = true
+			continue
+		case '"':
+			inDoubleQuote = true
+			continue
+		case '#':
+			if i == 0 || isTryAlwaysBoundary(src[i-1]) {
+				inComment = true
+			}
+			continue
+		case '$':
+			if i+1 < len(src) && src[i+1] == '\'' {
+				inANSICQuote = true
+				i++
+				continue
+			}
+		}
+		if arithmeticDepth == 0 && b == '<' && i+1 < len(src) && src[i+1] == '<' {
+			stripTabs := i+2 < len(src) && src[i+2] == '-'
+			delimiterStart := i + 2
+			if stripTabs {
+				delimiterStart++
+			}
+			delimiter, end, ok := parseHeredocDelimiter(src, delimiterStart)
+			if !ok {
+				return nil, false
+			}
+			heredocs = append(heredocs, pendingHeredoc{
+				delimiter: delimiter,
+				stripTabs: stripTabs,
+			})
+			i = end - 1
+			continue
+		}
+
+		if b != '}' {
+			continue
+		}
+		separator := i + 1
+		if separator >= len(src) || !isTryAlwaysSpace(src[separator]) {
+			continue
+		}
+		alwaysFrom := separator
+		for alwaysFrom < len(src) && isTryAlwaysSpace(src[alwaysFrom]) {
+			alwaysFrom++
+		}
+		alwaysTo := alwaysFrom + len("always")
+		if alwaysTo > len(src) || string(src[alwaysFrom:alwaysTo]) != "always" {
+			continue
+		}
+		if alwaysTo < len(src) && isIdentByte(src[alwaysTo]) {
+			continue
+		}
+		openBrace := alwaysTo
+		if openBrace >= len(src) || !isTryAlwaysSpace(src[openBrace]) {
+			continue
+		}
+		for openBrace < len(src) && isTryAlwaysSpace(src[openBrace]) {
+			openBrace++
+		}
+		if openBrace >= len(src) || src[openBrace] != '{' {
+			continue
+		}
+
+		edits = append(edits, tryAlwaysEdit{
+			separator:  separator,
+			alwaysFrom: alwaysFrom,
+			alwaysTo:   alwaysTo,
+		})
+		if seedOffset >= i && seedOffset <= openBrace {
+			seedRecognized = true
+		}
+	}
+
+	return edits, seedRecognized && len(edits) > 0
+}
+
+func isTryAlwaysSpace(b byte) bool {
+	return b == ' ' || b == '\t'
+}
+
+func isTryAlwaysBoundary(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == ';' || b == '{' || b == '}'
+}
+
+func applyTryAlwaysEdits(src []byte, edits []tryAlwaysEdit) []byte {
+	transformed := append([]byte(nil), src...)
+	for _, edit := range edits {
+		transformed[edit.separator] = ';'
+		for i := edit.alwaysFrom; i < edit.alwaysTo; i++ {
+			transformed[i] = ' '
+		}
+	}
+	return transformed
+}

--- a/internal/parse/try_always_test.go
+++ b/internal/parse/try_always_test.go
@@ -1,0 +1,183 @@
+package parse
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+func TestParseTryAlwaysAcceptsNativeSyntax(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "top level",
+			src:  "{\n  print try\n} always {\n  print cleanup\n}\n",
+		},
+		{
+			name: "tab separated boundary",
+			src:  "{\n  print try\n}\talways\t{\n  print cleanup\n}\n",
+		},
+		{
+			name: "nested in function",
+			src:  "cleanup() {\n  {\n    print try\n  } always {\n    print cleanup\n  }\n}\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			file, err := Parse(strings.NewReader(test.src), test.name+".zsh")
+			if err != nil {
+				t.Fatalf("Parse() error: %v", err)
+			}
+			if len(file.AST().Stmts) == 0 {
+				t.Fatal("Parse() returned no statements")
+			}
+		})
+	}
+}
+
+func TestParseTryAlwaysRejectsInvalidSeparators(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "newline before always",
+			src:  "{\n  print try\n}\nalways {\n  print cleanup\n}\n",
+		},
+		{
+			name: "semicolon before always",
+			src:  "{\n  print try\n}; always {\n  print cleanup\n}\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Parse(strings.NewReader(test.src), test.name+".zsh")
+			if err == nil {
+				t.Fatal("Parse() succeeded for native-invalid try/always separator")
+			}
+		})
+	}
+}
+
+func TestParseTryAlwaysPreservesHeredocBody(t *testing.T) {
+	src := "cat <<'EOF'\n} always {\nEOF\n{\n  print try\n} always {\n  print cleanup\n}\n"
+	file, err := Parse(strings.NewReader(src), "heredoc.zsh")
+	if err != nil {
+		t.Fatalf("Parse() error: %v", err)
+	}
+
+	var rendered strings.Builder
+	if err := syntax.NewPrinter().Print(&rendered, file.AST()); err != nil {
+		t.Fatalf("printing AST: %v", err)
+	}
+	if !strings.Contains(rendered.String(), "} always {") {
+		t.Fatalf("rendered heredoc body = %q, want original try/always text", rendered.String())
+	}
+}
+
+func TestParseTryAlwaysPreservesInactiveLookalikes(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix string
+	}{
+		{name: "comment", prefix: "# } always {\n"},
+		{name: "single quoted word", prefix: "print '} always {'\n"},
+		{name: "command substitution", prefix: "value=$(print '} always {')\n"},
+		{name: "legacy backtick substitution", prefix: "value=`print '} always {'`\n"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			src := test.prefix + "{\n  print try\n} always {\n  print cleanup\n}\n"
+			file, err := Parse(strings.NewReader(src), test.name+".zsh")
+			if err != nil {
+				t.Fatalf("Parse() error: %v", err)
+			}
+			var rendered strings.Builder
+			if err := syntax.NewPrinter().Print(&rendered, file.AST()); err != nil {
+				t.Fatalf("printing AST: %v", err)
+			}
+			if !strings.Contains(rendered.String(), "} always {") {
+				t.Fatalf("rendered source = %q, want inactive lookalike preserved", rendered.String())
+			}
+		})
+	}
+}
+
+func TestParseTryAlwaysAfterArithmeticShift(t *testing.T) {
+	src := "(( mask = 1 << 2 ))\n{\n  print try\n} always {\n  print cleanup\n}\n"
+	file, err := Parse(strings.NewReader(src), "arithmetic-shift.zsh")
+	if err != nil {
+		t.Fatalf("Parse() error: %v", err)
+	}
+	if len(file.AST().Stmts) != 3 {
+		t.Fatalf("statement count = %d, want 3", len(file.AST().Stmts))
+	}
+}
+
+func TestParseTryAlwaysPreservesBodyPositions(t *testing.T) {
+	src := "{\n  print try\n}  always {\n  print cleanup\n}\n"
+	file, err := Parse(strings.NewReader(src), "positions.zsh")
+	if err != nil {
+		t.Fatalf("Parse() error: %v", err)
+	}
+
+	var positions []syntax.Pos
+	syntax.Walk(file.AST(), func(node syntax.Node) bool {
+		call, ok := node.(*syntax.CallExpr)
+		if !ok || len(call.Args) == 0 || call.Args[0].Lit() != "print" {
+			return true
+		}
+		positions = append(positions, call.Pos())
+		return true
+	})
+	if len(positions) != 2 {
+		t.Fatalf("print positions = %v, want two", positions)
+	}
+	for i, want := range []struct{ line, col uint }{{2, 3}, {4, 3}} {
+		if positions[i].Line() != want.line || positions[i].Col() != want.col {
+			t.Errorf("print[%d].Pos() = %d:%d, want %d:%d", i, positions[i].Line(), positions[i].Col(), want.line, want.col)
+		}
+	}
+}
+
+func TestParseTryAlwaysRetriesOnce(t *testing.T) {
+	src := []byte("{\n  :\n} always {\n  :\n}\n")
+	_, firstErr := parseTree(src, "retry-once.zsh")
+	if firstErr == nil {
+		t.Fatal("parseTree() unexpectedly accepted the original source")
+	}
+
+	attempts := 0
+	_, err := parseTryAlwaysWithParser(src, "retry-once.zsh", firstErr, func(transformed []byte, name string) (*syntax.File, error) {
+		attempts++
+		if len(transformed) != len(src) {
+			t.Fatalf("transformed length = %d, want %d", len(transformed), len(src))
+		}
+		return parseTree(transformed, name)
+	})
+	if err != nil {
+		t.Fatalf("parseTryAlwaysWithParser() error: %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("compatibility parser attempts = %d, want 1", attempts)
+	}
+
+	_, err = parseTryAlwaysWithParser(src, "wrong-error.zsh", errors.New("other parse error"), parseTree)
+	if err == nil {
+		t.Fatal("parseTryAlwaysWithParser() unexpectedly accepted a non-parser error")
+	}
+}
+
+func TestScanTryAlwaysEditsRequiresErrorAtBoundary(t *testing.T) {
+	src := []byte("{\n  :\n} always {\n  :\n}\n")
+	if edits, ok := scanTryAlwaysEdits(src, 0); ok || len(edits) != 1 {
+		t.Fatalf("scanTryAlwaysEdits() = (%v, %t), want one edit and false", edits, ok)
+	}
+}

--- a/internal/survey/corpus_test.go
+++ b/internal/survey/corpus_test.go
@@ -23,6 +23,7 @@ var requiredFixtures = []string{
 	"ok-nested-conditional-alternation.zsh",
 	"ok-nested-param-expansion.zsh",
 	"ok-param-expansion-flags.zsh",
+	"ok-try-always.zsh",
 }
 
 // Fixture naming contract from docs/project/parser-gap-workflow.md:

--- a/internal/survey/testdata/corpus/ok-try-always.zsh
+++ b/internal/survey/testdata/corpus/ok-try-always.zsh
@@ -1,7 +1,7 @@
 # -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
 # vim: ft=zsh sw=2 ts=2 et
-# Issue #12: Zsh try/always blocks are valid complex commands but are not
-# parsed by the current mvdan/sh LangZsh front end.
+# Issue #12: Zsh try/always blocks ({ ... } always { }).
+# Preserved as permanent regression coverage.
 {
   :
 } always {


### PR DESCRIPTION
## Summary

- parse Zsh `} always {` boundaries through a narrow compatibility adapter
- gate the retry on the exact upstream parser diagnostic and preserve source byte offsets
- protect quoted text, comments, heredoc bodies, and arithmetic shifts from false rewrites
- promote the native-valid issue fixture and record the refreshed parser survey

## Validation

- `go build ./...`
- `go vet ./...`
- `go test ./... -count=1`
- `zsh -f -n internal/survey/testdata/corpus/ok-try-always.zsh`
- 19-file parser survey: 15 parse, 4 independently tracked gaps remain

Closes #12