### PR TITLE
docs(corpus): add zsh-eza functions/ to the parser-evaluation corpus

### DIFF
--- a/docs/project/corpus.md
+++ b/docs/project/corpus.md
@@ -17,14 +17,14 @@ survey command shown below.
 
 ## Inventory
 
-| Repository                      | Files                                                                        | Rationale                                                                        |
-| ------------------------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `z-shell/src`                   | `public/zsh/init.zsh`                                                        | Zi loader; heaviest real-world Zsh (parameter-expansion flags, `always` blocks). |
-| `z-shell/zd`                    | `docker/utils.zsh`, `docker/zshrc`, `docker/zshenv`                          | CI bootstrap Zsh; mixes POSIX-ish and Zsh-native style.                          |
-| `z-shell/zunit`                 | `build.zsh`                                                                  | Build script; representative tooling Zsh.                                        |
-| `z-shell/z-a-meta-plugins`      | `z-a-meta-plugins.plugin.zsh`, `functions/` (dot-prefixed handler functions) | Annex entry plus handler functions using the strict-emulation pattern.           |
-| `z-shell/zsh-fancy-completions` | `zsh-fancy-completions.plugin.zsh`, `functions/`, `lib/`                     | Completion-style plugin; globbing, zstyle, and completion-discovery heavy.       |
-| `z-shell/zsh-eza`               | `zsh-eza.plugin.zsh`                                                         | Small, typical plugin entry file.                                                |
+| Repository                      | Files                                                                        | Rationale                                                                                                                                                                      |
+| ------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `z-shell/src`                   | `public/zsh/init.zsh`                                                        | Zi loader; heaviest real-world Zsh (parameter-expansion flags, `always` blocks).                                                                                               |
+| `z-shell/zd`                    | `docker/utils.zsh`, `docker/zshrc`, `docker/zshenv`                          | CI bootstrap Zsh; mixes POSIX-ish and Zsh-native style.                                                                                                                        |
+| `z-shell/zunit`                 | `build.zsh`                                                                  | Build script; representative tooling Zsh.                                                                                                                                      |
+| `z-shell/z-a-meta-plugins`      | `z-a-meta-plugins.plugin.zsh`, `functions/` (dot-prefixed handler functions) | Annex entry plus handler functions using the strict-emulation pattern.                                                                                                         |
+| `z-shell/zsh-fancy-completions` | `zsh-fancy-completions.plugin.zsh`, `functions/`, `lib/`                     | Completion-style plugin; globbing, zstyle, and completion-discovery heavy.                                                                                                     |
+| `z-shell/zsh-eza`               | `zsh-eza.plugin.zsh`, `functions/` (dot-prefixed handler function)           | Small, typical plugin entry file plus a strict-emulation handler function, the same pattern `z-a-meta-plugins` was included for; omitted from the initial corpus by oversight. |
 
 Inclusion rationale, per family: the corpus deliberately spans the loader
 (`src`), the CI environment (`zd`), test tooling (`zunit`), an annex
@@ -46,6 +46,7 @@ Run from `$CORPUS_ROOT`, pointing `go run` at a local `zsh-lint` checkout
          zsh-fancy-completions/functions \
          zsh-fancy-completions/lib \
          zsh-eza/zsh-eza.plugin.zsh \
+         zsh-eza/functions \
          -type f | sort | xargs go run <path-to-zsh-lint>/cmd/zsh-lint-survey
 
 Directory entries are passed through `find -type f`, which also picks up


### PR DESCRIPTION
## Summary

`docs/project/corpus.md` lists `z-a-meta-plugins` and `zsh-fancy-completions` with their `functions/` (and `lib/`) directories, but `zsh-eza` was only ever given its single entry file, even though `functions/.zsh-eza` exists and is the same kind of strict-emulation handler function `z-a-meta-plugins` was explicitly included for.

## Evidence

- `functions/.zsh-eza` in `z-shell/zsh-eza` is 66 lines of real Zsh (strict emulation, not a stub).
- Every survey run since the corpus was defined (`corpus.md`'s own `find` command, and the `2026-08-14`/`2026-08-16` survey reports) has only ever passed `zsh-eza.plugin.zsh` — `functions/.zsh-eza` has never gone through the parser front end.
- Git blame on the original corpus commit (`e930190`, #9) shows the `zsh-eza` row's rationale ("Small, typical plugin entry file") describes the entry file only; it doesn't address the functions dir's existence the way the other two multi-file rows do.

## Change

- Add `functions/` to `zsh-eza`'s inventory row, with rationale.
- Add `zsh-eza/functions` to the reproducible `find` command in "Running the survey".

Per corpus.md's own "Changing the corpus" section, this is a direct PR (rationale row included), not a policy change — no ADR needed.

This does **not** re-run the survey or file new parser-gap issues; that's separate follow-up if this lands and turns anything up.