### PR TITLE
fix(parse): support grouped Zsh case patterns

### DIFF
--- a/internal/parse/grouped_case_pattern.go
+++ b/internal/parse/grouped_case_pattern.go
@@ -1,0 +1,50 @@
+package parse
+
+import (
+	"bytes"
+	"errors"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+const invalidGroupedCasePatternCloser = "`)` can only be used to close a subshell"
+
+// parseGroupedCasePattern retries only the documented Zsh case-arm grouping
+// boundary. The scanner masks structural grouping bytes, never the final
+// case-arm terminator, then restores the original AST literals byte for byte.
+func parseGroupedCasePattern(src []byte, name string, firstErr error) (*syntax.File, error) {
+	var parseErr syntax.ParseError
+	if !errors.As(firstErr, &parseErr) || parseErr.Text != invalidGroupedCasePatternCloser {
+		return nil, firstErr
+	}
+
+	scan, ok := scanConditionalPatterns(src, int(parseErr.Pos.Offset()), nil)
+	if !ok {
+		return nil, firstErr
+	}
+	var edits []patternEdit
+	for _, candidate := range scan.groupedCasePatterns {
+		if candidate.seed {
+			edits = append(edits, candidate.edits...)
+		}
+	}
+	if len(edits) == 0 {
+		return nil, firstErr
+	}
+
+	masked := bytes.Clone(src)
+	for _, edit := range edits {
+		if edit.offset < 0 || edit.offset >= len(masked) || masked[edit.offset] != edit.original {
+			return nil, firstErr
+		}
+		masked[edit.offset] = edit.replacement
+	}
+	tree, err := parseTree(masked, name)
+	if err != nil {
+		return nil, err
+	}
+	if err := restorePatternEdits(tree, src, edits); err != nil {
+		return nil, err
+	}
+	return tree, nil
+}

--- a/internal/parse/grouped_case_pattern_test.go
+++ b/internal/parse/grouped_case_pattern_test.go
@@ -1,0 +1,95 @@
+package parse
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// This catches removing the local parser-boundary compatibility adapter for
+// native-valid case patterns whose inner group closes immediately before the
+// case-arm terminator.
+func TestParseGroupedCasePattern(t *testing.T) {
+	const src = "case x in\n  (x|y)) : ;;\nesac\n"
+
+	file, err := Parse(strings.NewReader(src), "grouped-case-pattern.zsh")
+	if err != nil {
+		t.Fatalf("Parse() error: %v", err)
+	}
+	if got := len(file.AST().Stmts); got != 1 {
+		t.Errorf("statement count = %d, want 1", got)
+	}
+	var rendered bytes.Buffer
+	if err := syntax.NewPrinter().Print(&rendered, file.AST()); err != nil {
+		t.Fatalf("print AST: %v", err)
+	}
+	// The printer omits the optional case-arm opener, but the second closing
+	// parenthesis remains part of the restored last pattern before the arm
+	// terminator it renders.
+	if got := rendered.String(); !strings.Contains(got, "x | y))") {
+		t.Errorf("printed AST = %q, want original grouped case pattern", got)
+	}
+}
+
+// These controls catch masking structural parentheses outside the exact case
+// pattern boundary, or accepting an extra unmatched group closer.
+func TestParseGroupedCasePatternControls(t *testing.T) {
+	valid := []struct {
+		name string
+		src  string
+	}{
+		{name: "ungrouped alternatives", src: "case x in\n  (x|y) : ;;\nesac\n"},
+		{name: "command substitution", src: "case x in\n  ($(print x)|y)) : ;;\nesac\n"},
+		{name: "process substitution", src: "case x in\n  (<(print x)|y)) : ;;\nesac\n"},
+	}
+	for _, test := range valid {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := Parse(strings.NewReader(test.src), "grouped-case-control.zsh"); err != nil {
+				t.Fatalf("Parse() error: %v", err)
+			}
+		})
+	}
+
+	const malformed = "case x in\n  (x|y))) : ;;\nesac\n"
+	if _, err := Parse(strings.NewReader(malformed), "malformed-grouped-case.zsh"); err == nil {
+		t.Fatal("Parse() accepted a native-invalid grouped case pattern")
+	}
+}
+
+// A deeper native-valid group currently hits a different mvdan/sh error. The
+// #123 adapter must not replace that error with a secondary transformation
+// failure or silently broaden its recognized grammar.
+func TestParseGroupedCasePatternLeavesDifferentParserGapUntouched(t *testing.T) {
+	const src = "case x in\n  ((x|y))) : ;;\nesac\n"
+	_, firstErr := parseTree([]byte(src), "nested-grouped-case.zsh")
+	if firstErr == nil {
+		t.Fatal("parseTree() unexpectedly accepted the nested grouped case")
+	}
+	_, err := Parse(strings.NewReader(src), "nested-grouped-case.zsh")
+	if err == nil {
+		t.Fatal("Parse() unexpectedly accepted the nested grouped case")
+	}
+	if err.Error() != firstErr.Error() {
+		t.Errorf("Parse() error = %q, want original parser error %q", err, firstErr)
+	}
+}
+
+// The same-length masked retry must preserve locations for syntax errors that
+// occur after a successfully adapted case arm.
+func TestParseGroupedCasePatternPreservesLaterErrorPosition(t *testing.T) {
+	const src = "case x in\n  (x|y)) : ;;\nesac\n)\n"
+	_, err := Parse(strings.NewReader(src), "later-error.zsh")
+	if err == nil {
+		t.Fatal("Parse() unexpectedly accepted trailing unmatched parenthesis")
+	}
+	var parseErr syntax.ParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("error type = %T, want syntax.ParseError: %v", err, err)
+	}
+	if parseErr.Pos.Line() != 4 || parseErr.Pos.Col() != 1 {
+		t.Errorf("error position = %d:%d, want 4:1", parseErr.Pos.Line(), parseErr.Pos.Col())
+	}
+}

--- a/internal/parse/nested_conditional_pattern.go
+++ b/internal/parse/nested_conditional_pattern.go
@@ -59,8 +59,15 @@ const (
 
 type activeCaseContext struct {
 	phase             activeCasePhase
+	start             int
 	patternParenDepth int
 	inBracketPattern  bool
+	edits             []patternEdit
+}
+
+type groupedCasePatternCandidate struct {
+	edits []patternEdit
+	seed  bool
 }
 
 type pendingHeredoc struct {
@@ -108,9 +115,10 @@ type conditionalPatternFinding struct {
 }
 
 type conditionalPatternScan struct {
-	candidates      []patternCandidate
-	backtickIslands []legacyBacktickIsland
-	finding         *conditionalPatternFinding
+	candidates          []patternCandidate
+	groupedCasePatterns []groupedCasePatternCandidate
+	backtickIslands     []legacyBacktickIsland
+	finding             *conditionalPatternFinding
 }
 
 type activeConditionalContext struct {
@@ -265,6 +273,7 @@ func scanConditionalPatterns(
 	legacyLookupProbes ...activeLegacyLookupProbe,
 ) (conditionalPatternScan, bool) {
 	var candidates []patternCandidate
+	var groupedCasePatterns []groupedCasePatternCandidate
 	var backtickRoots []*legacyBacktickSpan
 	var finding *conditionalPatternFinding
 	var inspectLegacyLookup activeLegacyLookupProbe
@@ -414,7 +423,10 @@ func scanConditionalPatterns(
 		if frame.conditional == nil && frame.atWordStart && frame.atCommandStart &&
 			(currentCase == nil || currentCase.phase == activeCaseBody) &&
 			activeSourceWordAt(src, i, "case") {
-			frame.caseContexts = append(frame.caseContexts, activeCaseContext{phase: activeCaseSubject})
+			frame.caseContexts = append(frame.caseContexts, activeCaseContext{
+				phase: activeCaseSubject,
+				start: i,
+			})
 			i += len("case") - 1
 			frame.atWordStart = false
 			frame.atCommandStart = false
@@ -561,16 +573,34 @@ func scanConditionalPatterns(
 				frame.atCommandStart = false
 				continue
 			case '(':
+				if currentCase.patternParenDepth > 0 {
+					currentCase.edits = append(currentCase.edits, patternEdit{
+						offset:      i,
+						original:    '(',
+						replacement: nestedPatternMask,
+					})
+				}
 				currentCase.patternParenDepth++
 				frame.atWordStart = false
 				frame.atCommandStart = false
 				continue
 			case ')':
 				if currentCase.patternParenDepth > 0 {
+					currentCase.edits = append(currentCase.edits, patternEdit{
+						offset:      i,
+						original:    ')',
+						replacement: nestedPatternMask,
+					})
 					currentCase.patternParenDepth--
 					frame.atWordStart = false
 					frame.atCommandStart = false
 				} else {
+					if len(currentCase.edits) > 0 {
+						groupedCasePatterns = append(groupedCasePatterns, groupedCasePatternCandidate{
+							edits: append([]patternEdit(nil), currentCase.edits...),
+							seed:  currentCase.start <= seedOffset && seedOffset <= i,
+						})
+					}
 					currentCase.phase = activeCaseBody
 					frame.atWordStart = true
 					frame.atCommandStart = true
@@ -691,9 +721,10 @@ func scanConditionalPatterns(
 		return conditionalPatternScan{}, false
 	}
 	return conditionalPatternScan{
-		candidates:      candidates,
-		backtickIslands: islands,
-		finding:         finding,
+		candidates:          candidates,
+		groupedCasePatterns: groupedCasePatterns,
+		backtickIslands:     islands,
+		finding:             finding,
 	}, true
 }
 

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -66,7 +66,10 @@ func Parse(r io.Reader, name string) (*File, error) {
 				if err != nil {
 					tree, err = parseTryAlways(src, name, err)
 					if err != nil {
-						return nil, err
+						tree, err = parseGroupedCasePattern(src, name, err)
+						if err != nil {
+							return nil, err
+						}
 					}
 				}
 			}

--- a/internal/survey/corpus_test.go
+++ b/internal/survey/corpus_test.go
@@ -19,6 +19,7 @@ var requiredFixtures = []string{
 	"ok-baseline.zsh",
 	"ok-brace-termination.zsh",
 	"ok-glob-patterns.zsh",
+	"ok-grouped-case-pattern.zsh",
 	"ok-multi-name-loop.zsh",
 	"ok-nested-conditional-alternation.zsh",
 	"ok-nested-param-expansion.zsh",

--- a/internal/survey/testdata/corpus/ok-grouped-case-pattern.zsh
+++ b/internal/survey/testdata/corpus/ok-grouped-case-pattern.zsh
@@ -1,0 +1,7 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# Issue #123: grouped Zsh case patterns close before the case-arm terminator.
+# Preserved as permanent regression coverage.
+case x in
+  (x|y)) : ;;
+esac


### PR DESCRIPTION
## Summary

- add a narrowly gated parser-boundary adapter for native-valid grouped Zsh case patterns
- restore masked AST literals byte-for-byte, preserving source positions and the case-arm terminator
- add public parser coverage plus a permanent native-valid corpus fixture

Closes #123.

## Validation

- `zsh -f -n internal/survey/testdata/corpus/ok-grouped-case-pattern.zsh`
- `go build ./... && go vet ./... && go test ./... -count=1`
- commit hook checks passed for all six changed files

`trunk check --all --no-progress` remains environment-blocked because its configured gitleaks binary is absent from the shared Trunk cache for every file, including untouched files.