### PR TITLE
fix(parse): reject unmatched conditional pattern groups

### DIFF
--- a/docs/project/parser-gap-workflow.md
+++ b/docs/project/parser-gap-workflow.md
@@ -37,7 +37,7 @@ both directions:
     zsh -n <file>                         # must pass — the gap is real Zsh
 
 A fixture that `zsh -n` rejects is a broken script, not a parser gap; never
-commit one.
+commit one to the native-valid survey corpus.
 
 ## 4. Promote to fixture
 
@@ -51,6 +51,20 @@ any other name is rejected. There is no fixture
 count assertion — adding fixtures never requires test edits
 ([#14](https://github.com/z-shell/zsh-lint/issues/14)); only the small
 `requiredFixtures` baseline list is asserted by name.
+
+### Native-invalid regression sources
+
+False acceptance defects need the opposite contract: native Zsh rejects the
+source and zsh-lint must also reject it. Store a minimized source as
+`internal/parse/testdata/invalid-<issue>-<slug>.txt` and exercise it from a
+focused parser test. Use `.txt` deliberately so the repository-wide native Zsh
+syntax gate continues to require every tracked `.zsh` corpus source to be
+valid.
+
+Record the native decision with `zsh -f -n`, but never execute an invalid test
+source. Parser tests read its bytes and assert the error family and original
+source position. Do not add exceptions to the native Zsh syntax gate for
+ordinary `.zsh` files.
 
 ## 5. Close the loop
 

--- a/internal/parse/conditional_pattern_validation.go
+++ b/internal/parse/conditional_pattern_validation.go
@@ -1,0 +1,42 @@
+package parse
+
+import (
+	"fmt"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+func validateConditionalPatterns(src []byte, name string) error {
+	scan, ok := scanConditionalPatterns(src, -1, nil)
+	if !ok || scan.finding == nil {
+		return nil
+	}
+	pos, ok := sourcePos(src, scan.finding.offset)
+	if !ok {
+		return fmt.Errorf(
+			"%s: conditional-pattern finding outside source at byte %d",
+			name,
+			scan.finding.offset,
+		)
+	}
+	return syntax.ParseError{
+		Filename: name,
+		Pos:      pos,
+		Text:     scan.finding.text,
+	}
+}
+
+func sourcePos(src []byte, offset int) (syntax.Pos, bool) {
+	if offset < 0 || offset > len(src) {
+		return syntax.Pos{}, false
+	}
+	line, column := uint(1), uint(1)
+	for _, b := range src[:offset] {
+		if b == '\n' {
+			line, column = line+1, 1
+		} else {
+			column++
+		}
+	}
+	return syntax.NewPos(uint(offset), line, column), true
+}

--- a/internal/parse/conditional_pattern_validation_test.go
+++ b/internal/parse/conditional_pattern_validation_test.go
@@ -1,0 +1,119 @@
+package parse
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// Native Zsh 5.9.2 rejects this unmatched nested pattern group. This test
+// catches accepting the AST engine's more permissive success result.
+func TestParseRejectsUnmatchedNestedConditionalPatternGroup(t *testing.T) {
+	src, err := os.ReadFile("testdata/invalid-120-unmatched-conditional-pattern.txt")
+	if err != nil {
+		t.Fatalf("read invalid fixture: %v", err)
+	}
+	_, err = Parse(bytes.NewReader(src), "invalid-120-unmatched-conditional-pattern.zsh")
+	if err == nil {
+		t.Fatal("Parse() accepted a native-invalid unmatched nested pattern group")
+	}
+	var parseErr syntax.ParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("error type = %T, want syntax.ParseError: %v", err, err)
+	}
+	wantOffset := strings.Index(string(src), "((a|b)")
+	if got := int(parseErr.Pos.Offset()); got != wantOffset {
+		t.Errorf("error offset = %d, want %d", got, wantOffset)
+	}
+	if parseErr.Pos.Line() != 2 || parseErr.Pos.Col() != 13 {
+		t.Errorf("error position = %d:%d, want 2:13", parseErr.Pos.Line(), parseErr.Pos.Col())
+	}
+	if parseErr.Text != "unmatched `(` in conditional pattern" {
+		t.Errorf("error text = %q", parseErr.Text)
+	}
+}
+
+// These controls catch treating inactive or balanced parentheses as unmatched
+// pattern groups. Native Zsh 5.9.2 accepts every source in this table.
+func TestParseConditionalPatternValidationControls(t *testing.T) {
+	tests := []string{
+		"[[ $line == ((a|b)|c) ]]\n",
+		"[[ $line == \"((a|b)\" ]]\n",
+		"[[ $line == \\(\\(a\\|b\\) ]]\n",
+		"[[ $line == $((1 + 2)) ]]\n",
+		"[[ $line == $(print '((a|b)') ]]\n",
+		"[[ $line == <(print '((a|b)') ]]\n",
+		"[[ $line == (foo`print x`) ]]\n",
+		"[[ $line == <1-9> ]]\n",
+		"# [[ $line == ((a|b) ]]\nprint ok\n",
+		"cat <<'EOF'\n[[ $line == ((a|b) ]]\nEOF\n",
+		"print `[[ $line == ((a|b)|c) ]]`\n",
+	}
+	for _, src := range tests {
+		if _, err := Parse(strings.NewReader(src), "valid-control.zsh"); err != nil {
+			t.Errorf("Parse(%q) error: %v", src, err)
+		}
+	}
+}
+
+func TestScanConditionalPatternsReportsFirstUnmatchedGroup(t *testing.T) {
+	const src = "print 'λ'\n[[ $line == ((a|b) ]]\n"
+	scan, ok := scanConditionalPatterns([]byte(src), -1, nil)
+	if !ok || scan.finding == nil {
+		t.Fatalf("scan = (%+v, %t), want finding", scan, ok)
+	}
+	want := strings.Index(src, "((a|b)")
+	if scan.finding.offset != want {
+		t.Errorf("finding offset = %d, want %d", scan.finding.offset, want)
+	}
+}
+
+func TestScanConditionalPatternsKeepsBalancedCompatibilityCandidate(t *testing.T) {
+	const src = "[[ $line == ((a|b)|c) ]]\n"
+	_, firstErr := parseTree([]byte(src), "balanced.zsh")
+	var parseErr syntax.ParseError
+	if !errors.As(firstErr, &parseErr) {
+		t.Fatalf("parseTree() error = %v, want syntax.ParseError", firstErr)
+	}
+	scan, ok := scanConditionalPatterns([]byte(src), int(parseErr.Pos.Offset()), nil)
+	if !ok {
+		t.Fatal("scanConditionalPatterns() rejected balanced compatibility source")
+	}
+	if scan.finding != nil {
+		t.Fatalf("finding = %+v, want nil", scan.finding)
+	}
+	if len(scan.candidates) != 1 || len(scan.candidates[0].edits) == 0 {
+		t.Fatalf("candidates = %+v, want one compatibility candidate", scan.candidates)
+	}
+}
+
+func TestSourcePosCountsByteColumns(t *testing.T) {
+	src := []byte("λ(")
+	pos, ok := sourcePos(src, 2)
+	if !ok {
+		t.Fatal("sourcePos() rejected a valid UTF-8 byte offset")
+	}
+	if pos.Offset() != 2 || pos.Line() != 1 || pos.Col() != 3 {
+		t.Errorf("sourcePos() = offset %d line %d column %d, want 2/1/3", pos.Offset(), pos.Line(), pos.Col())
+	}
+}
+
+func FuzzValidateConditionalPatterns(f *testing.F) {
+	f.Add("[[ $line == ((a|b) ]]\n")
+	f.Add("[[ $line == ((a|b)|c) ]]\n")
+	f.Add("cat <<'EOF'\n((\nEOF\n")
+	f.Fuzz(func(t *testing.T, src string) {
+		err := validateConditionalPatterns([]byte(src), "fuzz.zsh")
+		if err == nil {
+			return
+		}
+		var parseErr syntax.ParseError
+		if errors.As(err, &parseErr) && int(parseErr.Pos.Offset()) > len(src) {
+			t.Fatalf("error offset %d exceeds source length %d", parseErr.Pos.Offset(), len(src))
+		}
+	})
+}

--- a/internal/parse/nested_conditional_pattern.go
+++ b/internal/parse/nested_conditional_pattern.go
@@ -102,6 +102,17 @@ type patternCandidate struct {
 	seed             bool
 }
 
+type conditionalPatternFinding struct {
+	offset int
+	text   string
+}
+
+type conditionalPatternScan struct {
+	candidates      []patternCandidate
+	backtickIslands []legacyBacktickIsland
+	finding         *conditionalPatternFinding
+}
+
 type activeConditionalContext struct {
 	start   int
 	pattern *activePatternState
@@ -211,13 +222,13 @@ func nestedPatternBatch(
 	if len(probes) > 0 {
 		inspect = probes[0]
 	}
-	candidates, backtickIslands, ok := collectNestedPatternCandidates(src, seedOffset, inspect)
+	scan, ok := scanConditionalPatterns(src, seedOffset, inspect)
 	if !ok {
 		return nestedPatternCompatibilityBatch{}, false
 	}
 	seedRecognized := false
 	editCount := 0
-	for _, candidate := range candidates {
+	for _, candidate := range scan.candidates {
 		if inspect != nil {
 			inspect()
 		}
@@ -232,7 +243,7 @@ func nestedPatternBatch(
 
 	edits := make([]patternEdit, 0, editCount)
 	seenOffsets := make(map[int]bool, editCount)
-	for _, candidate := range candidates {
+	for _, candidate := range scan.candidates {
 		for _, edit := range candidate.edits {
 			if seenOffsets[edit.offset] {
 				return nestedPatternCompatibilityBatch{}, false
@@ -243,18 +254,19 @@ func nestedPatternBatch(
 	}
 	return nestedPatternCompatibilityBatch{
 		edits:           edits,
-		backtickIslands: backtickIslands,
+		backtickIslands: scan.backtickIslands,
 	}, true
 }
 
-func collectNestedPatternCandidates(
+func scanConditionalPatterns(
 	src []byte,
 	seedOffset int,
 	inspect patternBatchProbe,
 	legacyLookupProbes ...activeLegacyLookupProbe,
-) ([]patternCandidate, []legacyBacktickIsland, bool) {
+) (conditionalPatternScan, bool) {
 	var candidates []patternCandidate
 	var backtickRoots []*legacyBacktickSpan
+	var finding *conditionalPatternFinding
 	var inspectLegacyLookup activeLegacyLookupProbe
 	if len(legacyLookupProbes) > 0 {
 		inspectLegacyLookup = legacyLookupProbes[0]
@@ -316,7 +328,7 @@ func collectNestedPatternCandidates(
 		if b == '\n' && frame.arithmeticDepth == 0 && len(frame.heredocs) > 0 {
 			next, ok := consumeHeredocBodies(src, i+1, frame.heredocs)
 			if !ok {
-				return nil, nil, false
+				return conditionalPatternScan{}, false
 			}
 			frame.heredocs = nil
 			frame.inComment = false
@@ -379,10 +391,10 @@ func collectNestedPatternCandidates(
 				continue
 			}
 			if escapeDepth != depth-1 {
-				return nil, nil, false
+				return conditionalPatternScan{}, false
 			}
 			if !activeSourceFrameCanClose(frame) {
-				return nil, nil, false
+				return conditionalPatternScan{}, false
 			}
 			frame.legacyBacktick.closeStart = i - delimiterEscapes
 			frame.legacyBacktick.closeOffset = i
@@ -463,7 +475,7 @@ func collectNestedPatternCandidates(
 			}
 		}
 		if frame.conditional != nil && frame.conditional.pattern != nil {
-			if activePatternByteConsumed(frame, src, i, seedOffset, &candidates) {
+			if activePatternByteConsumed(frame, src, i, seedOffset, &candidates, &finding) {
 				frame.atWordStart = false
 				frame.atCommandStart = false
 				continue
@@ -600,7 +612,7 @@ func collectNestedPatternCandidates(
 				continue
 			}
 			if !activeSourceFrameCanClose(frame) {
-				return nil, nil, false
+				return conditionalPatternScan{}, false
 			}
 			adaptedPattern := frame.adaptedPattern
 			frames = frames[:len(frames)-1]
@@ -626,7 +638,7 @@ func collectNestedPatternCandidates(
 			}
 			delimiter, end, ok := parseHeredocDelimiter(src, delimiterStart)
 			if !ok {
-				return nil, nil, false
+				return conditionalPatternScan{}, false
 			}
 			frame.heredocs = append(frame.heredocs, pendingHeredoc{
 				delimiter: delimiter,
@@ -644,7 +656,7 @@ func collectNestedPatternCandidates(
 			continue
 		}
 		if frame.conditional != nil && b == ']' && i+1 < len(src) && src[i+1] == ']' {
-			finalizeActivePattern(frame, i, &candidates)
+			finalizeActivePattern(frame, i, &candidates, &finding)
 			frame.conditional = nil
 			i++
 			frame.atWordStart = false
@@ -669,16 +681,20 @@ func collectNestedPatternCandidates(
 	}
 
 	if len(frames) == 1 && frames[0].conditional != nil {
-		finalizeActivePattern(&frames[0], len(src), &candidates)
+		finalizeActivePattern(&frames[0], len(src), &candidates, &finding)
 	}
 	if len(frames) != 1 || !activeSourceRootFrameComplete(&frames[0]) {
-		return nil, nil, false
+		return conditionalPatternScan{}, false
 	}
 	islands, ok := affectedLegacyBacktickIslands(backtickRoots)
 	if !ok {
-		return nil, nil, false
+		return conditionalPatternScan{}, false
 	}
-	return candidates, islands, true
+	return conditionalPatternScan{
+		candidates:      candidates,
+		backtickIslands: islands,
+		finding:         finding,
+	}, true
 }
 
 func activePatternOperatorEnd(src []byte, start int) (int, bool) {
@@ -704,6 +720,7 @@ func activePatternByteConsumed(
 	offset int,
 	seedOffset int,
 	candidates *[]patternCandidate,
+	finding **conditionalPatternFinding,
 ) bool {
 	pattern := frame.conditional.pattern
 	b := src[offset]
@@ -725,7 +742,7 @@ func activePatternByteConsumed(
 				(string(src[offset:offset+2]) == "&&" ||
 					string(src[offset:offset+2]) == "||" ||
 					string(src[offset:offset+2]) == "]]")) {
-			finalizeActivePattern(frame, offset, candidates)
+			finalizeActivePattern(frame, offset, candidates, finding)
 			return false
 		}
 	}
@@ -798,14 +815,26 @@ func finalizeActivePattern(
 	frame *activeSourceFrame,
 	rhsEnd int,
 	candidates *[]patternCandidate,
+	finding **conditionalPatternFinding,
 ) {
 	if frame.conditional == nil || frame.conditional.pattern == nil {
 		return
 	}
 	pattern := frame.conditional.pattern
 	frame.conditional.pattern = nil
-	if pattern.invalid || pattern.rhsStart < 0 || pattern.inBracketExpression ||
-		len(pattern.openings) != 0 || !pattern.nestedAlternation || len(pattern.pairs) == 0 {
+	if pattern.invalid || pattern.rhsStart < 0 || pattern.inBracketExpression {
+		return
+	}
+	if len(pattern.openings) != 0 {
+		if *finding == nil {
+			*finding = &conditionalPatternFinding{
+				offset: pattern.openings[0],
+				text:   "unmatched `(` in conditional pattern",
+			}
+		}
+		return
+	}
+	if !pattern.nestedAlternation || len(pattern.pairs) == 0 {
 		return
 	}
 	edits := make([]patternEdit, 0, len(pattern.pairs)*2)

--- a/internal/parse/nested_conditional_pattern_test.go
+++ b/internal/parse/nested_conditional_pattern_test.go
@@ -200,20 +200,20 @@ func TestNestedPatternBatchUsesConstantLegacyDelimiterLookups(t *testing.T) {
 			t.Fatalf("parseTree() error = %v, want %q", firstErr, invalidAlternationOperator)
 		}
 		lookups := 0
-		candidates, islands, ok := collectNestedPatternCandidates(
+		scan, ok := scanConditionalPatterns(
 			original,
 			int(parseErr.Pos.Offset()),
 			nil,
 			func() { lookups++ },
 		)
 		if !ok {
-			t.Fatal("collectNestedPatternCandidates() rejected native-valid legacy substitutions")
+			t.Fatal("scanConditionalPatterns() rejected native-valid legacy substitutions")
 		}
-		if len(candidates) != scale {
-			t.Fatalf("candidate count = %d, want %d", len(candidates), scale)
+		if len(scan.candidates) != scale {
+			t.Fatalf("candidate count = %d, want %d", len(scan.candidates), scale)
 		}
-		if len(islands) != scale {
-			t.Fatalf("legacy island count = %d, want %d", len(islands), scale)
+		if len(scan.backtickIslands) != scale {
+			t.Fatalf("legacy island count = %d, want %d", len(scan.backtickIslands), scale)
 		}
 		if lookups == 0 {
 			t.Fatal("legacy delimiter lookups = 0, want production observations")

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -72,6 +72,9 @@ func Parse(r io.Reader, name string) (*File, error) {
 			}
 		}
 	}
+	if err := validateConditionalPatterns(src, name); err != nil {
+		return nil, err
+	}
 	text := strings.TrimSuffix(string(src), "\n")
 	return &File{tree: tree, lines: strings.Split(text, "\n")}, nil
 }

--- a/internal/parse/testdata/invalid-120-unmatched-conditional-pattern.txt
+++ b/internal/parse/testdata/invalid-120-unmatched-conditional-pattern.txt
@@ -1,0 +1,2 @@
+print before
+[[ $line == ((a|b) ]]


### PR DESCRIPTION
## Summary

- Reject nested conditional pattern groups that native Zsh rejects but the parser front end previously accepted.
- Preserve valid nested pattern alternation and original source positions.
- Add regression fixtures and document the parser-gap validation boundary.

## Validation

- `go build ./...`
- `go vet ./...`
- `go test ./... -count=1`
- `git diff --check origin/next...HEAD`

Closes #120