### PR TITLE
fix(parse): support escaped ANSI-C heredoc delimiters (#122)

### DIFF
--- a/internal/parse/heredoc_compat.go
+++ b/internal/parse/heredoc_compat.go
@@ -1,0 +1,127 @@
+package parse
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+const unclosedHeredocPrefix = "unclosed here-document"
+
+// parseANSICHeredocDelimiter retries native Zsh heredocs whose delimiter uses
+// ANSI-C quoting with escape sequences (e.g. cat <<$'E\x4fF'). mvdan/sh does not
+// expand escape sequences in the delimiter before matching against heredoc body
+// lines, resulting in a spurious unclosed heredoc error. The adapter decodes the
+// ANSI-C delimiter, runs a same-width padded retry, and restores the original
+// ANSI-C literal in the resulting AST.
+func parseANSICHeredocDelimiter(src []byte, name string, firstErr error) (*syntax.File, error) {
+	return parseANSICHeredocDelimiterWithParser(src, name, firstErr, parseANSICHeredocDelimiters)
+}
+
+func parseANSICHeredocDelimiters(src []byte, name string) (*syntax.File, error) {
+	tree, err := parseTree(src, name)
+	if err != nil {
+		return parseANSICHeredocDelimiterWithParser(src, name, err, parseANSICHeredocDelimiters)
+	}
+	return tree, nil
+}
+
+func parseANSICHeredocDelimiterWithParser(
+	src []byte,
+	name string,
+	firstErr error,
+	parse func([]byte, string) (*syntax.File, error),
+) (*syntax.File, error) {
+	var parseErr syntax.ParseError
+	if !errors.As(firstErr, &parseErr) || !strings.HasPrefix(parseErr.Text, unclosedHeredocPrefix) {
+		return nil, firstErr
+	}
+
+	seed := int(parseErr.Pos.Offset())
+	if seed < 0 || seed >= len(src) {
+		return nil, firstErr
+	}
+
+	redirPos := -1
+	minOffset := seed - 2
+	if minOffset < 0 {
+		minOffset = 0
+	}
+	maxOffset := seed + 2
+	if maxOffset > len(src)-2 {
+		maxOffset = len(src) - 2
+	}
+	for i := minOffset; i <= maxOffset; i++ {
+		if src[i] == '<' && src[i+1] == '<' {
+			redirPos = i
+			break
+		}
+	}
+	if redirPos < 0 {
+		return nil, firstErr
+	}
+
+	delimStart := redirPos + 2
+	if delimStart < len(src) && src[delimStart] == '-' {
+		delimStart++
+	}
+	for delimStart < len(src) && (src[delimStart] == ' ' || src[delimStart] == '\t') {
+		delimStart++
+	}
+
+	if delimStart+1 >= len(src) || src[delimStart] != '$' || src[delimStart+1] != '\'' {
+		return nil, firstErr
+	}
+
+	decoded, delimEnd, ok := parseANSICQuotedHeredocSegment(src, delimStart)
+	if !ok || !bytes.Contains(src[delimStart:delimEnd], []byte("\\")) {
+		return nil, firstErr
+	}
+
+	origLen := delimEnd - delimStart
+	replacement := make([]byte, 0, origLen)
+	replacement = append(replacement, '$', '\'')
+	replacement = append(replacement, decoded...)
+	replacement = append(replacement, '\'')
+	if len(replacement) > origLen {
+		return nil, firstErr
+	}
+	pad := origLen - len(replacement)
+	if pad > 0 {
+		replacement = append(replacement, bytes.Repeat([]byte(" "), pad)...)
+	}
+
+	masked := bytes.Clone(src)
+	copy(masked[delimStart:delimEnd], replacement)
+
+	tree, err := parse(masked, name)
+	if err != nil {
+		return nil, err
+	}
+
+	rawInsideQuotes := string(src[delimStart+2 : delimEnd-1])
+	restored := false
+	syntax.Walk(tree, func(node syntax.Node) bool {
+		if restored {
+			return false
+		}
+		redir, ok := node.(*syntax.Redirect)
+		if !ok || redir.Word == nil || len(redir.Word.Parts) != 1 {
+			return true
+		}
+		sgl, ok := redir.Word.Parts[0].(*syntax.SglQuoted)
+		if !ok || !sgl.Dollar || int(sgl.Left.Offset()) != delimStart {
+			return true
+		}
+		sgl.Value = rawInsideQuotes
+		restored = true
+		return false
+	})
+
+	if !restored {
+		return nil, firstErr
+	}
+	return tree, nil
+}

--- a/internal/parse/heredoc_compat_test.go
+++ b/internal/parse/heredoc_compat_test.go
@@ -1,0 +1,91 @@
+package parse
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+func TestParseNativeANSICHeredocCompatibility(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "hex escape delimiter",
+			src:  "cat <<$'E\\x4fF'\nbody\nEOF\n",
+			want: "$'E\\x4fF'",
+		},
+		{
+			name: "octal escape delimiter",
+			src:  "cat <<$'E\\117F'\nbody\nEOF\n",
+			want: "$'E\\117F'",
+		},
+		{
+			name: "unicode escape delimiter",
+			src:  "cat <<$'E\\u004fF'\nbody\nEOF\n",
+			want: "$'E\\u004fF'",
+		},
+		{
+			name: "strip tabs heredoc with spaces",
+			src:  "cat <<-  $'E\\x4fF'\n\tbody\n\tEOF\n",
+			want: "$'E\\x4fF'",
+		},
+		{
+			name: "heredoc with trailing command redirection",
+			src:  "cat <<$'E\\x4fF' >out.txt\nbody\nEOF\n",
+			want: "$'E\\x4fF'",
+		},
+		{
+			name: "multiple ANSI-C heredocs",
+			src:  "cat <<$'H\\x45AD'\nheader\nHEAD\ncat <<$'T\\x41IL'\ntail\nTAIL\n",
+			want: "$'H\\x45AD'",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			file, err := Parse(strings.NewReader(test.src), test.name+".zsh")
+			if err != nil {
+				t.Fatalf("Parse() error: %v", err)
+			}
+			var rendered bytes.Buffer
+			if err := syntax.NewPrinter().Print(&rendered, file.AST()); err != nil {
+				t.Fatalf("print AST: %v", err)
+			}
+			if !strings.Contains(rendered.String(), test.want) {
+				t.Errorf("printed AST = %q, want original delimiter %q", rendered.String(), test.want)
+			}
+		})
+	}
+}
+
+func TestANSICHeredocPreservesLaterErrorPosition(t *testing.T) {
+	const src = "cat <<$'E\\x4fF'\nbody\nEOF\n)\n"
+	_, err := Parse(strings.NewReader(src), "later-error.zsh")
+	if err == nil {
+		t.Fatal("Parse() unexpectedly accepted a trailing unmatched parenthesis")
+	}
+	var parseErr syntax.ParseError
+	if !errors.As(err, &parseErr) {
+		t.Fatalf("error type = %T, want syntax.ParseError: %v", err, err)
+	}
+	if parseErr.Pos.Line() != 4 || parseErr.Pos.Col() != 1 {
+		t.Errorf("error position = %d:%d, want 4:1", parseErr.Pos.Line(), parseErr.Pos.Col())
+	}
+}
+
+func TestANSICHeredocRejectsGenuineUnclosedHeredoc(t *testing.T) {
+	for _, src := range []string{
+		"cat <<$'E\\x4fF'\nbody\nMISMATCH\n",
+		"cat <<$'EOF'\nbody\n",
+	} {
+		if _, err := Parse(strings.NewReader(src), "unclosed.zsh"); err == nil {
+			t.Fatalf("Parse(%q) unexpectedly succeeded", src)
+		}
+	}
+}

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -78,7 +78,10 @@ func Parse(r io.Reader, name string) (*File, error) {
 										if err != nil {
 											tree, err = parseGroupedCasePattern(src, name, err)
 											if err != nil {
-												return nil, err
+												tree, err = parseANSICHeredocDelimiter(src, name, err)
+												if err != nil {
+													return nil, err
+												}
 											}
 										}
 									}

--- a/internal/survey/corpus_test.go
+++ b/internal/survey/corpus_test.go
@@ -15,6 +15,7 @@ import (
 // (issue #14): new fixtures can be added freely without touching this test.
 var requiredFixtures = []string{
 	"ok-alternate-if-brace.zsh",
+	"ok-ansic-heredoc.zsh",
 	"ok-assoc-subscript-keys.zsh",
 	"ok-baseline.zsh",
 	"ok-brace-termination.zsh",

--- a/internal/survey/testdata/corpus/ok-ansic-heredoc.zsh
+++ b/internal/survey/testdata/corpus/ok-ansic-heredoc.zsh
@@ -1,6 +1,6 @@
 # -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
 # vim: ft=zsh sw=2 ts=2 et
-cat <<'EOF'
+# Issue #122: escaped ANSI-C heredoc delimiters
+cat <<$'E\x4fF'
 body
-
-
+EOF


### PR DESCRIPTION
Closes #122.

## Summary

- Add parseANSICHeredocDelimiter adapter in internal/parse/heredoc_compat.go for native Zsh heredocs using escaped ANSI-C delimiters (e.g. cat <<$'E\x4fF').
- Add ok-ansic-heredoc.zsh fixture and update requiredFixtures in internal/survey/corpus_test.go.
- Add comprehensive unit tests in internal/parse/heredoc_compat_test.go.

## Verification

- go test -count=1 ./...
- go vet ./...
- go build ./...
- Reference corpus survey: 19/19 files parsed cleanly with 0 failures
- Native zsh -f -n verification on all corpus fixtures