### PR TITLE
fix(corpus): enforce analyzer readiness

### DIFF
--- a/.github/workflows/corpus-gate.yml
+++ b/.github/workflows/corpus-gate.yml
@@ -1,0 +1,159 @@
+---
+name: Corpus Gate
+
+on:
+  push:
+    branches: [main, next]
+    paths:
+      - ".github/workflows/corpus-gate.yml"
+      - "cmd/**"
+      - "docs/project/corpus.md"
+      - "docs/project/corpus-paths.txt"
+      - "go.mod"
+      - "go.sum"
+      - "internal/**"
+  pull_request:
+    paths:
+      - ".github/workflows/corpus-gate.yml"
+      - "cmd/**"
+      - "docs/project/corpus.md"
+      - "docs/project/corpus-paths.txt"
+      - "go.mod"
+      - "go.sum"
+      - "internal/**"
+  schedule:
+    - cron: "17 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  corpus:
+    name: Reference corpus
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out zsh-lint
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: zsh-lint
+          persist-credentials: false
+
+      - name: Check out src
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: z-shell/src
+          ref: main
+          path: corpus/src
+          persist-credentials: false
+
+      - name: Check out zd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: z-shell/zd
+          ref: main
+          path: corpus/zd
+          persist-credentials: false
+
+      - name: Check out zunit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: z-shell/zunit
+          ref: main
+          path: corpus/zunit
+          persist-credentials: false
+
+      - name: Check out z-a-meta-plugins
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: z-shell/z-a-meta-plugins
+          ref: main
+          path: corpus/z-a-meta-plugins
+          persist-credentials: false
+
+      - name: Check out zsh-fancy-completions
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: z-shell/zsh-fancy-completions
+          ref: main
+          path: corpus/zsh-fancy-completions
+          persist-credentials: false
+
+      - name: Check out zsh-eza
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: z-shell/zsh-eza
+          ref: main
+          path: corpus/zsh-eza
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.25"
+          cache-dependency-path: zsh-lint/go.sum
+
+      - name: Set up Zsh
+        uses: z-shell/.github/actions/setup-zsh@4403e5a200c63596f641966dfb64e08a7a655ffa # main
+
+      - name: Build corpus tools
+        working-directory: zsh-lint
+        run: |
+          go build -o "$RUNNER_TEMP/zsh-lint-survey" ./cmd/zsh-lint-survey
+          go build -o "$RUNNER_TEMP/zsh-lint" ./cmd/zsh-lint
+
+      - name: Record corpus revisions
+        working-directory: corpus
+        run: |
+          for repository in src zd zunit z-a-meta-plugins zsh-fancy-completions zsh-eza; do
+            printf '%s ' "$repository"
+            git -C "$repository" rev-parse HEAD
+          done
+
+      - name: Verify reference corpus
+        working-directory: corpus
+        shell: bash
+        env:
+          EXPECTED_CORPUS_FILES: "20"
+        run: |
+          set -euo pipefail
+          mapfile -t roots < ../zsh-lint/docs/project/corpus-paths.txt
+          for root in "${roots[@]}"; do
+            if [[ ! -e "$root" ]]; then
+              echo "::error::Corpus path does not exist: $root"
+              exit 1
+            fi
+          done
+
+          mapfile -d '' files < <(find "${roots[@]}" -type f -print0 | sort -z)
+          if [[ ${#files[@]} -ne $EXPECTED_CORPUS_FILES ]]; then
+            echo "::error::Expected $EXPECTED_CORPUS_FILES corpus files, found ${#files[@]}."
+            printf '%s\n' "${files[@]}"
+            exit 1
+          fi
+
+          if grep -n -F 'zsh-lint disable=' "${files[@]}"; then
+            echo "::error::The strict corpus must not use zsh-lint suppressions."
+            exit 1
+          fi
+
+          for file in "${files[@]}"; do
+            zsh -f -n -- "$file"
+          done
+          "$RUNNER_TEMP/zsh-lint-survey" "${files[@]}"
+
+          analyzer_status=0
+          "$RUNNER_TEMP/zsh-lint" --format=json "${files[@]}" > "$RUNNER_TEMP/corpus-diagnostics.json" || analyzer_status=$?
+          jq . "$RUNNER_TEMP/corpus-diagnostics.json"
+          if ! jq -e '.summary.errors == 0 and .summary.warnings == 0' "$RUNNER_TEMP/corpus-diagnostics.json" >/dev/null; then
+            echo "::error::The corpus contains error- or warning-level diagnostics."
+            exit 1
+          fi
+          if [[ $analyzer_status -ne 0 ]]; then
+            echo "::error::zsh-lint exited with status $analyzer_status."
+            exit "$analyzer_status"
+          fi

--- a/docs/project/corpus-paths.txt
+++ b/docs/project/corpus-paths.txt
@@ -1,0 +1,12 @@
+src/public/zsh/init.zsh
+zd/docker/utils.zsh
+zd/docker/zshrc
+zd/docker/zshenv
+zunit/build.zsh
+z-a-meta-plugins/z-a-meta-plugins.plugin.zsh
+z-a-meta-plugins/functions
+zsh-fancy-completions/zsh-fancy-completions.plugin.zsh
+zsh-fancy-completions/functions
+zsh-fancy-completions/lib
+zsh-eza/zsh-eza.plugin.zsh
+zsh-eza/functions

--- a/docs/project/corpus.md
+++ b/docs/project/corpus.md
@@ -1,19 +1,25 @@
-# Parser Evaluation Corpus
+# Reference Corpus
 
-Tracking issue: [#9](https://github.com/z-shell/zsh-lint/issues/9).
+Tracking issues: [#9](https://github.com/z-shell/zsh-lint/issues/9) and
+[#132](https://github.com/z-shell/zsh-lint/issues/132).
 
 This is the explicit, reproducible set of real Z-Shell sources used to
-evaluate the parser front end (`cmd/zsh-lint-survey`). Survey runs and
-parser-gap issues must reference corpus entries by repository and path so
-results stay comparable across runs and front ends
-([#17](https://github.com/z-shell/zsh-lint/issues/17)).
+evaluate both the parser front end (`cmd/zsh-lint-survey`) and the semantic
+analyzer (`cmd/zsh-lint`). Survey runs and parser-gap issues must reference
+corpus entries by repository and path so results stay comparable across runs
+and front ends ([#17](https://github.com/z-shell/zsh-lint/issues/17)).
+
+`corpus-paths.txt` is the machine-readable path inventory. This document owns
+the rationale for those entries. `.github/workflows/corpus-gate.yml` checks out
+the six repositories at their `main` branches, records the resolved revisions,
+and applies the strict gate to the exact discovered file set.
 
 ## Layout assumption
 
 Entries are paths relative to a checkout root containing the listed
 repositories as sibling directories named after the repository. Set
 `CORPUS_ROOT` to that root and clone each repository under it, then run the
-survey command shown below.
+gate commands described below.
 
 ## Inventory
 
@@ -31,29 +37,28 @@ Inclusion rationale, per family: the corpus deliberately spans the loader
 (`z-a-meta-plugins`), and user-facing plugins (completions, eza) so parser
 gaps found here generalize across the organization's Zsh styles.
 
-## Running the survey
+## Running the gate
 
-Run from `$CORPUS_ROOT`, pointing `go run` at a local `zsh-lint` checkout
-(replace `<path-to-zsh-lint>` with its location):
+The `Corpus Gate` workflow is the canonical automated execution. It runs on
+relevant `zsh-lint` changes, weekly to detect consumer drift, and by manual
+dispatch. It performs all of these checks:
 
-    cd "$CORPUS_ROOT"
-    find src/public/zsh/init.zsh \
-         zd/docker/utils.zsh zd/docker/zshrc zd/docker/zshenv \
-         zunit/build.zsh \
-         z-a-meta-plugins/z-a-meta-plugins.plugin.zsh \
-         z-a-meta-plugins/functions \
-         zsh-fancy-completions/zsh-fancy-completions.plugin.zsh \
-         zsh-fancy-completions/functions \
-         zsh-fancy-completions/lib \
-         zsh-eza/zsh-eza.plugin.zsh \
-         zsh-eza/functions \
-         -type f | sort | xargs go run <path-to-zsh-lint>/cmd/zsh-lint-survey
+- every listed root exists and expands to the reviewed file count;
+- no source contains a `zsh-lint disable=` suppression;
+- native `zsh -f -n` accepts every file;
+- the parser survey reports no failures; and
+- the semantic analyzer reports zero errors and zero warnings.
 
-Directory entries are passed through `find -type f`, which also picks up
-dot-prefixed function files (the `z-a-meta-plugins` handlers).
+For a local run, arrange the repositories as siblings under `$CORPUS_ROOT`,
+build `cmd/zsh-lint-survey` and `cmd/zsh-lint`, then execute the same commands
+from the workflow. Directory entries are passed through NUL-delimited
+`find -type f`, which includes dot-prefixed extensionless function files.
 
 ## Changing the corpus
 
-Add or remove entries via a pull request to this file, including a rationale
-row. Survey reports under `docs/project/` record the corpus state they ran
-against, so older reports stay interpretable after the corpus changes.
+Add or remove roots by updating `corpus-paths.txt` and the matching rationale
+row in this file. Review any changed discovered-file count explicitly and
+update the workflow's expected count in the same change. A fresh parser-only
+survey is insufficient: every corpus change must re-run the complete native,
+parser, analyzer, and no-suppression gate. Reports under `docs/project/` record
+the revisions they ran against, so older reports stay interpretable.

--- a/internal/rules/unquoted_var.go
+++ b/internal/rules/unquoted_var.go
@@ -36,10 +36,11 @@ import (
 // Severity: Warning. Losing an empty argument or inheriting `SH_WORD_SPLIT`
 // can change command behavior, while intentional elision remains realistic.
 //
-// False positives: Code may intentionally omit an empty argument, deliberately
-// rely on `SH_WORD_SPLIT`, or expand a value guaranteed to be non-empty. Those
-// cases should use a reasoned suppression rather than weakening unrelated
-// diagnostics.
+// False positives: Explicit native-Zsh splitting forms such as `${=words}` and
+// flag-guided array or field splitting are excluded. Other code may
+// intentionally omit an empty argument, rely on `SH_WORD_SPLIT`, or expand a
+// value guaranteed to be non-empty. Those cases should use a reasoned
+// suppression rather than weakening unrelated diagnostics.
 //
 // Suppression: Use
 // `# zsh-lint disable=quoting/unquoted-var -- <reason>` on the finding line or
@@ -109,5 +110,25 @@ func shouldSkipUnquotedParam(param *syntax.ParamExp) bool {
 		}
 	}
 
+	// 4. ${=spec} explicitly requests SH_WORD_SPLIT behavior in native Zsh.
+	// mvdan/sh represents the leading split toggle as an omitted parameter name
+	// plus AssignUnset. A second leading '=' in the expansion word represents
+	// ${==spec}, which disables splitting and therefore retains the ordinary
+	// unquoted-empty-elision risk covered by this rule.
+	if isExplicitZshWordSplit(param) {
+		return true
+	}
+
 	return false
+}
+
+func isExplicitZshWordSplit(param *syntax.ParamExp) bool {
+	if param.Param != nil || param.NestedParam != nil || param.Exp == nil || param.Exp.Op != syntax.AssignUnset {
+		return false
+	}
+	if param.Exp.Word == nil || len(param.Exp.Word.Parts) == 0 {
+		return true
+	}
+	first, ok := param.Exp.Word.Parts[0].(*syntax.Lit)
+	return !ok || !strings.HasPrefix(first.Value, "=")
 }

--- a/internal/rules/unquoted_var_test.go
+++ b/internal/rules/unquoted_var_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -42,5 +43,70 @@ echo ${(@)array}
 	}
 	if diags[0].Range.Start.Line != 2 {
 		t.Errorf("expected diagnostic on line 2 (echo $foo), got line %d", diags[0].Range.Start.Line)
+	}
+}
+
+func TestUnquotedVarExplicitSplitting(t *testing.T) {
+	tests := []struct {
+		name      string
+		src       string
+		wantDiags int
+	}{
+		{
+			name:      "nested split toggle",
+			src:       "builtin emulate -L zsh ${=${options[xtrace]:#off}:+-o xtrace}\n",
+			wantDiags: 0,
+		},
+		{
+			name:      "simple split toggle",
+			src:       "print -r -- ${=value}\n",
+			wantDiags: 0,
+		},
+		{
+			name:      "split toggle disabled",
+			src:       "print -r -- ${==value}\n",
+			wantDiags: 1,
+		},
+		{
+			name:      "ordinary assignment expansion",
+			src:       "print -r -- ${value=default}\n",
+			wantDiags: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			file, err := parse.Parse(strings.NewReader(test.src), test.name+".zsh")
+			if err != nil {
+				t.Fatalf("parse failed: %v", err)
+			}
+
+			diags := analyzer.New(UnquotedVar{}).Analyze(file, test.name+".zsh")
+			if len(diags) != test.wantDiags {
+				t.Fatalf("diagnostics = %d, want %d: %v", len(diags), test.wantDiags, diags)
+			}
+		})
+	}
+}
+
+func TestExplicitSplitRequiresUnquotedEmptyElision(t *testing.T) {
+	zsh, err := exec.LookPath("zsh")
+	if err != nil {
+		t.Skip("zsh is required for the native expansion control")
+	}
+
+	const script = `
+unsetopt xtrace
+set -- ${=${options[xtrace]:#off}:+-o xtrace}
+print -r -- "unquoted:$#"
+set -- "${=${options[xtrace]:#off}:+-o xtrace}"
+print -r -- "quoted:$#"
+`
+	output, err := exec.Command(zsh, "-f", "-c", script).CombinedOutput()
+	if err != nil {
+		t.Fatalf("native Zsh control failed: %v\n%s", err, output)
+	}
+	if got, want := string(output), "unquoted:0\nquoted:1\n"; got != want {
+		t.Fatalf("native Zsh argument counts = %q, want %q", got, want)
 	}
 }

--- a/internal/workflowcontract/corpus_gate_test.go
+++ b/internal/workflowcontract/corpus_gate_test.go
@@ -1,0 +1,74 @@
+package workflowcontract
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCorpusManifestIsExactAndContained(t *testing.T) {
+	want := []string{
+		"src/public/zsh/init.zsh",
+		"zd/docker/utils.zsh",
+		"zd/docker/zshrc",
+		"zd/docker/zshenv",
+		"zunit/build.zsh",
+		"z-a-meta-plugins/z-a-meta-plugins.plugin.zsh",
+		"z-a-meta-plugins/functions",
+		"zsh-fancy-completions/zsh-fancy-completions.plugin.zsh",
+		"zsh-fancy-completions/functions",
+		"zsh-fancy-completions/lib",
+		"zsh-eza/zsh-eza.plugin.zsh",
+		"zsh-eza/functions",
+	}
+
+	manifest := readRepositoryFile(t, "docs", "project", "corpus-paths.txt")
+	got := strings.Split(strings.TrimSuffix(manifest, "\n"), "\n")
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("corpus manifest differs from the reviewed inventory:\nwant: %q\ngot:  %q", want, got)
+	}
+	for _, entry := range got {
+		if filepath.IsAbs(entry) || filepath.Clean(entry) != entry || strings.HasPrefix(entry, "..") {
+			t.Fatalf("corpus manifest entry must be a contained clean relative path: %q", entry)
+		}
+	}
+}
+
+func TestCorpusGateUsesReadOnlyMainCheckouts(t *testing.T) {
+	workflow := readRepositoryFile(t, ".github", "workflows", "corpus-gate.yml")
+	if got := strings.Count(workflow, "uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"); got != 7 {
+		t.Fatalf("corpus gate must use seven pinned checkout steps; got %d", got)
+	}
+	if got := strings.Count(workflow, "persist-credentials: false"); got != 7 {
+		t.Fatalf("every corpus checkout must disable persisted credentials; got %d", got)
+	}
+
+	for _, repository := range []string{"src", "zd", "zunit", "z-a-meta-plugins", "zsh-fancy-completions", "zsh-eza"} {
+		want := "repository: z-shell/" + repository + "\n" +
+			"          ref: main\n" +
+			"          path: corpus/" + repository + "\n" +
+			"          persist-credentials: false"
+		if !strings.Contains(workflow, want) {
+			t.Errorf("corpus checkout for %s must use its main branch and isolated path", repository)
+		}
+	}
+}
+
+func TestCorpusGateRunsTheFullReadinessContract(t *testing.T) {
+	workflow := readRepositoryFile(t, ".github", "workflows", "corpus-gate.yml")
+	for _, required := range []string{
+		"permissions:\n  contents: read",
+		`mapfile -t roots < ../zsh-lint/docs/project/corpus-paths.txt`,
+		`mapfile -d '' files < <(find "${roots[@]}" -type f -print0 | sort -z)`,
+		`EXPECTED_CORPUS_FILES: "20"`,
+		`grep -n -F 'zsh-lint disable=' "${files[@]}"`,
+		`zsh -f -n -- "$file"`,
+		`"$RUNNER_TEMP/zsh-lint-survey" "${files[@]}"`,
+		`"$RUNNER_TEMP/zsh-lint" --format=json "${files[@]}"`,
+		`.summary.errors == 0 and .summary.warnings == 0`,
+	} {
+		if !strings.Contains(workflow, required) {
+			t.Errorf("corpus gate is missing required contract fragment %q", required)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- recognize explicit native Zsh `${=spec}` word splitting so `quoting/unquoted-var` does not recommend a behavior-changing quote
- retain the diagnostic for `${==spec}` and ordinary unquoted parameter expansions
- add a deterministic 20-file corpus gate across six consumer repositories
- reject corpus drift, suppressions, native syntax failures, parser failures, analyzer errors, and analyzer warnings
- pin every action and keep all checkouts read-only

## Verified corpus revisions

- `src`: `5ac79863d55baf056796e5e3afce5970506b8871`
- `zd`: `2f8604763292e5697fb97fd25fb68dc12b418839`
- `zunit`: `60fa1d180bb0e4b879d69dc3814c840b54067cac`
- `z-a-meta-plugins`: `e6e93098c6b97a7878e9af9d8e4af2a9412b76f1`
- `zsh-fancy-completions`: `c9f75f9e377b53f2ff0ea552eb9fe8b429b18d6e`
- `zsh-eza`: `242216f714031a5269aa1fc6c9c19ddeb46f01c5`

Fresh result: 20 native parses, 20 parser successes, zero analyzer errors, zero warnings, four infos, three hints, and no suppressions.

## Local verification

- `go mod tidy -diff`
- `gofmt`
- `go vet ./...`
- `go build ./...`
- `go test -count=1 ./...`
- `actionlint .github/workflows/corpus-gate.yml`
- generated-reference non-empty check
- `git diff --check`

Normal lint execution remains static and does not spawn Zsh. Native Zsh is used only by tests and the CI corpus oracle.

Closes #132
Closes #150
