### PR TITLE
feat: parse strict rollout reference corpus

### DIFF
--- a/docs/project/2026-08-16-readiness-gate.md
+++ b/docs/project/2026-08-16-readiness-gate.md
@@ -19,7 +19,7 @@ change is reviewed and published.
 
 | Repository                      | Local branch                    | Base revision | Candidate commit |
 | ------------------------------- | ------------------------------- | ------------- | ---------------- |
-| `z-shell/zsh-lint`              | `feature-129-rollout-readiness` | `8facdaf`     | pending          |
+| `z-shell/zsh-lint`              | `feature-129-rollout-readiness` | `8facdaf`     | `e58316f`        |
 | `z-shell/src`                   | `feature-180-zsh-lint-warnings` | `9633151`     | `baa5268`        |
 | `z-shell/zd`                    | `feature-97-zsh-lint-warning`   | `626f0cb`     | `29a6e85`        |
 | `z-shell/z-a-meta-plugins`      | `feature-41-zsh-lint-findings`  | `c88d62a`     | `dabbc80`        |

--- a/docs/project/2026-08-16-readiness-gate.md
+++ b/docs/project/2026-08-16-readiness-gate.md
@@ -1,0 +1,93 @@
+# Organization Rollout Readiness Gate, 2026-08-16
+
+## Decision
+
+The local mixed-worktree candidate satisfies the strict reference-corpus gate:
+
+- 19 files surveyed, 19 parsed, 0 failed;
+- 0 error-level diagnostics;
+- 0 warning-level diagnostics;
+- no suppression directive, ignored path, waiver, or severity downgrade; and
+- 4 info and 2 hint diagnostics recorded below, outside the strict gate.
+
+This is implementation evidence, not rollout authority. The changes below are
+committed locally, but organization rollout, required-check configuration,
+publication, and release work remain out of scope until each owning repository
+change is reviewed and published.
+
+## Candidate revisions
+
+| Repository                      | Local branch                    | Base revision | Candidate commit |
+| ------------------------------- | ------------------------------- | ------------- | ---------------- |
+| `z-shell/zsh-lint`              | `feature-129-rollout-readiness` | `8facdaf`     | pending          |
+| `z-shell/src`                   | `feature-180-zsh-lint-warnings` | `9633151`     | `baa5268`        |
+| `z-shell/zd`                    | `feature-97-zsh-lint-warning`   | `626f0cb`     | `29a6e85`        |
+| `z-shell/z-a-meta-plugins`      | `feature-41-zsh-lint-findings`  | `c88d62a`     | `dabbc80`        |
+| `z-shell/zsh-eza`               | `feature-93-zsh-lint-finding`   | `820ff48`     | `93fb8c9`        |
+| `z-shell/zsh-fancy-completions` | `feature-51-zsh-lint-findings`  | `5f5a002`     | `734bd1b`        |
+
+The unchanged `z-shell/zunit` corpus file came from the meta-workspace checkout.
+
+## Parser result
+
+The documented command shape from [corpus.md](corpus.md), pointed at the six
+candidate worktrees, produced:
+
+```text
+19 file(s) surveyed, 19 ok, 0 failed
+```
+
+The local front end provides narrowly gated compatibility for these native-Zsh
+forms that the pinned parser rejects:
+
+- bare associative subscript keys beginning with a dot or containing the
+  punctuation used by the Zi communication keys;
+- `${^name}` RC_EXPAND_PARAM syntax;
+- pattern-bearing `(i)`, `(I)`, `(r)`, and `(R)` subscripts; and
+- composed alternate brace-form `if` and `while` constructs in the annex
+  handler.
+
+Each same-width mask is restored in the typed AST. Focused tests cover original
+rendered text, later-error positions, malformed forms, multiple keys, and the
+full real-file paths.
+
+## Analyzer result
+
+Normal analyzer execution with `--format=json` over the same 19 paths produced:
+
+```json
+{
+  "files": 19,
+  "diagnostics": 6,
+  "errors": 0,
+  "warnings": 0,
+  "infos": 4,
+  "hints": 2
+}
+```
+
+The remaining non-gating diagnostics are transparent:
+
+- 2 `plugin/function-scoped-options` hints in completion functions; and
+- 4 `security/eval` info diagnostics in `lib/state.zsh`.
+
+No diagnostic was suppressed or reclassified to obtain this result.
+
+## Source remediation ownership
+
+- Organization parent: [z-shell/.github#504](https://github.com/z-shell/.github/issues/504)
+- Parser work: [zsh-lint#15](https://github.com/z-shell/zsh-lint/issues/15),
+  [#60](https://github.com/z-shell/zsh-lint/issues/60),
+  [#61](https://github.com/z-shell/zsh-lint/issues/61), and
+  [#129](https://github.com/z-shell/zsh-lint/issues/129)
+- Consumer findings: [src#180](https://github.com/z-shell/src/issues/180),
+  [zd#97](https://github.com/z-shell/zd/issues/97),
+  [z-a-meta-plugins#41](https://github.com/z-shell/z-a-meta-plugins/issues/41),
+  [zsh-eza#93](https://github.com/z-shell/zsh-eza/issues/93), and
+  [zsh-fancy-completions#51](https://github.com/z-shell/zsh-fancy-completions/issues/51)
+
+## Publication boundary
+
+Before this evidence can authorize organization rollout, each owning repository
+must publish its reviewed change, CI must pass on the published revision, and
+the organization rollout must be separately authorized.

--- a/internal/parse/alternate_if.go
+++ b/internal/parse/alternate_if.go
@@ -453,7 +453,7 @@ func scanAlternateConditionBrace(src []byte, i int) int {
 		if i < len(src) && src[i] == '{' {
 			return i
 		}
-		if i+1 >= len(src) || !((src[i] == '&' && src[i+1] == '&') || (src[i] == '|' && src[i+1] == '|')) {
+		if i+1 >= len(src) || (src[i] != '&' || src[i+1] != '&') && (src[i] != '|' || src[i+1] != '|') {
 			return i
 		}
 		i = skipAlternateConditionSpaces(src, i+2)

--- a/internal/parse/alternate_if.go
+++ b/internal/parse/alternate_if.go
@@ -20,6 +20,8 @@ const (
 	editElse
 	editChain
 	editFi
+	editWhileDo
+	editDone
 )
 
 type alternateIfEdit struct {
@@ -33,7 +35,21 @@ type alternateIfSourceMap struct {
 }
 
 func parseAlternateIfBrace(src []byte, name string, firstErr error) (*syntax.File, error) {
-	return parseAlternateIfBraceWithParser(src, name, firstErr, parseTree)
+	return parseAlternateIfBraceWithParser(src, name, firstErr, parseAfterAlternateIf)
+}
+
+// parseAfterAlternateIf lets independently gated, same-boundary adapters
+// compose when one real file contains more than one unsupported Zsh form.
+// Each adapter still activates only from its own concrete parser error.
+func parseAfterAlternateIf(src []byte, name string) (*syntax.File, error) {
+	tree, err := parseTree(src, name)
+	if err != nil {
+		tree, err = parseAssociativeSubscriptWithParser(src, name, err, parseAfterAlternateIf)
+		if err != nil {
+			tree, err = parseMultiNameForWithParser(src, name, err, parseAfterAlternateIf)
+		}
+	}
+	return tree, err
 }
 
 func parseAlternateIfBraceWithParser(
@@ -85,6 +101,7 @@ func scanAlternateIfEdits(src []byte, seedOffset int) ([]alternateIfEdit, bool) 
 		kindIfThen
 		kindElifThen
 		kindElse
+		kindWhileDo
 	)
 	type blockFrame struct {
 		kind       blockKind
@@ -98,6 +115,7 @@ func scanAlternateIfEdits(src []byte, seedOffset int) ([]alternateIfEdit, bool) 
 		ifSawIf
 		ifSawElif
 		ifSawElse
+		ifSawWhile
 	)
 	currentIf := ifNone
 
@@ -210,14 +228,21 @@ func scanAlternateIfEdits(src []byte, seedOffset int) ([]alternateIfEdit, bool) 
 				atCommandStart = false
 				continue
 			}
+			if matchSourceWord(src, i, "while") {
+				currentIf = ifSawWhile
+				i += 5
+				atWordStart = false
+				atCommandStart = false
+				continue
+			}
 		}
 
-		if currentIf == ifSawIf || currentIf == ifSawElif {
+		if currentIf == ifSawIf || currentIf == ifSawElif || currentIf == ifSawWhile {
 			if b == '[' && i+1 < len(src) && src[i+1] == '[' {
 				end := scanClosingDoubleBracket(src, i)
 				if end > i {
 					i = end
-					braceOffset := skipSpacesAndComments(src, i)
+					braceOffset := scanAlternateConditionBrace(src, i)
 					if braceOffset < len(src) && src[braceOffset] == '{' {
 						if braceOffset == seedOffset {
 							seedRecognized = true
@@ -225,11 +250,15 @@ func scanAlternateIfEdits(src []byte, seedOffset int) ([]alternateIfEdit, bool) 
 						kind := editIfThen
 						if currentIf == ifSawElif {
 							kind = editElifThen
+						} else if currentIf == ifSawWhile {
+							kind = editWhileDo
 						}
 						edits = append(edits, alternateIfEdit{offset: braceOffset, kind: kind})
 						bk := kindIfThen
 						if currentIf == ifSawElif {
 							bk = kindElifThen
+						} else if currentIf == ifSawWhile {
+							bk = kindWhileDo
 						}
 						blockStack = append(blockStack, blockFrame{kind: bk, openOffset: braceOffset})
 						currentIf = ifNone
@@ -244,7 +273,7 @@ func scanAlternateIfEdits(src []byte, seedOffset int) ([]alternateIfEdit, bool) 
 				end := scanClosingDoubleParen(src, i)
 				if end > i {
 					i = end
-					braceOffset := skipSpacesAndComments(src, i)
+					braceOffset := scanAlternateConditionBrace(src, i)
 					if braceOffset < len(src) && src[braceOffset] == '{' {
 						if braceOffset == seedOffset {
 							seedRecognized = true
@@ -252,11 +281,15 @@ func scanAlternateIfEdits(src []byte, seedOffset int) ([]alternateIfEdit, bool) 
 						kind := editIfThen
 						if currentIf == ifSawElif {
 							kind = editElifThen
+						} else if currentIf == ifSawWhile {
+							kind = editWhileDo
 						}
 						edits = append(edits, alternateIfEdit{offset: braceOffset, kind: kind})
 						bk := kindIfThen
 						if currentIf == ifSawElif {
 							bk = kindElifThen
+						} else if currentIf == ifSawWhile {
+							bk = kindWhileDo
 						}
 						blockStack = append(blockStack, blockFrame{kind: bk, openOffset: braceOffset})
 						currentIf = ifNone
@@ -323,13 +356,27 @@ func scanAlternateIfEdits(src []byte, seedOffset int) ([]alternateIfEdit, bool) 
 			if len(blockStack) > 0 {
 				top := blockStack[len(blockStack)-1]
 				blockStack = blockStack[:len(blockStack)-1]
+				nextWordOffset := skipSpacesAndComments(src, i+1)
+				if top.kind == kindWhileDo {
+					edits = append(edits, alternateIfEdit{offset: i, kind: editDone})
+					i++
+					atWordStart = true
+					atCommandStart = true
+					continue
+				}
 				if top.kind == kindIfThen || top.kind == kindElifThen || top.kind == kindElse {
-					nextWordOffset := skipSpacesAndComments(src, i+1)
 					if nextWordOffset < len(src) && (matchSourceWord(src, nextWordOffset, "elif") || matchSourceWord(src, nextWordOffset, "else")) {
 						edits = append(edits, alternateIfEdit{offset: i, kind: editChain})
 					} else {
 						edits = append(edits, alternateIfEdit{offset: i, kind: editFi})
 					}
+					i++
+					atWordStart = true
+					atCommandStart = true
+					continue
+				}
+				if nextWordOffset < len(src) && (matchSourceWord(src, nextWordOffset, "elif") || matchSourceWord(src, nextWordOffset, "else")) {
+					edits = append(edits, alternateIfEdit{offset: i, kind: editChain})
 					i++
 					atWordStart = true
 					atCommandStart = true
@@ -398,6 +445,44 @@ func skipSpacesAndComments(src []byte, i int) int {
 		break
 	}
 	return i
+}
+
+func scanAlternateConditionBrace(src []byte, i int) int {
+	for {
+		i = skipAlternateConditionSpaces(src, i)
+		if i < len(src) && src[i] == '{' {
+			return i
+		}
+		if i+1 >= len(src) || !((src[i] == '&' && src[i+1] == '&') || (src[i] == '|' && src[i+1] == '|')) {
+			return i
+		}
+		i = skipAlternateConditionSpaces(src, i+2)
+		for i < len(src) && src[i] == '!' {
+			i = skipAlternateConditionSpaces(src, i+1)
+		}
+		switch {
+		case i+1 < len(src) && src[i] == '[' && src[i+1] == '[':
+			i = scanClosingDoubleBracket(src, i)
+		case i+1 < len(src) && src[i] == '(' && src[i+1] == '(':
+			i = scanClosingDoubleParen(src, i)
+		default:
+			return i
+		}
+		if i < 0 {
+			return len(src)
+		}
+	}
+}
+
+func skipAlternateConditionSpaces(src []byte, i int) int {
+	for {
+		next := skipSpacesAndComments(src, i)
+		if next < len(src) && src[next] == '\\' && next+1 < len(src) && src[next+1] == '\n' {
+			i = next + 2
+			continue
+		}
+		return next
+	}
 }
 
 func scanClosingDoubleBracket(src []byte, start int) int {
@@ -485,12 +570,16 @@ func applyAlternateIfEdits(src []byte, edits []alternateIfEdit) ([]byte, alterna
 			switch edit.kind {
 			case editIfThen, editElifThen:
 				appendSynthetic("; then\n", i)
+			case editWhileDo:
+				appendSynthetic("; do\n", i)
 			case editElse:
 				appendSynthetic("\n", i)
 			case editChain:
 				appendSynthetic("\n", i)
 			case editFi:
 				appendSynthetic("\nfi\n", i)
+			case editDone:
+				appendSynthetic("\ndone\n", i)
 			}
 			continue
 		}

--- a/internal/parse/alternate_if_test.go
+++ b/internal/parse/alternate_if_test.go
@@ -31,6 +31,14 @@ func TestParseAlternateIfBrace(t *testing.T) {
 			wantStmts: 1,
 		},
 		{
+			name: "alternate while with arithmetic condition",
+			src: `while (( count < 3 )) {
+  (( count++ ))
+}
+`,
+			wantStmts: 1,
+		},
+		{
 			name: "brace condition",
 			src: `if { true } {
   print "brace"
@@ -46,6 +54,15 @@ func TestParseAlternateIfBrace(t *testing.T) {
   print "two"
 } else {
   print "three"
+}
+`,
+			wantStmts: 1,
+		},
+		{
+			name: "alternate if with compound conditions",
+			src: `if (( first )) && \
+  [[ -n $second ]] || [[ $third == yes ]] {
+  print -r -- matched
 }
 `,
 			wantStmts: 1,

--- a/internal/parse/parameter_compat.go
+++ b/internal/parse/parameter_compat.go
@@ -1,0 +1,123 @@
+package parse
+
+import (
+	"bytes"
+	"errors"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+const invalidReverseGlob = "`*` must follow an expression"
+
+func parseRCExpandCaret(src []byte, name string, firstErr error) (*syntax.File, error) {
+	return parseRCExpandCaretWithParser(src, name, firstErr, parseRCExpandCarets)
+}
+
+func parseRCExpandCarets(src []byte, name string) (*syntax.File, error) {
+	tree, err := parseTree(src, name)
+	if err != nil {
+		return parseRCExpandCaretWithParser(src, name, err, parseRCExpandCarets)
+	}
+	return tree, nil
+}
+
+func parseRCExpandCaretWithParser(
+	src []byte,
+	name string,
+	firstErr error,
+	parse func([]byte, string) (*syntax.File, error),
+) (*syntax.File, error) {
+	var langErr syntax.LangError
+	if !errors.As(firstErr, &langErr) || langErr.Feature != "this expansion operator" || langErr.LangUsed != syntax.LangZsh {
+		return nil, firstErr
+	}
+	seed := int(langErr.Pos.Offset())
+	offset := -1
+	for candidate := seed - 1; candidate <= seed+1; candidate++ {
+		if candidate >= 2 && candidate < len(src) && src[candidate] == '^' && src[candidate-1] == '{' && src[candidate-2] == '$' {
+			offset = candidate
+			break
+		}
+	}
+	if offset < 0 {
+		return nil, firstErr
+	}
+
+	masked := bytes.Clone(src)
+	masked[offset] = 'x'
+	edit := patternEdit{offset: offset, original: '^', replacement: 'x'}
+	tree, err := parse(masked, name)
+	if err != nil {
+		return nil, err
+	}
+	if err := restorePatternEdits(tree, src, []patternEdit{edit}); err != nil {
+		return nil, err
+	}
+	return tree, nil
+}
+
+func parseReverseSubscript(src []byte, name string, firstErr error) (*syntax.File, error) {
+	return parseReverseSubscriptWithParser(src, name, firstErr, parseReverseSubscripts)
+}
+
+func parseReverseSubscripts(src []byte, name string) (*syntax.File, error) {
+	tree, err := parseTree(src, name)
+	if err != nil {
+		return parseReverseSubscriptWithParser(src, name, err, parseReverseSubscripts)
+	}
+	return tree, nil
+}
+
+func parseReverseSubscriptWithParser(
+	src []byte,
+	name string,
+	firstErr error,
+	parse func([]byte, string) (*syntax.File, error),
+) (*syntax.File, error) {
+	var parseErr syntax.ParseError
+	if !errors.As(firstErr, &parseErr) || parseErr.Text != invalidReverseGlob {
+		return nil, firstErr
+	}
+	seed := int(parseErr.Pos.Offset())
+	if seed < 0 || seed >= len(src) || src[seed] != '*' {
+		return nil, firstErr
+	}
+	open := seed
+	for open > 0 && src[open] != '[' && src[open] != ']' && src[open] != '\n' {
+		open--
+	}
+	closeRelative := bytes.IndexByte(src[seed:], ']')
+	if src[open] != '[' || closeRelative < 1 {
+		return nil, firstErr
+	}
+	close := seed + closeRelative
+	key := src[open+1 : close]
+	if len(key) <= 3 || key[0] != '(' || key[2] != ')' || !bytes.ContainsRune([]byte("iIrR"), rune(key[1])) {
+		return nil, firstErr
+	}
+
+	masked := bytes.Clone(src)
+	var edits []patternEdit
+	for offset := open + 4; offset < close; offset++ {
+		if isIdentByte(masked[offset]) {
+			continue
+		}
+		if masked[offset] != '-' && masked[offset] != '*' && masked[offset] != '?' {
+			return nil, firstErr
+		}
+		edits = append(edits, patternEdit{offset: offset, original: masked[offset], replacement: '_'})
+		masked[offset] = '_'
+	}
+	if len(edits) == 0 {
+		return nil, firstErr
+	}
+
+	tree, err := parse(masked, name)
+	if err != nil {
+		return nil, err
+	}
+	if err := restorePatternEdits(tree, src, edits); err != nil {
+		return nil, err
+	}
+	return tree, nil
+}

--- a/internal/parse/parameter_compat_test.go
+++ b/internal/parse/parameter_compat_test.go
@@ -1,0 +1,90 @@
+package parse
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+func TestParseNativeParameterExpansionCompatibility(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "rc expand caret",
+			src:  "print -r -- ${^manpath}\n",
+			want: "${^manpath}",
+		},
+		{
+			name: "reverse subscript pattern",
+			src:  "print -r -- ${_comps[(I)-value-*]}\n",
+			want: "[(I)-value-*]",
+		},
+		{
+			name: "forward index subscript pattern",
+			src:  "print -r -- ${_comps[(i)-value-*]}\n",
+			want: "[(i)-value-*]",
+		},
+		{
+			name: "reverse value subscript pattern",
+			src:  "print -r -- ${_comps[(R)-value-*]}\n",
+			want: "[(R)-value-*]",
+		},
+		{
+			name: "forward value subscript pattern",
+			src:  "print -r -- ${_comps[(r)-value-*]}\n",
+			want: "[(r)-value-*]",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			file, err := Parse(strings.NewReader(test.src), test.name+".zsh")
+			if err != nil {
+				t.Fatalf("Parse() error: %v", err)
+			}
+			var rendered bytes.Buffer
+			if err := syntax.NewPrinter().Print(&rendered, file.AST()); err != nil {
+				t.Fatalf("print AST: %v", err)
+			}
+			if !strings.Contains(rendered.String(), test.want) {
+				t.Errorf("printed AST = %q, want original expansion %q", rendered.String(), test.want)
+			}
+		})
+	}
+}
+
+func TestParameterCompatibilityPreservesLaterErrorPosition(t *testing.T) {
+	for _, src := range []string{
+		"print -r -- ${^manpath}\n)\n",
+		"print -r -- ${_comps[(I)-value-*]}\n)\n",
+	} {
+		_, err := Parse(strings.NewReader(src), "later-error.zsh")
+		if err == nil {
+			t.Fatal("Parse() unexpectedly accepted a trailing unmatched parenthesis")
+		}
+		var parseErr syntax.ParseError
+		if !errors.As(err, &parseErr) {
+			t.Fatalf("error type = %T, want syntax.ParseError: %v", err, err)
+		}
+		if parseErr.Pos.Line() != 2 || parseErr.Pos.Col() != 1 {
+			t.Errorf("error position = %d:%d, want 2:1", parseErr.Pos.Line(), parseErr.Pos.Col())
+		}
+	}
+}
+
+func TestParameterCompatibilityRejectsMalformedForms(t *testing.T) {
+	for _, src := range []string{
+		"print -r -- ${^manpath\n",
+		"print -r -- ${_comps[(I)-value-*}\n",
+	} {
+		if _, err := Parse(strings.NewReader(src), "malformed.zsh"); err == nil {
+			t.Fatalf("Parse(%q) unexpectedly succeeded", src)
+		}
+	}
+}

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -62,13 +62,22 @@ func Parse(r io.Reader, name string) (*File, error) {
 		if err != nil {
 			tree, err = parseAlternateIfBrace(src, name, err)
 			if err != nil {
-				tree, err = parseMultiNameFor(src, name, err)
+				tree, err = parseAssociativeSubscript(src, name, err)
 				if err != nil {
-					tree, err = parseTryAlways(src, name, err)
+					tree, err = parseRCExpandCaret(src, name, err)
 					if err != nil {
-						tree, err = parseGroupedCasePattern(src, name, err)
+						tree, err = parseReverseSubscript(src, name, err)
 						if err != nil {
-							return nil, err
+							tree, err = parseMultiNameFor(src, name, err)
+							if err != nil {
+								tree, err = parseTryAlways(src, name, err)
+								if err != nil {
+									tree, err = parseGroupedCasePattern(src, name, err)
+									if err != nil {
+										return nil, err
+									}
+								}
+							}
 						}
 					}
 				}

--- a/internal/parse/subscript_compat.go
+++ b/internal/parse/subscript_compat.go
@@ -1,0 +1,109 @@
+package parse
+
+import (
+	"bytes"
+	"errors"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+const (
+	invalidSubscriptExpression = "`[` must be followed by an expression"
+	invalidSubscriptTernary    = "ternary operator missing `?` before `:`"
+)
+
+// parseAssociativeSubscript retries only native-Zsh bare associative keys that
+// mvdan/sh mistakes for arithmetic syntax. The retry masks punctuation with
+// same-width identifier bytes and restores every changed AST literal.
+func parseAssociativeSubscript(src []byte, name string, firstErr error) (*syntax.File, error) {
+	return parseAssociativeSubscriptWithParser(src, name, firstErr, parseAssociativeSubscripts)
+}
+
+func parseAssociativeSubscripts(src []byte, name string) (*syntax.File, error) {
+	tree, err := parseTree(src, name)
+	if err != nil {
+		return parseAssociativeSubscriptWithParser(src, name, err, parseAssociativeSubscripts)
+	}
+	return tree, nil
+}
+
+func parseAssociativeSubscriptWithParser(
+	src []byte,
+	name string,
+	firstErr error,
+	parse func([]byte, string) (*syntax.File, error),
+) (*syntax.File, error) {
+	var parseErr syntax.ParseError
+	if !errors.As(firstErr, &parseErr) ||
+		(parseErr.Text != invalidSubscriptExpression && parseErr.Text != invalidSubscriptTernary) {
+		return nil, firstErr
+	}
+
+	open, close, ok := findBareAssociativeKey(src, int(parseErr.Pos.Offset()), parseErr.Text)
+	if !ok {
+		return nil, firstErr
+	}
+
+	masked := bytes.Clone(src)
+	edits := make([]patternEdit, 0, close-open-1)
+	for offset := open + 1; offset < close; offset++ {
+		if isIdentByte(masked[offset]) {
+			continue
+		}
+		edits = append(edits, patternEdit{offset: offset, original: masked[offset], replacement: '_'})
+		masked[offset] = '_'
+	}
+	if len(edits) == 0 {
+		return nil, firstErr
+	}
+
+	tree, err := parse(masked, name)
+	if err != nil {
+		return nil, err
+	}
+	if err := restorePatternEdits(tree, src, edits); err != nil {
+		return nil, err
+	}
+	return tree, nil
+}
+
+func findBareAssociativeKey(src []byte, seed int, errorText string) (int, int, bool) {
+	if seed < 0 || seed >= len(src) {
+		return 0, 0, false
+	}
+
+	open := seed
+	if src[open] != '[' {
+		for open > 0 && src[open] != '[' && src[open] != ']' && src[open] != '\n' {
+			open--
+		}
+	}
+	if src[open] != '[' || open == 0 || !isIdentByte(src[open-1]) {
+		return 0, 0, false
+	}
+
+	relativeSeed := seed - open - 1
+	closeRelative := bytes.IndexByte(src[open+1:], ']')
+	if closeRelative <= 0 {
+		return 0, 0, false
+	}
+	close := open + 1 + closeRelative
+	key := src[open+1 : close]
+	for _, b := range key {
+		if !isIdentByte(b) && b != '.' && b != '-' && b != ':' && b != '@' {
+			return 0, 0, false
+		}
+	}
+
+	switch errorText {
+	case invalidSubscriptExpression:
+		if key[0] != '.' || seed != open {
+			return 0, 0, false
+		}
+	case invalidSubscriptTernary:
+		if relativeSeed < 0 || relativeSeed >= len(key) || key[relativeSeed] != ':' {
+			return 0, 0, false
+		}
+	}
+	return open, close, true
+}

--- a/internal/parse/subscript_compat_test.go
+++ b/internal/parse/subscript_compat_test.go
@@ -1,0 +1,71 @@
+package parse
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+func TestParseNativeAssociativeSubscriptKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "punctuated assignment key",
+			src:  "ZI[annex-before-load:new-@]=value\n",
+			want: "annex-before-load:new-@",
+		},
+		{
+			name: "leading dot expansion key",
+			src:  "print -r -- ${functions[.foo]}\n",
+			want: ".foo",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			file, err := Parse(strings.NewReader(test.src), test.name+".zsh")
+			if err != nil {
+				t.Fatalf("Parse() error: %v", err)
+			}
+			var rendered bytes.Buffer
+			if err := syntax.NewPrinter().Print(&rendered, file.AST()); err != nil {
+				t.Fatalf("print AST: %v", err)
+			}
+			if !strings.Contains(rendered.String(), test.want) {
+				t.Errorf("printed AST = %q, want original subscript key %q", rendered.String(), test.want)
+			}
+		})
+	}
+}
+
+func TestAssociativeSubscriptCompatibilityPreservesLaterErrorPosition(t *testing.T) {
+	const src = "print -r -- ${functions[.foo]}\n)\n"
+	_, err := Parse(strings.NewReader(src), "later-error.zsh")
+	if err == nil {
+		t.Fatal("Parse() unexpectedly accepted a trailing unmatched parenthesis")
+	}
+	var parseErr syntax.ParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("error type = %T, want syntax.ParseError: %v", err, err)
+	}
+	if parseErr.Pos.Line() != 2 || parseErr.Pos.Col() != 1 {
+		t.Errorf("error position = %d:%d, want 2:1", parseErr.Pos.Line(), parseErr.Pos.Col())
+	}
+}
+
+func TestAssociativeSubscriptCompatibilityRejectsMalformedKeys(t *testing.T) {
+	for _, src := range []string{
+		"print -r -- ${functions[.foo}\n",
+		"ZI[annex-before-load:new-@=value\n",
+	} {
+		if _, err := Parse(strings.NewReader(src), "malformed.zsh"); err == nil {
+			t.Fatalf("Parse(%q) unexpectedly succeeded", src)
+		}
+	}
+}

--- a/internal/survey/corpus_test.go
+++ b/internal/survey/corpus_test.go
@@ -14,8 +14,8 @@ import (
 // against accidental deletion without asserting a brittle total count
 // (issue #14): new fixtures can be added freely without touching this test.
 var requiredFixtures = []string{
-	"gap-15-reverse-subscript.zsh",
 	"ok-alternate-if-brace.zsh",
+	"ok-assoc-subscript-keys.zsh",
 	"ok-baseline.zsh",
 	"ok-brace-termination.zsh",
 	"ok-glob-patterns.zsh",
@@ -24,6 +24,8 @@ var requiredFixtures = []string{
 	"ok-nested-conditional-alternation.zsh",
 	"ok-nested-param-expansion.zsh",
 	"ok-param-expansion-flags.zsh",
+	"ok-rc-expand-caret.zsh",
+	"ok-reverse-subscript.zsh",
 	"ok-try-always.zsh",
 }
 

--- a/internal/survey/testdata/corpus/gap-60-rc-expand-caret.zsh
+++ b/internal/survey/testdata/corpus/gap-60-rc-expand-caret.zsh
@@ -1,5 +1,0 @@
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# Issue #60: rc-expand caret ${^spec} (zshexpn, RC_EXPAND_PARAM) does not
-# parse under LangZsh; minimized from zsh-fancy-completions .man_glob.
-print -- ${^manpath}

--- a/internal/survey/testdata/corpus/gap-61-assoc-subscript-leading-dot.zsh
+++ b/internal/survey/testdata/corpus/gap-61-assoc-subscript-leading-dot.zsh
@@ -1,6 +1,0 @@
-# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
-# vim: ft=zsh sw=2 ts=2 et
-# Issue #61: associative-array subscripts beginning with a dot (zshparam,
-# Array Subscripts) do not parse under LangZsh; minimized from the
-# ${+functions[.zsh-eza]} probe in zsh-eza.plugin.zsh.
-print ${functions[.foo]}

--- a/internal/survey/testdata/corpus/ok-assoc-subscript-keys.zsh
+++ b/internal/survey/testdata/corpus/ok-assoc-subscript-keys.zsh
@@ -1,0 +1,6 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+# Issues #61 and #129: native-Zsh bare associative keys may begin with a dot
+# or contain punctuation that mvdan/sh otherwise treats as arithmetic syntax.
+print ${functions[.foo]}
+ZI[annex-before-load:new-@]=value

--- a/internal/survey/testdata/corpus/ok-rc-expand-caret.zsh
+++ b/internal/survey/testdata/corpus/ok-rc-expand-caret.zsh
@@ -1,3 +1,4 @@
 # -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
 # vim: ft=zsh sw=2 ts=2 et
-print -r -- ${~pattern}
+# Issue #60: rc-expand caret syntax from zshexpn and RC_EXPAND_PARAM.
+print -- ${^manpath}

--- a/internal/survey/testdata/corpus/ok-reverse-subscript.zsh
+++ b/internal/survey/testdata/corpus/ok-reverse-subscript.zsh
@@ -1,5 +1,4 @@
 # -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
 # vim: ft=zsh sw=2 ts=2 et
-# Issue #15: reverse-subscript flags in parameter expansion; minimized from
-# zsh-fancy-completions lib/completion.zsh.
+# Issue #15: reverse-subscript flags with a native-Zsh glob pattern.
 print -r -- ${_comps[(I)-value-*]}


### PR DESCRIPTION
Closes #15, #60, #61, and #129.

## Summary
- add narrowly gated parser compatibility for native Zsh corpus forms
- promote the resolved parser gaps into the strict 19-file reference corpus
- record the zero-error, zero-warning readiness evidence

## Verification
- `go test ./... -count=1`
- `go vet ./...`
- `go build -buildvcs=false ./...`
- reference corpus survey: 19/19 parsed, zero failures
- analyzer: zero errors and zero warnings