### PR TITLE
feat: add project-aware function namespace checks

### DIFF
--- a/cmd/zsh-lint/main.go
+++ b/cmd/zsh-lint/main.go
@@ -3,7 +3,9 @@ package main
 
 import (
 	"errors"
+	"flag"
 	"fmt"
+	"io"
 	"os"
 
 	"mvdan.cc/sh/v3/syntax"
@@ -11,29 +13,73 @@ import (
 	"github.com/z-shell/zsh-lint/internal/analyzer"
 	"github.com/z-shell/zsh-lint/internal/diag"
 	"github.com/z-shell/zsh-lint/internal/parse"
+	"github.com/z-shell/zsh-lint/internal/projectconfig"
 	"github.com/z-shell/zsh-lint/internal/rules"
 )
 
+const usage = "usage: zsh-lint [--format=json] [--config PATH] <file.zsh> [file.zsh ...]"
+
 func main() {
-	args := os.Args[1:]
-	jsonOut := false
-	if len(args) > 0 && args[0] == "--format=json" {
-		jsonOut = true
-		args = args[1:]
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	var formatFlag singleValue
+	formatFlag.name = "format"
+	var configFlag singleValue
+	configFlag.name = "config"
+
+	flags := flag.NewFlagSet("zsh-lint", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	flags.Var(&formatFlag, "format", "output format (json)")
+	flags.Var(&configFlag, "config", "explicit project configuration path")
+	if err := flags.Parse(args); err != nil {
+		fmt.Fprintf(stderr, "zsh-lint: %v\n%s\n", err, usage)
+		return 2
 	}
-	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: zsh-lint [--format=json] <file.zsh> [file.zsh ...]")
-		os.Exit(2)
+	if formatFlag.set && formatFlag.value != "json" {
+		fmt.Fprintf(stderr, "zsh-lint: unsupported output format %q\n%s\n", formatFlag.value, usage)
+		return 2
+	}
+	if configFlag.set && configFlag.value == "" {
+		fmt.Fprintf(stderr, "zsh-lint: --config requires a non-empty path\n%s\n", usage)
+		return 2
+	}
+	names := flags.Args()
+	if len(names) == 0 {
+		fmt.Fprintln(stderr, usage)
+		return 2
+	}
+	jsonOut := formatFlag.value == "json"
+
+	var sourceContexts []projectconfig.SourceContext
+	activeRules := rules.Default()
+	if configFlag.set {
+		config, err := projectconfig.Load(configFlag.value)
+		if err != nil {
+			fmt.Fprintf(stderr, "zsh-lint: configuration: %v\n", err)
+			return 2
+		}
+		activeRules = append(activeRules, rules.ProjectProfile(config.Version)...)
+		sourceContexts = make([]projectconfig.SourceContext, len(names))
+		for index, name := range names {
+			context, err := config.Resolve(name)
+			if err != nil {
+				fmt.Fprintf(stderr, "zsh-lint: configuration: %v\n", err)
+				return 2
+			}
+			sourceContexts[index] = context
+		}
 	}
 
-	an := analyzer.New(rules.Default()...)
+	an := analyzer.New(activeRules...)
 	var all diag.Diagnostics
 	var exitNonZero bool
 
-	for _, name := range args {
+	for index, name := range names {
 		f, err := os.Open(name)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s: %v\n", name, err)
+			fmt.Fprintf(stderr, "%s: %v\n", name, err)
 			exitNonZero = true
 			continue
 		}
@@ -49,12 +95,17 @@ func main() {
 				// (docs/project/output-contract.md).
 				all = append(all, parseErrDiag(name, err))
 			} else {
-				fmt.Println(formatErr(name, err))
+				fmt.Fprintln(stdout, formatErr(name, err))
 			}
 			continue
 		}
 
-		diags := an.Analyze(file, name)
+		var diags diag.Diagnostics
+		if sourceContexts == nil {
+			diags = an.Analyze(file, name)
+		} else {
+			diags = an.AnalyzeSource(file, name, sourceContexts[index])
+		}
 		for _, d := range diags {
 			// Errors and warnings cause a non-zero exit; Info/Hint do not.
 			if d.Severity <= diag.Warning {
@@ -66,9 +117,9 @@ func main() {
 			}
 			// Format similar to gcc/clang
 			if d.Range.IsValid() {
-				fmt.Printf("%s:%d:%d: [%s] %s\n", d.File, d.Range.Start.Line, d.Range.Start.Column, d.RuleID, d.Message)
+				fmt.Fprintf(stdout, "%s:%d:%d: [%s] %s\n", d.File, d.Range.Start.Line, d.Range.Start.Column, d.RuleID, d.Message)
 			} else {
-				fmt.Printf("%s: [%s] %s\n", d.File, d.RuleID, d.Message)
+				fmt.Fprintf(stdout, "%s: [%s] %s\n", d.File, d.RuleID, d.Message)
 			}
 		}
 		if jsonOut {
@@ -78,15 +129,33 @@ func main() {
 
 	if jsonOut {
 		all.Sort()
-		if err := diag.WriteJSON(os.Stdout, len(args), all); err != nil {
-			fmt.Fprintf(os.Stderr, "zsh-lint: encoding JSON: %v\n", err)
-			os.Exit(2)
+		if err := diag.WriteJSON(stdout, len(names), all); err != nil {
+			fmt.Fprintf(stderr, "zsh-lint: encoding JSON: %v\n", err)
+			return 2
 		}
 	}
 
 	if exitNonZero {
-		os.Exit(1)
+		return 1
 	}
+	return 0
+}
+
+type singleValue struct {
+	name  string
+	value string
+	set   bool
+}
+
+func (value *singleValue) String() string { return value.value }
+
+func (value *singleValue) Set(text string) error {
+	if value.set {
+		return fmt.Errorf("--%s may be specified only once", value.name)
+	}
+	value.value = text
+	value.set = true
+	return nil
 }
 
 // parseErrDiag converts a parser/IO error into a parse/error diagnostic,

--- a/cmd/zsh-lint/main.go
+++ b/cmd/zsh-lint/main.go
@@ -34,20 +34,20 @@ func run(args []string, stdout, stderr io.Writer) int {
 	flags.Var(&formatFlag, "format", "output format (json)")
 	flags.Var(&configFlag, "config", "explicit project configuration path")
 	if err := flags.Parse(args); err != nil {
-		fmt.Fprintf(stderr, "zsh-lint: %v\n%s\n", err, usage)
+		_, _ = fmt.Fprintf(stderr, "zsh-lint: %v\n%s\n", err, usage)
 		return 2
 	}
 	if formatFlag.set && formatFlag.value != "json" {
-		fmt.Fprintf(stderr, "zsh-lint: unsupported output format %q\n%s\n", formatFlag.value, usage)
+		_, _ = fmt.Fprintf(stderr, "zsh-lint: unsupported output format %q\n%s\n", formatFlag.value, usage)
 		return 2
 	}
 	if configFlag.set && configFlag.value == "" {
-		fmt.Fprintf(stderr, "zsh-lint: --config requires a non-empty path\n%s\n", usage)
+		_, _ = fmt.Fprintf(stderr, "zsh-lint: --config requires a non-empty path\n%s\n", usage)
 		return 2
 	}
 	names := flags.Args()
 	if len(names) == 0 {
-		fmt.Fprintln(stderr, usage)
+		_, _ = fmt.Fprintln(stderr, usage)
 		return 2
 	}
 	jsonOut := formatFlag.value == "json"
@@ -57,7 +57,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	if configFlag.set {
 		config, err := projectconfig.Load(configFlag.value)
 		if err != nil {
-			fmt.Fprintf(stderr, "zsh-lint: configuration: %v\n", err)
+			_, _ = fmt.Fprintf(stderr, "zsh-lint: configuration: %v\n", err)
 			return 2
 		}
 		activeRules = append(activeRules, rules.ProjectProfile(config.Version)...)
@@ -65,7 +65,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 		for index, name := range names {
 			context, err := config.Resolve(name)
 			if err != nil {
-				fmt.Fprintf(stderr, "zsh-lint: configuration: %v\n", err)
+				_, _ = fmt.Fprintf(stderr, "zsh-lint: configuration: %v\n", err)
 				return 2
 			}
 			sourceContexts[index] = context
@@ -79,7 +79,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	for index, name := range names {
 		f, err := os.Open(name)
 		if err != nil {
-			fmt.Fprintf(stderr, "%s: %v\n", name, err)
+			_, _ = fmt.Fprintf(stderr, "%s: %v\n", name, err)
 			exitNonZero = true
 			continue
 		}
@@ -95,7 +95,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 				// (docs/project/output-contract.md).
 				all = append(all, parseErrDiag(name, err))
 			} else {
-				fmt.Fprintln(stdout, formatErr(name, err))
+				_, _ = fmt.Fprintln(stdout, formatErr(name, err))
 			}
 			continue
 		}
@@ -117,9 +117,9 @@ func run(args []string, stdout, stderr io.Writer) int {
 			}
 			// Format similar to gcc/clang
 			if d.Range.IsValid() {
-				fmt.Fprintf(stdout, "%s:%d:%d: [%s] %s\n", d.File, d.Range.Start.Line, d.Range.Start.Column, d.RuleID, d.Message)
+				_, _ = fmt.Fprintf(stdout, "%s:%d:%d: [%s] %s\n", d.File, d.Range.Start.Line, d.Range.Start.Column, d.RuleID, d.Message)
 			} else {
-				fmt.Fprintf(stdout, "%s: [%s] %s\n", d.File, d.RuleID, d.Message)
+				_, _ = fmt.Fprintf(stdout, "%s: [%s] %s\n", d.File, d.RuleID, d.Message)
 			}
 		}
 		if jsonOut {
@@ -130,7 +130,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	if jsonOut {
 		all.Sort()
 		if err := diag.WriteJSON(stdout, len(names), all); err != nil {
-			fmt.Fprintf(stderr, "zsh-lint: encoding JSON: %v\n", err)
+			_, _ = fmt.Fprintf(stderr, "zsh-lint: encoding JSON: %v\n", err)
 			return 2
 		}
 	}

--- a/cmd/zsh-lint/main_test.go
+++ b/cmd/zsh-lint/main_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const cliConfig = `{
+  "version": 1,
+  "project": {
+    "kind": "plugin",
+    "minimum_zsh": "5.8",
+    "function_namespaces": ["example"]
+  },
+  "sources": [
+    {"root": ".", "profile": "sourced-library"},
+    {"root": "functions", "profile": "autoload-function"}
+  ]
+}`
+
+func TestRunUsageErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "no inputs", want: usage},
+		{name: "unknown flag", args: []string{"--unknown"}, want: "flag provided but not defined"},
+		{name: "unknown format", args: []string{"--format=text", "test.zsh"}, want: "unsupported output format"},
+		{name: "empty config", args: []string{"--config=", "test.zsh"}, want: "requires a non-empty path"},
+		{name: "duplicate config", args: []string{"--config=one", "--config=two", "test.zsh"}, want: "may be specified only once"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if exit := run(test.args, &stdout, &stderr); exit != 2 {
+				t.Errorf("run() exit = %d, want 2", exit)
+			}
+			if stdout.Len() != 0 {
+				t.Errorf("stdout = %q, want empty", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), test.want) {
+				t.Errorf("stderr = %q, want substring %q", stderr.String(), test.want)
+			}
+		})
+	}
+}
+
+func TestRunPreservesUnconfiguredBehavior(t *testing.T) {
+	root := t.TempDir()
+	filename := filepath.Join(root, "script.zsh")
+	writeFile(t, filename, "eval $value\n")
+
+	var stdout, stderr bytes.Buffer
+	if exit := run([]string{filename}, &stdout, &stderr); exit != 1 {
+		t.Fatalf("run() exit = %d, want 1", exit)
+	}
+	if !strings.Contains(stdout.String(), "[security/eval]") {
+		t.Errorf("stdout = %q, want security/eval diagnostic", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestRunWithConfiguration(t *testing.T) {
+	root := t.TempDir()
+	config := filepath.Join(root, "zsh-lint.json")
+	script := filepath.Join(root, "functions", "example-run")
+	writeFile(t, config, cliConfig)
+	writeFile(t, script, "builtin emulate -L zsh\nprint ok\n")
+
+	var stdout, stderr bytes.Buffer
+	if exit := run([]string{"--config", config, script}, &stdout, &stderr); exit != 0 {
+		t.Fatalf("run() exit = %d, want 0; stderr = %q", exit, stderr.String())
+	}
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Errorf("stdout = %q, stderr = %q, want both empty", stdout.String(), stderr.String())
+	}
+}
+
+func TestRunRejectsConfigurationBeforeAnalysis(t *testing.T) {
+	root := t.TempDir()
+	config := filepath.Join(root, "zsh-lint.json")
+	outside := filepath.Join(t.TempDir(), "outside.zsh")
+	writeFile(t, config, cliConfig)
+	writeFile(t, outside, "eval $value\n")
+
+	var stdout, stderr bytes.Buffer
+	if exit := run([]string{"--format=json", "--config", config, outside}, &stdout, &stderr); exit != 2 {
+		t.Fatalf("run() exit = %d, want 2", exit)
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("stdout = %q, want no diagnostics", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "outside configuration root") {
+		t.Errorf("stderr = %q, want containment error", stderr.String())
+	}
+}
+
+func TestRunRejectsMissingOrInvalidConfiguration(t *testing.T) {
+	root := t.TempDir()
+	script := filepath.Join(root, "script.zsh")
+	invalid := filepath.Join(root, "invalid.json")
+	writeFile(t, script, "eval $value\n")
+	writeFile(t, invalid, `{}`)
+
+	tests := []struct {
+		name   string
+		config string
+		want   string
+	}{
+		{name: "missing", config: filepath.Join(root, "missing.json"), want: "configuration: open"},
+		{name: "invalid", config: invalid, want: "missing required field"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if exit := run([]string{"--format=json", "--config", test.config, script}, &stdout, &stderr); exit != 2 {
+				t.Fatalf("run() exit = %d, want 2", exit)
+			}
+			if stdout.Len() != 0 {
+				t.Errorf("stdout = %q, want no diagnostics", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), test.want) {
+				t.Errorf("stderr = %q, want substring %q", stderr.String(), test.want)
+			}
+		})
+	}
+}
+
+func TestRunJSONWithConfiguration(t *testing.T) {
+	root := t.TempDir()
+	config := filepath.Join(root, "zsh-lint.json")
+	script := filepath.Join(root, "script.zsh")
+	writeFile(t, config, cliConfig)
+	writeFile(t, script, "print ok\n")
+
+	var stdout, stderr bytes.Buffer
+	if exit := run([]string{"--format=json", "--config", config, script}, &stdout, &stderr); exit != 0 {
+		t.Fatalf("run() exit = %d, want 0; stderr = %q", exit, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"files":1`) {
+		t.Errorf("stdout = %q, want JSON file count", stdout.String())
+	}
+}
+
+func TestRunConfigurationActivatesProjectProfile(t *testing.T) {
+	root := t.TempDir()
+	config := filepath.Join(root, "zsh-lint.json")
+	script := filepath.Join(root, "functions", "refresh")
+	writeFile(t, config, cliConfig)
+	writeFile(t, script, "builtin emulate -L zsh\n")
+
+	var stdout, stderr bytes.Buffer
+	if exit := run([]string{"--config", config, script}, &stdout, &stderr); exit != 0 {
+		t.Fatalf("run() exit = %d, want 0 for hint-only finding; stderr = %q", exit, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "[plugin/function-namespace]") {
+		t.Errorf("stdout = %q, want project-profile diagnostic", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr = %q, want empty", stderr.String())
+	}
+
+	stdout.Reset()
+	if exit := run([]string{script}, &stdout, &stderr); exit != 0 {
+		t.Fatalf("unconfigured run() exit = %d, want 0; stderr = %q", exit, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "[plugin/function-namespace]") {
+		t.Errorf("unconfigured stdout = %q, want no project-profile diagnostic", stdout.String())
+	}
+}
+
+func writeFile(t *testing.T, filename, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(filename), 0o755); err != nil {
+		t.Fatalf("create parent directory: %v", err)
+	}
+	if err := os.WriteFile(filename, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", filename, err)
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,9 @@ by hand on the wiki.
 
 ## For contributors
 
+The source-adjacent [project configuration contract](project/project-configuration.md)
+documents the explicit metadata available to project-aware rules.
+
 ```sh
 go build ./... && go vet ./... && go test ./...
 go tool gomarkdoc --output ref.md \

--- a/docs/project/project-configuration.md
+++ b/docs/project/project-configuration.md
@@ -30,14 +30,14 @@ sources with explicit function namespaces.
     "function_namespaces": ["example"]
   },
   "sources": [
-    {"root": ".", "profile": "sourced-library"},
-    {"root": "functions", "profile": "autoload-function"},
+    { "root": ".", "profile": "sourced-library" },
+    { "root": "functions", "profile": "autoload-function" },
     {
       "root": "completions",
       "profile": "autoload-function",
       "role": "completion"
     },
-    {"root": "tests", "profile": "test-fixture"}
+    { "root": "tests", "profile": "test-fixture" }
   ]
 }
 ```

--- a/docs/project/project-configuration.md
+++ b/docs/project/project-configuration.md
@@ -1,0 +1,94 @@
+# Project configuration
+
+The `zsh-lint` project configuration supplies explicit project and source
+metadata to rules that need more context than one syntax tree can provide. It
+is opt-in. Version 1 performs no automatic configuration discovery.
+
+Pass the configuration path on every configured invocation:
+
+```sh
+zsh-lint --config zsh-lint.json plugin.zsh functions/example-run
+zsh-lint --format=json --config zsh-lint.json plugin.zsh
+```
+
+Invocations without `--config` preserve the unconfigured behavior and default
+rule set.
+
+A valid version 1 configuration also activates the version 1 project-aware
+rule profile. The current profile adds `plugin/function-namespace`; it remains
+inactive without `--config` and evaluates only configured plugin or Zi annex
+sources with explicit function namespaces.
+
+## Version 1 format
+
+```json
+{
+  "version": 1,
+  "project": {
+    "kind": "plugin",
+    "minimum_zsh": "5.8",
+    "function_namespaces": ["example"]
+  },
+  "sources": [
+    {"root": ".", "profile": "sourced-library"},
+    {"root": "functions", "profile": "autoload-function"},
+    {
+      "root": "completions",
+      "profile": "autoload-function",
+      "role": "completion"
+    },
+    {"root": "tests", "profile": "test-fixture"}
+  ]
+}
+```
+
+All fields shown above are required except `sources[].role`.
+
+### Project fields
+
+- `version` must be `1`.
+- `project.kind` must be one of `plugin`, `theme`, `zi-annex`, `module`,
+  `library`, `tool`, or `application`.
+- `project.minimum_zsh` has two or three numeric components, such as `5.8` or
+  `5.9.1`. Components must not have leading zeroes.
+- `project.function_namespaces` is an explicit list of namespaces accepted by
+  rules that evaluate function names. Each value is matched as a literal name
+  prefix. Namespaces are never inferred from a repository or directory name.
+  The list may be empty.
+
+### Source fields
+
+Each `sources` entry maps a configuration-relative root to an execution
+profile. At least one source entry is required.
+
+`profile` must be one of:
+
+- `standalone-executable`
+- `startup-file`
+- `sourced-library`
+- `autoload-function`
+- `test-fixture`
+
+The optional `role` field supports `completion` in version 1. That role requires
+the `autoload-function` profile.
+
+Source roots use forward slashes, must be clean relative paths, and must not
+escape the directory containing the configuration. Duplicate roots are
+invalid. When roots overlap, the longest matching root wins. For example,
+`functions/example-run` resolves to `functions` rather than `.` in the example
+configuration.
+
+Resolution is lexical. The linter does not execute files or resolve symlinks to
+classify an input. Every configured input must remain beneath the configuration
+directory and match one source root.
+
+## Validation and errors
+
+Configuration parsing is strict and accepts exactly one UTF-8 JSON document of
+at most 1 MiB. Unknown, duplicate, or case-mismatched field names are errors.
+
+The CLI loads the configuration and resolves all input paths before parsing any
+source file. A configuration or source-mapping error is written to standard
+error, produces no source diagnostics, and exits with status 2. Findings retain
+the existing exit-status contract: status 1 when an error or warning is
+reported, otherwise status 0.

--- a/docs/project/rule-policy.md
+++ b/docs/project/rule-policy.md
@@ -90,8 +90,9 @@ A rule PR is mergeable when:
    safe text extraction, table-driven tests).
 3. Table-driven tests cover the Bad and Good examples plus every documented
    false-positive case.
-4. The rule is registered in `internal/rules.Default()` and the generated
-   reference docs are regenerated.
+4. The rule is registered in `internal/rules.Default()`, or in an explicitly
+   versioned opt-in profile when its approved proposal requires project
+   metadata. The generated reference docs are regenerated in either case.
 5. Running the analyzer over the survey corpus produces no finding the
    author cannot classify as true positive or documented false positive.
 

--- a/docs/project/suppression.md
+++ b/docs/project/suppression.md
@@ -48,10 +48,19 @@ Two placements, both line-scoped:
    print $word_splitting_intended
    ```
 
-There is deliberately **no file-level or block-level scope in the first
-wave**: line scope keeps suppressions adjacent to the code they excuse and
-prevents drive-by blanket disabling. File/block scope, if ever needed, is a
-separate proposal that must amend this contract.
+An unpositioned whole-file diagnostic, such as a contract derived from an
+autoload filename, can be suppressed only by a standalone directive in the
+file header before any source code:
+
+```zsh
+# zsh-lint disable=plugin/function-namespace -- intentional external API name
+builtin emulate -L zsh
+```
+
+The same header directive retains its ordinary preceding-line scope for
+positioned findings. A directive after executable code cannot suppress a
+whole-file finding. There is no general file-wide or block-level suppression
+for positioned diagnostics.
 
 A suppression silences only the listed rule IDs, only within its scope.
 Diagnostics from other rules on the same line are unaffected.
@@ -93,9 +102,9 @@ remain included so editor and CI integrations can audit suppression usage.
 See `docs/project/output-contract.md` for the settled machine-readable
 contract.
 
-## Out of scope (first wave)
+## Out of scope
 
-- File-level and block-level scopes.
+- File-wide suppression of positioned diagnostics and block-level scopes.
 - Severity overrides via comments (use configuration, not inline
   directives).
 - Enabling rules inline (`enable=`) — configuration owns rule activation.

--- a/docs/project/suppression.md
+++ b/docs/project/suppression.md
@@ -107,4 +107,4 @@ contract.
 - File-wide suppression of positioned diagnostics and block-level scopes.
 - Severity overrides via comments (use configuration, not inline
   directives).
-- Enabling rules inline (`enable=`) — configuration owns rule activation.
+- Enabling rules inline (`enable=`): configuration owns rule activation.

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -3,6 +3,7 @@ package analyzer
 import (
 	"github.com/z-shell/zsh-lint/internal/diag"
 	"github.com/z-shell/zsh-lint/internal/parse"
+	"github.com/z-shell/zsh-lint/internal/projectconfig"
 	"github.com/z-shell/zsh-lint/internal/suppress"
 	"mvdan.cc/sh/v3/syntax"
 )
@@ -22,8 +23,22 @@ func New(rules ...Rule) *Analyzer {
 // Analyze runs the semantic analyzer on the parsed file. Rules that implement
 // ScopeAwareRule opt into a scope-resolution pass before rule evaluation.
 func (a *Analyzer) Analyze(file *parse.File, path string) diag.Diagnostics {
-	ctx := NewContext(file, path)
+	return a.AnalyzeSource(file, path, projectconfig.SourceContext{})
+}
+
+// AnalyzeSource runs the semantic analyzer with resolved project and
+// execution-profile metadata. Analyze remains the compatibility entry point
+// for callers that do not use project configuration.
+func (a *Analyzer) AnalyzeSource(file *parse.File, path string, source projectconfig.SourceContext) diag.Diagnostics {
+	ctx := NewContextWithSource(file, path, source)
 	ast := file.AST()
+
+	// File-level evaluation runs once and may report an unpositioned finding.
+	for _, rule := range a.rules {
+		if fileRule, ok := rule.(FileRule); ok {
+			fileRule.AnalyzeFile(ctx)
+		}
+	}
 
 	// Pass 1: Scope Resolution (Indexer), only when a rule consumes it.
 	if ast != nil && needsScope(a.rules) {

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/z-shell/zsh-lint/internal/analyzer"
 	"github.com/z-shell/zsh-lint/internal/diag"
 	"github.com/z-shell/zsh-lint/internal/parse"
+	"github.com/z-shell/zsh-lint/internal/projectconfig"
 	"github.com/z-shell/zsh-lint/internal/rules"
 	"mvdan.cc/sh/v3/syntax"
 )
@@ -27,6 +28,28 @@ func (r *dummyRule) Analyze(ctx *analyzer.Context, node syntax.Node) {
 
 type scopeRule struct {
 	sawGlobal bool
+}
+
+type sourceRule struct {
+	source projectconfig.SourceContext
+}
+
+func (r *sourceRule) ID() diag.RuleID { return "test/source" }
+func (r *sourceRule) Name() string    { return "Source Rule" }
+func (r *sourceRule) Analyze(ctx *analyzer.Context, _ syntax.Node) {
+	r.source = ctx.Source.Clone()
+}
+
+type fileRule struct {
+	calls int
+}
+
+func (r *fileRule) ID() diag.RuleID                            { return "test/file" }
+func (r *fileRule) Name() string                               { return "File Rule" }
+func (r *fileRule) Analyze(_ *analyzer.Context, _ syntax.Node) {}
+func (r *fileRule) AnalyzeFile(ctx *analyzer.Context) {
+	r.calls++
+	ctx.Report(syntax.Pos{}, syntax.Pos{}, r.ID(), diag.Hint, "file finding")
 }
 
 func (r *scopeRule) ID() diag.RuleID { return "test/scope" }
@@ -75,6 +98,62 @@ func TestAnalyzerIndexesScopeForOptInRule(t *testing.T) {
 
 	if !rule.sawGlobal {
 		t.Fatal("scope-aware rule did not receive the declaration index")
+	}
+}
+
+func TestAnalyzerSuppliesSourceContext(t *testing.T) {
+	file, err := parse.Parse(strings.NewReader("print ok\n"), "functions/example-run")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	want := projectconfig.SourceContext{
+		ConfigVersion:      projectconfig.CurrentVersion,
+		ProjectKind:        projectconfig.KindPlugin,
+		MinimumZsh:         "5.8",
+		FunctionNamespaces: []string{"example"},
+		Profile:            projectconfig.ProfileAutoloadFunction,
+		SourceRoot:         "functions",
+	}
+	rule := &sourceRule{}
+	analyzer.New(rule).AnalyzeSource(file, "functions/example-run", want)
+	if rule.source.ConfigVersion != want.ConfigVersion || rule.source.ProjectKind != want.ProjectKind ||
+		rule.source.MinimumZsh != want.MinimumZsh ||
+		rule.source.Profile != want.Profile || rule.source.SourceRoot != want.SourceRoot ||
+		len(rule.source.FunctionNamespaces) != 1 || rule.source.FunctionNamespaces[0] != "example" {
+		t.Errorf("source context = %+v, want %+v", rule.source, want)
+	}
+
+	want.FunctionNamespaces[0] = "mutated"
+	if rule.source.FunctionNamespaces[0] != "example" {
+		t.Errorf("analyzer retained caller-owned namespace storage: %q", rule.source.FunctionNamespaces)
+	}
+}
+
+func TestAnalyzerLegacyEntryPointHasUnconfiguredSource(t *testing.T) {
+	file, err := parse.Parse(strings.NewReader("print ok\n"), "test.zsh")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	rule := &sourceRule{}
+	analyzer.New(rule).Analyze(file, "test.zsh")
+	if rule.source.Configured() {
+		t.Errorf("legacy Analyze() source = %+v, want unconfigured context", rule.source)
+	}
+}
+
+func TestAnalyzerRunsFileRuleOnce(t *testing.T) {
+	file, err := parse.Parse(strings.NewReader("print one\nprint two\n"), "test.zsh")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	rule := &fileRule{}
+	diagnostics := analyzer.New(rule).Analyze(file, "test.zsh")
+	if rule.calls != 1 {
+		t.Errorf("AnalyzeFile calls = %d, want 1", rule.calls)
+	}
+	if len(diagnostics) != 1 || diagnostics[0].Range.IsValid() {
+		t.Errorf("file diagnostics = %+v, want one unpositioned finding", diagnostics)
 	}
 }
 

--- a/internal/analyzer/context.go
+++ b/internal/analyzer/context.go
@@ -3,6 +3,7 @@ package analyzer
 import (
 	"github.com/z-shell/zsh-lint/internal/diag"
 	"github.com/z-shell/zsh-lint/internal/parse"
+	"github.com/z-shell/zsh-lint/internal/projectconfig"
 	"github.com/z-shell/zsh-lint/internal/scope"
 	"mvdan.cc/sh/v3/syntax"
 )
@@ -12,15 +13,26 @@ type Context struct {
 	File        *parse.File
 	FilePath    string
 	Diagnostics diag.Diagnostics
+	// Source contains optional project and execution-profile metadata supplied
+	// by an explicit project configuration.
+	Source projectconfig.SourceContext
 	// Scope tracking per ADR 0011
 	Scope *scope.Map
 }
 
 // NewContext creates a new analysis context for a file.
 func NewContext(file *parse.File, path string) *Context {
+	return NewContextWithSource(file, path, projectconfig.SourceContext{})
+}
+
+// NewContextWithSource creates an analysis context with resolved project and
+// execution-profile metadata. Slice fields are cloned so rules cannot mutate
+// metadata shared with another input.
+func NewContextWithSource(file *parse.File, path string, source projectconfig.SourceContext) *Context {
 	return &Context{
 		File:     file,
 		FilePath: path,
+		Source:   source.Clone(),
 		Scope:    scope.NewMap(),
 	}
 }

--- a/internal/analyzer/rule.go
+++ b/internal/analyzer/rule.go
@@ -15,6 +15,13 @@ type Rule interface {
 	Analyze(ctx *Context, node syntax.Node)
 }
 
+// FileRule is implemented by rules that report file-level findings which do
+// not belong to one AST node, such as contracts derived from an autoload file
+// name. AnalyzeFile is called once per parsed file before node traversal.
+type FileRule interface {
+	AnalyzeFile(ctx *Context)
+}
+
 // ScopeAwareRule is implemented by rules that need the declaration index.
 // Most rules inspect syntax only, so the analyzer skips the indexing pass
 // unless at least one registered rule opts in.

--- a/internal/projectconfig/config.go
+++ b/internal/projectconfig/config.go
@@ -1,0 +1,209 @@
+// Package projectconfig loads and resolves explicit zsh-lint project metadata.
+package projectconfig
+
+import (
+	"fmt"
+	"path"
+	"strconv"
+	"strings"
+)
+
+// CurrentVersion is the only configuration schema version understood by this
+// release.
+const CurrentVersion = 1
+
+// ProjectKind identifies the kind of Z-Shell project being analyzed.
+type ProjectKind string
+
+const (
+	KindPlugin      ProjectKind = "plugin"
+	KindTheme       ProjectKind = "theme"
+	KindZiAnnex     ProjectKind = "zi-annex"
+	KindModule      ProjectKind = "module"
+	KindLibrary     ProjectKind = "library"
+	KindTool        ProjectKind = "tool"
+	KindApplication ProjectKind = "application"
+)
+
+// Profile identifies how a source file executes in Zsh.
+type Profile string
+
+const (
+	ProfileStandaloneExecutable Profile = "standalone-executable"
+	ProfileStartupFile          Profile = "startup-file"
+	ProfileSourcedLibrary       Profile = "sourced-library"
+	ProfileAutoloadFunction     Profile = "autoload-function"
+	ProfileTestFixture          Profile = "test-fixture"
+)
+
+// SourceRole refines a source profile when a rule needs a narrower contract.
+// The empty role is ordinary source; completion is the only version 1 role.
+type SourceRole string
+
+const RoleCompletion SourceRole = "completion"
+
+// Config is the validated version 1 project configuration.
+type Config struct {
+	Version int
+	Project Project
+	Sources []Source
+
+	root string
+}
+
+// Project contains project-wide metadata shared by every configured source.
+type Project struct {
+	Kind               ProjectKind
+	MinimumZsh         string
+	FunctionNamespaces []string
+}
+
+// Source maps a project-relative root to one execution profile and optional
+// role. More-specific roots take precedence during resolution.
+type Source struct {
+	Root    string
+	Profile Profile
+	Role    SourceRole
+}
+
+// SourceContext is immutable-by-convention metadata supplied to analyzer
+// rules for one resolved input file.
+type SourceContext struct {
+	ConfigVersion      int
+	ProjectKind        ProjectKind
+	MinimumZsh         string
+	FunctionNamespaces []string
+	Profile            Profile
+	Role               SourceRole
+	ConfigRoot         string
+	SourceRoot         string
+}
+
+// Configured reports whether this context came from a configured source.
+func (c SourceContext) Configured() bool { return c.Profile != "" }
+
+// Clone returns a context whose slice fields do not share backing storage with
+// the receiver.
+func (c SourceContext) Clone() SourceContext {
+	c.FunctionNamespaces = append([]string(nil), c.FunctionNamespaces...)
+	return c
+}
+
+func (c *Config) validate() error {
+	if c.Version != CurrentVersion {
+		return fmt.Errorf("version: unsupported schema version %d (want %d)", c.Version, CurrentVersion)
+	}
+	if !validProjectKind(c.Project.Kind) {
+		return fmt.Errorf("project.kind: unknown project kind %q", c.Project.Kind)
+	}
+	if err := validateZshVersion(c.Project.MinimumZsh); err != nil {
+		return fmt.Errorf("project.minimum_zsh: %w", err)
+	}
+
+	seenNamespaces := make(map[string]bool, len(c.Project.FunctionNamespaces))
+	for index, namespace := range c.Project.FunctionNamespaces {
+		field := fmt.Sprintf("project.function_namespaces[%d]", index)
+		if namespace == "" {
+			return fmt.Errorf("%s: must not be empty", field)
+		}
+		if strings.TrimSpace(namespace) != namespace {
+			return fmt.Errorf("%s: must not have leading or trailing whitespace", field)
+		}
+		if strings.ContainsRune(namespace, '\x00') {
+			return fmt.Errorf("%s: must not contain NUL", field)
+		}
+		if seenNamespaces[namespace] {
+			return fmt.Errorf("%s: duplicate namespace %q", field, namespace)
+		}
+		seenNamespaces[namespace] = true
+	}
+
+	if len(c.Sources) == 0 {
+		return fmt.Errorf("sources: must contain at least one source root")
+	}
+	seenRoots := make(map[string]bool, len(c.Sources))
+	for index, source := range c.Sources {
+		field := fmt.Sprintf("sources[%d]", index)
+		if err := validateSourceRoot(source.Root); err != nil {
+			return fmt.Errorf("%s.root: %w", field, err)
+		}
+		if seenRoots[source.Root] {
+			return fmt.Errorf("%s.root: duplicate source root %q", field, source.Root)
+		}
+		seenRoots[source.Root] = true
+		if !validProfile(source.Profile) {
+			return fmt.Errorf("%s.profile: unknown execution profile %q", field, source.Profile)
+		}
+		if source.Role != "" && source.Role != RoleCompletion {
+			return fmt.Errorf("%s.role: unknown source role %q", field, source.Role)
+		}
+		if source.Role == RoleCompletion && source.Profile != ProfileAutoloadFunction {
+			return fmt.Errorf("%s.role: completion requires profile %q", field, ProfileAutoloadFunction)
+		}
+	}
+	return nil
+}
+
+func validProjectKind(kind ProjectKind) bool {
+	switch kind {
+	case KindPlugin, KindTheme, KindZiAnnex, KindModule, KindLibrary, KindTool, KindApplication:
+		return true
+	default:
+		return false
+	}
+}
+
+func validProfile(profile Profile) bool {
+	switch profile {
+	case ProfileStandaloneExecutable, ProfileStartupFile, ProfileSourcedLibrary,
+		ProfileAutoloadFunction, ProfileTestFixture:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateZshVersion(version string) error {
+	parts := strings.Split(version, ".")
+	if len(parts) < 2 || len(parts) > 3 {
+		return fmt.Errorf("must contain two or three numeric components")
+	}
+	for _, part := range parts {
+		if part == "" {
+			return fmt.Errorf("must contain two or three numeric components")
+		}
+		if len(part) > 1 && part[0] == '0' {
+			return fmt.Errorf("component %q has a leading zero", part)
+		}
+		if _, err := strconv.ParseUint(part, 10, 31); err != nil {
+			return fmt.Errorf("component %q is not a non-negative integer", part)
+		}
+	}
+	return nil
+}
+
+func validateSourceRoot(root string) error {
+	if root == "" {
+		return fmt.Errorf("must not be empty")
+	}
+	if strings.ContainsRune(root, '\x00') {
+		return fmt.Errorf("must not contain NUL")
+	}
+	if strings.ContainsRune(root, '\\') {
+		return fmt.Errorf("must use forward slashes")
+	}
+	if path.IsAbs(root) {
+		return fmt.Errorf("must be relative to the configuration directory")
+	}
+	if len(root) >= 2 && root[1] == ':' &&
+		((root[0] >= 'A' && root[0] <= 'Z') || (root[0] >= 'a' && root[0] <= 'z')) {
+		return fmt.Errorf("must not contain a Windows drive prefix")
+	}
+	if cleaned := path.Clean(root); cleaned != root {
+		return fmt.Errorf("must be clean (use %q)", cleaned)
+	}
+	if root == ".." || strings.HasPrefix(root, "../") {
+		return fmt.Errorf("must not escape the configuration directory")
+	}
+	return nil
+}

--- a/internal/projectconfig/config_test.go
+++ b/internal/projectconfig/config_test.go
@@ -1,0 +1,123 @@
+package projectconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const validConfig = `{
+  "version": 1,
+  "project": {
+    "kind": "plugin",
+    "minimum_zsh": "5.8",
+    "function_namespaces": ["example"]
+  },
+  "sources": [
+    {"root": ".", "profile": "sourced-library"},
+    {"root": "functions", "profile": "autoload-function"},
+    {"root": "completions", "profile": "autoload-function", "role": "completion"},
+    {"root": "tests", "profile": "test-fixture"}
+  ]
+}`
+
+func TestLoadValidConfiguration(t *testing.T) {
+	filename := writeConfig(t, []byte(validConfig))
+	config, err := Load(filename)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if config.Version != CurrentVersion {
+		t.Errorf("Version = %d, want %d", config.Version, CurrentVersion)
+	}
+	if config.Project.Kind != KindPlugin {
+		t.Errorf("Project.Kind = %q, want %q", config.Project.Kind, KindPlugin)
+	}
+	if config.Project.MinimumZsh != "5.8" {
+		t.Errorf("Project.MinimumZsh = %q, want 5.8", config.Project.MinimumZsh)
+	}
+	if got := config.Project.FunctionNamespaces; len(got) != 1 || got[0] != "example" {
+		t.Errorf("Project.FunctionNamespaces = %q, want [example]", got)
+	}
+	if len(config.Sources) != 4 {
+		t.Fatalf("Sources count = %d, want 4", len(config.Sources))
+	}
+	if config.Sources[2].Role != RoleCompletion {
+		t.Errorf("completion role = %q, want %q", config.Sources[2].Role, RoleCompletion)
+	}
+}
+
+func TestLoadRejectsInvalidConfiguration(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want string
+	}{
+		{name: "unknown top-level field", data: strings.Replace(validConfig, `"version": 1,`, `"version": 1, "extra": true,`, 1), want: `unknown field "extra"`},
+		{name: "case-mismatched field", data: strings.Replace(validConfig, `"version"`, `"Version"`, 1), want: `unknown field "Version"`},
+		{name: "duplicate nested field", data: strings.Replace(validConfig, `"kind": "plugin",`, `"kind": "plugin", "kind": "theme",`, 1), want: `duplicate field "kind"`},
+		{name: "trailing document", data: validConfig + ` {}`, want: "unexpected value after top-level document"},
+		{name: "unsupported version", data: strings.Replace(validConfig, `"version": 1`, `"version": 2`, 1), want: "unsupported schema version 2"},
+		{name: "unknown kind", data: strings.Replace(validConfig, `"kind": "plugin"`, `"kind": "bundle"`, 1), want: `unknown project kind "bundle"`},
+		{name: "invalid zsh version", data: strings.Replace(validConfig, `"minimum_zsh": "5.8"`, `"minimum_zsh": "05.8"`, 1), want: "leading zero"},
+		{name: "null namespaces", data: strings.Replace(validConfig, `["example"]`, `null`, 1), want: "function_namespaces: must be an array"},
+		{name: "duplicate namespace", data: strings.Replace(validConfig, `["example"]`, `["example", "example"]`, 1), want: "duplicate namespace"},
+		{name: "whitespace namespace", data: strings.Replace(validConfig, `["example"]`, `[" example"]`, 1), want: "leading or trailing whitespace"},
+		{name: "empty sources", data: replaceSources(validConfig, `[]`), want: "must contain at least one source root"},
+		{name: "absolute source root", data: strings.Replace(validConfig, `"root": "."`, `"root": "/tmp"`, 1), want: "must be relative"},
+		{name: "drive-prefixed source root", data: strings.Replace(validConfig, `"root": "."`, `"root": "C:/tmp"`, 1), want: "Windows drive prefix"},
+		{name: "escaping source root", data: strings.Replace(validConfig, `"root": "."`, `"root": "../outside"`, 1), want: "must not escape"},
+		{name: "dirty source root", data: strings.Replace(validConfig, `"root": "functions"`, `"root": "src/../functions"`, 1), want: "must be clean"},
+		{name: "backslash source root", data: strings.Replace(validConfig, `"root": "functions"`, `"root": "functions\\\\nested"`, 1), want: "must use forward slashes"},
+		{name: "duplicate source root", data: strings.Replace(validConfig, `"root": "functions"`, `"root": "."`, 1), want: "duplicate source root"},
+		{name: "unknown profile", data: strings.Replace(validConfig, `"profile": "sourced-library"`, `"profile": "library"`, 1), want: `unknown execution profile "library"`},
+		{name: "unknown role", data: strings.Replace(validConfig, `"role": "completion"`, `"role": "generated"`, 1), want: `unknown source role "generated"`},
+		{name: "completion role mismatch", data: strings.Replace(validConfig, `"profile": "autoload-function", "role": "completion"`, `"profile": "sourced-library", "role": "completion"`, 1), want: "completion requires profile"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Load(writeConfig(t, []byte(test.data)))
+			if err == nil {
+				t.Fatal("Load() succeeded, want error")
+			}
+			if !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Load() error = %q, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestLoadRejectsInvalidUTF8(t *testing.T) {
+	data := append([]byte(validConfig), 0xff)
+	_, err := Load(writeConfig(t, data))
+	if err == nil || !strings.Contains(err.Error(), "not valid UTF-8") {
+		t.Fatalf("Load() error = %v, want invalid UTF-8 error", err)
+	}
+}
+
+func TestLoadRejectsOversizedConfiguration(t *testing.T) {
+	_, err := Load(writeConfig(t, make([]byte, maxConfigBytes+1)))
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("Load() error = %v, want size limit error", err)
+	}
+}
+
+func writeConfig(t *testing.T, data []byte) string {
+	t.Helper()
+	filename := filepath.Join(t.TempDir(), "zsh-lint.json")
+	if err := os.WriteFile(filename, data, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return filename
+}
+
+func replaceSources(config, replacement string) string {
+	start := strings.Index(config, `"sources": [`)
+	if start < 0 {
+		return config
+	}
+	return config[:start] + `"sources": ` + replacement + "\n}"
+}

--- a/internal/projectconfig/config_test.go
+++ b/internal/projectconfig/config_test.go
@@ -74,6 +74,7 @@ func TestLoadRejectsInvalidConfiguration(t *testing.T) {
 		{name: "duplicate source root", data: strings.Replace(validConfig, `"root": "functions"`, `"root": "."`, 1), want: "duplicate source root"},
 		{name: "unknown profile", data: strings.Replace(validConfig, `"profile": "sourced-library"`, `"profile": "library"`, 1), want: `unknown execution profile "library"`},
 		{name: "unknown role", data: strings.Replace(validConfig, `"role": "completion"`, `"role": "generated"`, 1), want: `unknown source role "generated"`},
+		{name: "null role", data: strings.Replace(validConfig, `"role": "completion"`, `"role": null`, 1), want: "role: must be a string"},
 		{name: "completion role mismatch", data: strings.Replace(validConfig, `"profile": "autoload-function", "role": "completion"`, `"profile": "sourced-library", "role": "completion"`, 1), want: "completion requires profile"},
 	}
 

--- a/internal/projectconfig/decode.go
+++ b/internal/projectconfig/decode.go
@@ -19,7 +19,7 @@ func Load(filename string) (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open %q: %w", filename, err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	data, err := io.ReadAll(io.LimitReader(file, maxConfigBytes+1))
 	if err != nil {

--- a/internal/projectconfig/decode.go
+++ b/internal/projectconfig/decode.go
@@ -191,6 +191,9 @@ func decodeSource(data []byte, index int) (Source, error) {
 		return Source{}, fmt.Errorf("%s.profile: %w", location, err)
 	}
 	if raw, ok := object["role"]; ok {
+		if isJSONNull(raw) {
+			return Source{}, fmt.Errorf("%s.role: must be a string", location)
+		}
 		if err := json.Unmarshal(raw, &source.Role); err != nil {
 			return Source{}, fmt.Errorf("%s.role: %w", location, err)
 		}

--- a/internal/projectconfig/decode.go
+++ b/internal/projectconfig/decode.go
@@ -1,0 +1,230 @@
+package projectconfig
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"unicode/utf8"
+)
+
+const maxConfigBytes = 1 << 20
+
+// Load reads, strictly decodes, and validates a project configuration. The
+// configuration root is the directory containing filename.
+func Load(filename string) (*Config, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("open %q: %w", filename, err)
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(io.LimitReader(file, maxConfigBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read %q: %w", filename, err)
+	}
+	if len(data) > maxConfigBytes {
+		return nil, fmt.Errorf("read %q: configuration exceeds %d bytes", filename, maxConfigBytes)
+	}
+	if !utf8.Valid(data) {
+		return nil, fmt.Errorf("decode %q: configuration is not valid UTF-8", filename)
+	}
+	if err := rejectDuplicateNames(data); err != nil {
+		return nil, fmt.Errorf("decode %q: %w", filename, err)
+	}
+
+	config, err := decodeConfig(data)
+	if err != nil {
+		return nil, fmt.Errorf("decode %q: %w", filename, err)
+	}
+	if err := config.validate(); err != nil {
+		return nil, fmt.Errorf("validate %q: %w", filename, err)
+	}
+	abs, err := filepath.Abs(filename)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %q: %w", filename, err)
+	}
+	config.root = filepath.Dir(filepath.Clean(abs))
+	return config, nil
+}
+
+func rejectDuplicateNames(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	if err := walkJSONValue(decoder, "$"); err != nil {
+		return err
+	}
+	if token, err := decoder.Token(); err != io.EOF {
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("unexpected value after top-level document: %v", token)
+	}
+	return nil
+}
+
+func walkJSONValue(decoder *json.Decoder, location string) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+
+	switch delim {
+	case '{':
+		seen := make(map[string]bool)
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return fmt.Errorf("%s: object key is not a string", location)
+			}
+			if seen[key] {
+				return fmt.Errorf("%s: duplicate field %q", location, key)
+			}
+			seen[key] = true
+			if err := walkJSONValue(decoder, location+"."+key); err != nil {
+				return err
+			}
+		}
+		_, err = decoder.Token()
+		return err
+	case '[':
+		index := 0
+		for decoder.More() {
+			if err := walkJSONValue(decoder, fmt.Sprintf("%s[%d]", location, index)); err != nil {
+				return err
+			}
+			index++
+		}
+		_, err = decoder.Token()
+		return err
+	default:
+		return fmt.Errorf("%s: unexpected delimiter %q", location, delim)
+	}
+}
+
+func decodeConfig(data []byte) (*Config, error) {
+	object, err := decodeObject(data, "$", []string{"version", "project", "sources"})
+	if err != nil {
+		return nil, err
+	}
+	if err := requireFields(object, "$", "version", "project", "sources"); err != nil {
+		return nil, err
+	}
+
+	config := &Config{}
+	if err := json.Unmarshal(object["version"], &config.Version); err != nil {
+		return nil, fmt.Errorf("$.version: %w", err)
+	}
+	project, err := decodeProject(object["project"])
+	if err != nil {
+		return nil, err
+	}
+	config.Project = project
+
+	var rawSources []json.RawMessage
+	if isJSONNull(object["sources"]) {
+		return nil, fmt.Errorf("$.sources: must be an array")
+	}
+	if err := json.Unmarshal(object["sources"], &rawSources); err != nil {
+		return nil, fmt.Errorf("$.sources: %w", err)
+	}
+	config.Sources = make([]Source, 0, len(rawSources))
+	for index, raw := range rawSources {
+		source, err := decodeSource(raw, index)
+		if err != nil {
+			return nil, err
+		}
+		config.Sources = append(config.Sources, source)
+	}
+	return config, nil
+}
+
+func decodeProject(data []byte) (Project, error) {
+	object, err := decodeObject(data, "$.project", []string{"kind", "minimum_zsh", "function_namespaces"})
+	if err != nil {
+		return Project{}, err
+	}
+	if err := requireFields(object, "$.project", "kind", "minimum_zsh", "function_namespaces"); err != nil {
+		return Project{}, err
+	}
+
+	var project Project
+	if err := json.Unmarshal(object["kind"], &project.Kind); err != nil {
+		return Project{}, fmt.Errorf("$.project.kind: %w", err)
+	}
+	if err := json.Unmarshal(object["minimum_zsh"], &project.MinimumZsh); err != nil {
+		return Project{}, fmt.Errorf("$.project.minimum_zsh: %w", err)
+	}
+	if isJSONNull(object["function_namespaces"]) {
+		return Project{}, fmt.Errorf("$.project.function_namespaces: must be an array")
+	}
+	if err := json.Unmarshal(object["function_namespaces"], &project.FunctionNamespaces); err != nil {
+		return Project{}, fmt.Errorf("$.project.function_namespaces: %w", err)
+	}
+	return project, nil
+}
+
+func decodeSource(data []byte, index int) (Source, error) {
+	location := fmt.Sprintf("$.sources[%d]", index)
+	object, err := decodeObject(data, location, []string{"root", "profile", "role"})
+	if err != nil {
+		return Source{}, err
+	}
+	if err := requireFields(object, location, "root", "profile"); err != nil {
+		return Source{}, err
+	}
+
+	var source Source
+	if err := json.Unmarshal(object["root"], &source.Root); err != nil {
+		return Source{}, fmt.Errorf("%s.root: %w", location, err)
+	}
+	if err := json.Unmarshal(object["profile"], &source.Profile); err != nil {
+		return Source{}, fmt.Errorf("%s.profile: %w", location, err)
+	}
+	if raw, ok := object["role"]; ok {
+		if err := json.Unmarshal(raw, &source.Role); err != nil {
+			return Source{}, fmt.Errorf("%s.role: %w", location, err)
+		}
+	}
+	return source, nil
+}
+
+func decodeObject(data []byte, location string, allowed []string) (map[string]json.RawMessage, error) {
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(data, &object); err != nil {
+		return nil, fmt.Errorf("%s: %w", location, err)
+	}
+	if object == nil {
+		return nil, fmt.Errorf("%s: must be an object", location)
+	}
+	allowedSet := make(map[string]bool, len(allowed))
+	for _, field := range allowed {
+		allowedSet[field] = true
+	}
+	for field := range object {
+		if !allowedSet[field] {
+			return nil, fmt.Errorf("%s: unknown field %q", location, field)
+		}
+	}
+	return object, nil
+}
+
+func requireFields(object map[string]json.RawMessage, location string, fields ...string) error {
+	for _, field := range fields {
+		if _, ok := object[field]; !ok {
+			return fmt.Errorf("%s: missing required field %q", location, field)
+		}
+	}
+	return nil
+}
+
+func isJSONNull(data []byte) bool { return bytes.Equal(bytes.TrimSpace(data), []byte("null")) }

--- a/internal/projectconfig/resolve.go
+++ b/internal/projectconfig/resolve.go
@@ -1,0 +1,68 @@
+package projectconfig
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// Resolve classifies filename using the most-specific matching source root.
+// Both the configuration root and input path use lexical absolute paths;
+// symlinks are not resolved or executed.
+func (c *Config) Resolve(filename string) (SourceContext, error) {
+	if c == nil || c.root == "" {
+		return SourceContext{}, fmt.Errorf("resolve %q: configuration has no root", filename)
+	}
+	abs, err := filepath.Abs(filename)
+	if err != nil {
+		return SourceContext{}, fmt.Errorf("resolve %q: %w", filename, err)
+	}
+	abs = filepath.Clean(abs)
+	if !pathContains(c.root, abs) {
+		return SourceContext{}, fmt.Errorf("resolve %q: input is outside configuration root %q", filename, c.root)
+	}
+
+	best := -1
+	bestDepth := -1
+	for index, source := range c.Sources {
+		root := filepath.Join(c.root, filepath.FromSlash(source.Root))
+		if !pathContains(root, abs) {
+			continue
+		}
+		depth := sourceDepth(source.Root)
+		if depth > bestDepth {
+			best = index
+			bestDepth = depth
+		}
+	}
+	if best < 0 {
+		return SourceContext{}, fmt.Errorf("resolve %q: input matches no configured source root", filename)
+	}
+
+	source := c.Sources[best]
+	return SourceContext{
+		ConfigVersion:      c.Version,
+		ProjectKind:        c.Project.Kind,
+		MinimumZsh:         c.Project.MinimumZsh,
+		FunctionNamespaces: append([]string(nil), c.Project.FunctionNamespaces...),
+		Profile:            source.Profile,
+		Role:               source.Role,
+		ConfigRoot:         c.root,
+		SourceRoot:         source.Root,
+	}, nil
+}
+
+func pathContains(root, candidate string) bool {
+	relative, err := filepath.Rel(root, candidate)
+	if err != nil {
+		return false
+	}
+	return relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}
+
+func sourceDepth(root string) int {
+	if root == "." {
+		return 0
+	}
+	return strings.Count(root, "/") + 1
+}

--- a/internal/projectconfig/resolve_test.go
+++ b/internal/projectconfig/resolve_test.go
@@ -1,0 +1,81 @@
+package projectconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveUsesMostSpecificSourceRoot(t *testing.T) {
+	root := t.TempDir()
+	filename := filepath.Join(root, "zsh-lint.json")
+	if err := os.WriteFile(filename, []byte(validConfig), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	config, err := Load(filename)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	tests := []struct {
+		path        string
+		wantRoot    string
+		wantProfile Profile
+		wantRole    SourceRole
+	}{
+		{path: "plugin.zsh", wantRoot: ".", wantProfile: ProfileSourcedLibrary},
+		{path: "functions/example-run", wantRoot: "functions", wantProfile: ProfileAutoloadFunction},
+		{path: "completions/_example", wantRoot: "completions", wantProfile: ProfileAutoloadFunction, wantRole: RoleCompletion},
+		{path: "tests/fixture.zsh", wantRoot: "tests", wantProfile: ProfileTestFixture},
+	}
+
+	for _, test := range tests {
+		t.Run(test.path, func(t *testing.T) {
+			context, err := config.Resolve(filepath.Join(root, filepath.FromSlash(test.path)))
+			if err != nil {
+				t.Fatalf("Resolve() error = %v", err)
+			}
+			if context.SourceRoot != test.wantRoot || context.Profile != test.wantProfile || context.Role != test.wantRole {
+				t.Errorf("Resolve() = root %q profile %q role %q, want %q/%q/%q",
+					context.SourceRoot, context.Profile, context.Role,
+					test.wantRoot, test.wantProfile, test.wantRole)
+			}
+			if context.ConfigVersion != CurrentVersion || context.ProjectKind != KindPlugin ||
+				context.MinimumZsh != "5.8" || !context.Configured() {
+				t.Errorf("project context is incomplete: %+v", context)
+			}
+			context.FunctionNamespaces[0] = "mutated"
+		})
+	}
+
+	context, err := config.Resolve(filepath.Join(root, "plugin.zsh"))
+	if err != nil {
+		t.Fatalf("Resolve() after mutation error = %v", err)
+	}
+	if context.FunctionNamespaces[0] != "example" {
+		t.Errorf("resolved namespace was mutated across calls: %q", context.FunctionNamespaces)
+	}
+}
+
+func TestResolveRejectsOutsideAndUnmatchedInputs(t *testing.T) {
+	root := t.TempDir()
+	data := strings.Replace(validConfig,
+		`{"root": ".", "profile": "sourced-library"},`, "", 1)
+	filename := filepath.Join(root, "zsh-lint.json")
+	if err := os.WriteFile(filename, []byte(data), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	config, err := Load(filename)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	outside := filepath.Join(filepath.Dir(root), filepath.Base(root)+"-sibling", "script.zsh")
+	if _, err := config.Resolve(outside); err == nil || !strings.Contains(err.Error(), "outside configuration root") {
+		t.Fatalf("Resolve(outside) error = %v, want containment error", err)
+	}
+	if _, err := config.Resolve(filepath.Join(root, "script.zsh")); err == nil || !strings.Contains(err.Error(), "matches no configured") {
+		t.Fatalf("Resolve(unmatched) error = %v, want unmatched error", err)
+	}
+}

--- a/internal/rules/function_namespace.go
+++ b/internal/rules/function_namespace.go
@@ -1,0 +1,173 @@
+package rules
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/z-shell/zsh-lint/internal/analyzer"
+	"github.com/z-shell/zsh-lint/internal/diag"
+	"github.com/z-shell/zsh-lint/internal/projectconfig"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// FunctionNamespace reports persistent plugin function names outside the
+// configured stable project namespace.
+//
+// ID: `plugin/function-namespace`
+//
+// Name: Project-owned function namespace
+//
+// Summary: Reports named functions in configured plugin and Zi annex source
+// files, plus effective function names derived from configured autoload file
+// basenames, when they do not use an explicitly declared project namespace.
+//
+// Why: The Zsh Plugin Standard requires persistent shell-visible names to use
+// a stable project identifier. Namespacing prevents collisions when unrelated
+// plugins share one shell process. Native completions keep Zsh's `_command`
+// convention, and the established `.`, `→`, `+`, `/`, and `@` role prefixes
+// remain valid before the project namespace. The portable `_example_callback`
+// form is also accepted. See
+// https://wiki.zshell.dev/community/zsh_plugin_standard#names-and-persistent-state
+// and
+// https://wiki.zshell.dev/community/zsh_plugin_standard#standard-function-name-space-prefixes.
+//
+// Bad:
+//
+//	refresh() { builtin emulate -L zsh; }
+//
+// Good:
+//
+//	example_refresh() { builtin emulate -L zsh; }
+//	_example_precmd() { builtin emulate -L zsh; }
+//
+// Severity: Hint. A mismatched namespace is an interoperability and hygiene
+// concern, not invalid Zsh syntax.
+//
+// False positives: The rule runs only with version 1 project configuration,
+// a plugin or Zi annex project kind, a sourced-library or autoload-function
+// source profile, and at least one explicit function namespace. Completion
+// basenames use `_command` only when the source role is `completion`.
+// Repository names and directory names are never inferred as namespaces.
+//
+// Suppression: Use
+// `# zsh-lint disable=plugin/function-namespace -- <reason>` on a declaration
+// line or immediately before it. For an autoload basename finding, put the
+// standalone directive in the file header before any source code.
+//
+// Corpus evidence: `zsh-eza/functions/.zsh-eza` and the
+// `z-a-meta-plugins/functions/.za-meta-plugins-*` files use their configured
+// namespaces. `zsh-fancy-completions/lib/state.zsh` uses its explicit `zfc`
+// namespace. Its five legacy dot-prefixed autoload basenames (`.complete_menu`,
+// `.completion-prediction`, `.expand-or-complete-with-dots`, `.force_rehash`,
+// and `.man_glob`) are classified as true-positive Hint findings. Advisory
+// rollout does not require renaming those established external interfaces.
+type FunctionNamespace struct{}
+
+func (FunctionNamespace) ID() diag.RuleID { return "plugin/function-namespace" }
+
+func (FunctionNamespace) Name() string { return "Project-owned function namespace" }
+
+func (rule FunctionNamespace) Analyze(ctx *analyzer.Context, node syntax.Node) {
+	if !functionNamespaceEnabled(ctx.Source) || ctx.Source.Profile != projectconfig.ProfileSourcedLibrary {
+		return
+	}
+	declaration, ok := node.(*syntax.FuncDecl)
+	if !ok || declaration == nil {
+		return
+	}
+	for _, name := range functionDeclarationNames(declaration) {
+		if namespacedFunction(name.Value, ctx.Source.FunctionNamespaces) {
+			continue
+		}
+		ctx.Report(
+			name.Pos(),
+			name.End(),
+			rule.ID(),
+			diag.Hint,
+			functionNamespaceMessage("Function", name.Value, ctx.Source.FunctionNamespaces),
+		)
+	}
+}
+
+// AnalyzeFile checks the effective function name supplied by an autoload file
+// basename. It deliberately reports an unpositioned diagnostic because no AST
+// token represents that name.
+func (rule FunctionNamespace) AnalyzeFile(ctx *analyzer.Context) {
+	if !functionNamespaceEnabled(ctx.Source) || ctx.Source.Profile != projectconfig.ProfileAutoloadFunction {
+		return
+	}
+	name := filepath.Base(filepath.Clean(ctx.FilePath))
+	if ctx.Source.Role == projectconfig.RoleCompletion {
+		if strings.HasPrefix(name, "_") && name != "_" {
+			return
+		}
+		ctx.Report(
+			syntax.Pos{},
+			syntax.Pos{},
+			rule.ID(),
+			diag.Hint,
+			fmt.Sprintf("Autoload completion name %q must use the _command form", name),
+		)
+		return
+	}
+	if namespacedFunction(name, ctx.Source.FunctionNamespaces) {
+		return
+	}
+	ctx.Report(
+		syntax.Pos{},
+		syntax.Pos{},
+		rule.ID(),
+		diag.Hint,
+		functionNamespaceMessage("Autoload function", name, ctx.Source.FunctionNamespaces),
+	)
+}
+
+func functionNamespaceEnabled(source projectconfig.SourceContext) bool {
+	if source.ConfigVersion != projectconfig.CurrentVersion || len(source.FunctionNamespaces) == 0 {
+		return false
+	}
+	return source.ProjectKind == projectconfig.KindPlugin || source.ProjectKind == projectconfig.KindZiAnnex
+}
+
+func functionDeclarationNames(declaration *syntax.FuncDecl) []*syntax.Lit {
+	if declaration.Name != nil {
+		return []*syntax.Lit{declaration.Name}
+	}
+	return declaration.Names
+}
+
+func namespacedFunction(name string, namespaces []string) bool {
+	if hasFunctionNamespace(name, namespaces) {
+		return true
+	}
+	for _, prefix := range []string{".", "→", "+", "/", "@", "_"} {
+		if strings.HasPrefix(name, prefix) {
+			return hasFunctionNamespace(strings.TrimPrefix(name, prefix), namespaces)
+		}
+	}
+	return false
+}
+
+func hasFunctionNamespace(name string, namespaces []string) bool {
+	for _, namespace := range namespaces {
+		if strings.HasPrefix(name, namespace) {
+			return true
+		}
+	}
+	return false
+}
+
+func functionNamespaceMessage(kind, name string, namespaces []string) string {
+	quoted := make([]string, len(namespaces))
+	for index, namespace := range namespaces {
+		quoted[index] = strconv.Quote(namespace)
+	}
+	return fmt.Sprintf(
+		"%s name %q must use a configured project namespace (%s) after any recognized role prefix",
+		kind,
+		name,
+		strings.Join(quoted, ", "),
+	)
+}

--- a/internal/rules/function_namespace_test.go
+++ b/internal/rules/function_namespace_test.go
@@ -1,0 +1,265 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/z-shell/zsh-lint/internal/analyzer"
+	"github.com/z-shell/zsh-lint/internal/diag"
+	"github.com/z-shell/zsh-lint/internal/parse"
+	"github.com/z-shell/zsh-lint/internal/projectconfig"
+)
+
+func TestFunctionNamespaceDeclarations(t *testing.T) {
+	tests := []struct {
+		name       string
+		source     string
+		namespaces []string
+		want       int
+	}{
+		{name: "public underscore", source: "example_refresh() { :; }\n", want: 0},
+		{name: "portable private", source: "_example_precmd() { :; }\n", want: 0},
+		{name: "established private", source: "function .example_private { :; }\n", want: 0},
+		{name: "hook role", source: "function →example_hook { :; }\n", want: 0},
+		{name: "output role", source: "function +example_output { :; }\n", want: 0},
+		{name: "debug role", source: "function /example_debug { :; }\n", want: 0},
+		{name: "api role", source: "function @example_api { :; }\n", want: 0},
+		{name: "alternate namespace", source: "_zfc_state() { :; }\n", namespaces: []string{"example", "zfc"}, want: 0},
+		{name: "unicode role and namespace", source: "function →δοκιμή_hook { :; }\n", namespaces: []string{"δοκιμή"}, want: 0},
+		{name: "missing namespace", source: "refresh() { :; }\n", want: 1},
+		{name: "role without namespace", source: "function .refresh { :; }\n", want: 1},
+		{name: "only one role prefix stripped", source: "function ..example_private { :; }\n", want: 1},
+		{name: "multiple declaration names", source: "function example_one foreign { :; }\n", want: 1},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			namespaces := test.namespaces
+			if namespaces == nil {
+				namespaces = []string{"example"}
+			}
+			diagnostics := analyzeFunctionNamespace(t, test.source, "plugin.zsh", sourcedPlugin(namespaces...))
+			got := diagnosticsByID(diagnostics, "plugin/function-namespace")
+			if len(got) != test.want {
+				t.Fatalf("finding count = %d, want %d: %+v", len(got), test.want, diagnostics)
+			}
+		})
+	}
+}
+
+func TestFunctionNamespaceDeclarationRange(t *testing.T) {
+	diagnostics := analyzeFunctionNamespace(t, "print ok\nfunction refresh { :; }\n", "plugin.zsh", sourcedPlugin("example"))
+	got := diagnosticsByID(diagnostics, "plugin/function-namespace")
+	if len(got) != 1 {
+		t.Fatalf("finding count = %d, want 1: %+v", len(got), diagnostics)
+	}
+	if got[0].Range.Start.Line != 2 || got[0].Range.Start.Column != 10 || got[0].Range.End.Column != 17 {
+		t.Errorf("range = %+v, want line 2 columns 10..17", got[0].Range)
+	}
+	if !strings.Contains(got[0].Message, `Function name "refresh"`) {
+		t.Errorf("message = %q, want function name", got[0].Message)
+	}
+}
+
+func TestFunctionNamespaceZiAnnexDeclaration(t *testing.T) {
+	context := sourceContext(projectconfig.KindZiAnnex, projectconfig.ProfileSourcedLibrary, "za-example")
+	diagnostics := analyzeFunctionNamespace(t, ".foreign_handler() { :; }\n", "z-a-example.plugin.zsh", context)
+	got := diagnosticsByID(diagnostics, "plugin/function-namespace")
+	if len(got) != 1 {
+		t.Fatalf("finding count = %d, want 1: %+v", len(got), diagnostics)
+	}
+}
+
+func TestFunctionNamespaceNoOpProfiles(t *testing.T) {
+	tests := []struct {
+		name    string
+		context projectconfig.SourceContext
+	}{
+		{name: "unconfigured", context: projectconfig.SourceContext{}},
+		{name: "standalone", context: sourceContext(projectconfig.KindPlugin, projectconfig.ProfileStandaloneExecutable, "example")},
+		{name: "startup", context: sourceContext(projectconfig.KindPlugin, projectconfig.ProfileStartupFile, "example")},
+		{name: "test fixture", context: sourceContext(projectconfig.KindPlugin, projectconfig.ProfileTestFixture, "example")},
+		{name: "library project", context: sourceContext(projectconfig.KindLibrary, projectconfig.ProfileSourcedLibrary, "example")},
+		{name: "empty namespaces", context: sourceContext(projectconfig.KindPlugin, projectconfig.ProfileSourcedLibrary)},
+		{name: "unknown config version", context: sourcedPlugin("example")},
+	}
+	tests[len(tests)-1].context.ConfigVersion = 2
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			diagnostics := analyzeFunctionNamespace(t, "refresh() { :; }\n", "script.zsh", test.context)
+			if got := diagnosticsByID(diagnostics, "plugin/function-namespace"); len(got) != 0 {
+				t.Errorf("findings = %+v, want none", got)
+			}
+		})
+	}
+}
+
+func TestFunctionNamespaceAutoloadBasenames(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		role       projectconfig.SourceRole
+		namespaces []string
+		want       int
+		message    string
+	}{
+		{name: "public", path: "functions/example_refresh", want: 0},
+		{name: "private", path: "functions/.example_refresh", want: 0},
+		{name: "hook", path: "functions/→example_hook", want: 0},
+		{name: "output", path: "functions/+example_output", want: 0},
+		{name: "api", path: "functions/@example_api", want: 0},
+		{name: "alternate namespace", path: "functions/.zfc_state", namespaces: []string{"example", "zfc"}, want: 0},
+		{name: "missing namespace", path: "functions/.refresh", want: 1, message: `Autoload function name ".refresh"`},
+		{name: "completion", path: "completions/_git", role: projectconfig.RoleCompletion, want: 0},
+		{name: "completion requires underscore", path: "completions/example_git", role: projectconfig.RoleCompletion, want: 1, message: "must use the _command form"},
+		{name: "bare underscore is not completion", path: "completions/_", role: projectconfig.RoleCompletion, want: 1, message: "must use the _command form"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			namespaces := test.namespaces
+			if namespaces == nil {
+				namespaces = []string{"example"}
+			}
+			context := sourceContext(projectconfig.KindPlugin, projectconfig.ProfileAutoloadFunction, namespaces...)
+			context.Role = test.role
+			diagnostics := analyzeFunctionNamespace(t, "builtin emulate -L zsh\n", test.path, context)
+			got := diagnosticsByID(diagnostics, "plugin/function-namespace")
+			if len(got) != test.want {
+				t.Fatalf("finding count = %d, want %d: %+v", len(got), test.want, diagnostics)
+			}
+			if len(got) != 0 {
+				if got[0].Range.IsValid() {
+					t.Errorf("basename finding range = %+v, want unpositioned", got[0].Range)
+				}
+				if test.message != "" && !strings.Contains(got[0].Message, test.message) {
+					t.Errorf("message = %q, want substring %q", got[0].Message, test.message)
+				}
+			}
+		})
+	}
+}
+
+func TestFunctionNamespaceSuppression(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		source       string
+		wantRule     int
+		wantMeta     diag.RuleID
+		wantContains string
+	}{
+		{
+			name:     "header suppresses basename",
+			path:     "functions/.refresh",
+			source:   "# zsh-lint disable=plugin/function-namespace -- intentional external API\nbuiltin emulate -L zsh\n",
+			wantRule: 0,
+		},
+		{
+			name:         "header is stale for valid basename",
+			path:         "functions/.example_refresh",
+			source:       "# zsh-lint disable=plugin/function-namespace -- intentional external API\nbuiltin emulate -L zsh\n",
+			wantRule:     0,
+			wantMeta:     "meta/unused-suppression",
+			wantContains: "matched no finding",
+		},
+		{
+			name:         "malformed header suppresses nothing",
+			path:         "functions/.refresh",
+			source:       "# zsh-lint enable=plugin/function-namespace\nbuiltin emulate -L zsh\n",
+			wantRule:     1,
+			wantMeta:     "meta/malformed-suppression",
+			wantContains: "unknown verb",
+		},
+		{
+			name:         "unknown header rule is stale",
+			path:         "functions/.refresh",
+			source:       "# zsh-lint disable=plugin/not-a-rule\nbuiltin emulate -L zsh\n",
+			wantRule:     1,
+			wantMeta:     "meta/unused-suppression",
+			wantContains: "unknown rule ID",
+		},
+		{
+			name:         "directive after code cannot suppress basename",
+			path:         "functions/.refresh",
+			source:       "builtin emulate -L zsh\n# zsh-lint disable=plugin/function-namespace\n",
+			wantRule:     1,
+			wantMeta:     "meta/unused-suppression",
+			wantContains: "matched no finding",
+		},
+		{
+			name:     "preceding suppresses declaration",
+			path:     "plugin.zsh",
+			source:   "# zsh-lint disable=plugin/function-namespace -- external API\nrefresh() { :; }\n",
+			wantRule: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			context := sourceContext(projectconfig.KindPlugin, projectconfig.ProfileAutoloadFunction, "example")
+			if test.path == "plugin.zsh" {
+				context.Profile = projectconfig.ProfileSourcedLibrary
+			}
+			diagnostics := analyzeFunctionNamespace(t, test.source, test.path, context)
+			if got := diagnosticsByID(diagnostics, "plugin/function-namespace"); len(got) != test.wantRule {
+				t.Errorf("rule findings = %d, want %d: %+v", len(got), test.wantRule, diagnostics)
+			}
+			if test.wantMeta == "" {
+				if got := metaDiagnostics(diagnostics); len(got) != 0 {
+					t.Errorf("meta findings = %+v, want none", got)
+				}
+				return
+			}
+			got := diagnosticsByID(diagnostics, test.wantMeta)
+			if len(got) != 1 || !strings.Contains(got[0].Message, test.wantContains) {
+				t.Errorf("meta findings = %+v, want one %s containing %q", got, test.wantMeta, test.wantContains)
+			}
+		})
+	}
+}
+
+func analyzeFunctionNamespace(t *testing.T, source, path string, context projectconfig.SourceContext) diag.Diagnostics {
+	t.Helper()
+	file, err := parse.Parse(strings.NewReader(source), path)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	return analyzer.New(FunctionNamespace{}).AnalyzeSource(file, path, context)
+}
+
+func sourcedPlugin(namespaces ...string) projectconfig.SourceContext {
+	return sourceContext(projectconfig.KindPlugin, projectconfig.ProfileSourcedLibrary, namespaces...)
+}
+
+func sourceContext(kind projectconfig.ProjectKind, profile projectconfig.Profile, namespaces ...string) projectconfig.SourceContext {
+	return projectconfig.SourceContext{
+		ConfigVersion:      projectconfig.CurrentVersion,
+		ProjectKind:        kind,
+		MinimumZsh:         "5.8",
+		FunctionNamespaces: namespaces,
+		Profile:            profile,
+		SourceRoot:         ".",
+	}
+}
+
+func diagnosticsByID(diagnostics diag.Diagnostics, id diag.RuleID) diag.Diagnostics {
+	var found diag.Diagnostics
+	for _, diagnostic := range diagnostics {
+		if diagnostic.RuleID == id {
+			found = append(found, diagnostic)
+		}
+	}
+	return found
+}
+
+func metaDiagnostics(diagnostics diag.Diagnostics) diag.Diagnostics {
+	var found diag.Diagnostics
+	for _, diagnostic := range diagnostics {
+		if strings.HasPrefix(string(diagnostic.RuleID), "meta/") {
+			found = append(found, diagnostic)
+		}
+	}
+	return found
+}

--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"github.com/z-shell/zsh-lint/internal/analyzer"
+	"github.com/z-shell/zsh-lint/internal/projectconfig"
 )
 
 // Default returns the default set of static analysis rules.
@@ -18,4 +19,13 @@ func Default() []analyzer.Rule {
 		UnloadFunction{},
 		FpathHygiene{},
 	}
+}
+
+// ProjectProfile returns the opt-in rules associated with one validated
+// project-configuration version. These rules are not part of Default.
+func ProjectProfile(version int) []analyzer.Rule {
+	if version != projectconfig.CurrentVersion {
+		return nil
+	}
+	return []analyzer.Rule{FunctionNamespace{}}
 }

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -92,3 +92,33 @@ func TestDefaultIncludesFpathHygiene(t *testing.T) {
 	}
 	t.Fatal("Default rules do not include plugin/fpath-hygiene")
 }
+
+func TestFunctionNamespaceIsOptIn(t *testing.T) {
+	for _, rule := range Default() {
+		if rule.ID() == "plugin/function-namespace" {
+			t.Fatal("Default includes opt-in plugin/function-namespace")
+		}
+	}
+	profile := ProjectProfile(1)
+	if len(profile) != 1 || profile[0].ID() != "plugin/function-namespace" {
+		t.Fatalf("ProjectProfile(1) = %v, want plugin/function-namespace", profile)
+	}
+	if profile := ProjectProfile(2); len(profile) != 0 {
+		t.Fatalf("ProjectProfile(2) = %v, want no rules", profile)
+	}
+}
+
+func TestFunctionNamespaceSeverity(t *testing.T) {
+	file, err := parse.Parse(strings.NewReader("refresh() { :; }\n"), "plugin.zsh")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	diagnostics := analyzer.New(FunctionNamespace{}).AnalyzeSource(
+		file,
+		"plugin.zsh",
+		sourcedPlugin("example"),
+	)
+	if len(diagnostics) != 1 || diagnostics[0].Severity != diag.Hint {
+		t.Fatalf("diagnostics = %+v, want one hint", diagnostics)
+	}
+}

--- a/internal/suppress/suppress.go
+++ b/internal/suppress/suppress.go
@@ -6,11 +6,12 @@
 //	# zsh-lint disable=<rule-id>[,<rule-id>...] [-- reason]
 //
 // with two line-based scopes: trailing (same line as code) and preceding
-// (next non-comment, non-blank source line). Malformed directives are
-// reported as meta/malformed-suppression and suppress nothing; listed rule
-// IDs that match no finding in scope are reported per ID as
-// meta/unused-suppression. meta/* findings are never suppressible, so
-// machine output always carries them (docs/project/output-contract.md).
+// (next non-comment, non-blank source line). A standalone directive in the
+// file header also applies to unpositioned whole-file findings. Malformed
+// directives are reported as meta/malformed-suppression and suppress nothing;
+// listed rule IDs that match no finding in scope are reported per ID as
+// meta/unused-suppression. meta/* findings are never suppressible, so machine
+// output always carries them (docs/project/output-contract.md).
 package suppress
 
 import (
@@ -44,6 +45,9 @@ type Directive struct {
 	// Target is the 1-based line findings must start on to be suppressed;
 	// 0 means the directive has no scope (nothing follows it).
 	Target int
+	// Header reports whether this is a standalone directive before any source
+	// code. Header directives additionally target unpositioned file findings.
+	Header bool
 	// Range spans the source comment, for positioning meta findings.
 	Range diag.Range
 	// Malformed holds the parse-failure reason; empty means well-formed.
@@ -82,13 +86,20 @@ func Apply(ds []Directive, findings diag.Diagnostics, known map[diag.RuleID]bool
 	}
 	type slot struct{ d, r int }
 	active := make(map[key][]slot)
+	fileActive := make(map[diag.RuleID][]slot)
 	for di, d := range ds {
-		if d.Malformed != "" || d.Target == 0 {
+		if d.Malformed != "" {
 			continue
 		}
 		for ri, id := range d.Rules {
-			k := key{d.Target, id}
-			active[k] = append(active[k], slot{di, ri})
+			s := slot{di, ri}
+			if d.Target != 0 {
+				k := key{d.Target, id}
+				active[k] = append(active[k], s)
+			}
+			if d.Header {
+				fileActive[id] = append(fileActive[id], s)
+			}
 		}
 	}
 
@@ -99,7 +110,13 @@ func Apply(ds []Directive, findings diag.Diagnostics, known map[diag.RuleID]bool
 			kept = append(kept, f)
 			continue
 		}
-		if slots, ok := active[key{f.Range.Start.Line, f.RuleID}]; ok {
+		var slots []slot
+		if f.Range.IsValid() {
+			slots = active[key{f.Range.Start.Line, f.RuleID}]
+		} else {
+			slots = fileActive[f.RuleID]
+		}
+		if len(slots) != 0 {
 			for _, s := range slots {
 				used[s] = true
 			}
@@ -149,6 +166,7 @@ func parseDirective(c *syntax.Comment, lines []string) (Directive, bool) {
 	d := Directive{
 		Range:  commentRange(c),
 		Target: targetLine(int(c.Hash.Line()), int(c.Hash.Col()), lines),
+		Header: headerDirective(int(c.Hash.Line()), int(c.Hash.Col()), lines),
 	}
 	rest := fields[1:]
 	if len(rest) == 0 {
@@ -186,6 +204,29 @@ func parseDirective(c *syntax.Comment, lines []string) (Directive, bool) {
 		d.Rules = append(d.Rules, diag.RuleID(id))
 	}
 	return d, true
+}
+
+// headerDirective reports whether the comment is standalone and every earlier
+// source line is blank or comment-only. This makes file suppressions explicit
+// and keeps a directive after executable code line-scoped.
+func headerDirective(line, col int, lines []string) bool {
+	if line < 1 || line > len(lines) {
+		return false
+	}
+	prefix := lines[line-1]
+	if col-1 >= 0 && col-1 <= len(prefix) {
+		prefix = prefix[:col-1]
+	}
+	if strings.TrimSpace(prefix) != "" {
+		return false
+	}
+	for _, earlier := range lines[:line-1] {
+		trimmed := strings.TrimSpace(earlier)
+		if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+			return false
+		}
+	}
+	return true
 }
 
 // targetLine resolves the directive's scope per the contract: trailing when

--- a/internal/suppress/suppress_test.go
+++ b/internal/suppress/suppress_test.go
@@ -182,6 +182,15 @@ func finding(id diag.RuleID, line int) diag.Diagnostic {
 	}
 }
 
+func fileFinding(id diag.RuleID) diag.Diagnostic {
+	return diag.Diagnostic{
+		RuleID:   id,
+		Severity: diag.Hint,
+		Message:  "file finding",
+		File:     "test.zsh",
+	}
+}
+
 func ids(ds diag.Diagnostics) []string {
 	var out []string
 	for _, d := range ds {
@@ -318,4 +327,45 @@ func TestApply(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("header directive suppresses an unpositioned file finding", func(t *testing.T) {
+		d := wellFormed(3, "security/eval")
+		d.Header = true
+		got := Apply([]Directive{d}, diag.Diagnostics{fileFinding("security/eval")}, known, "test.zsh")
+		if len(got) != 0 {
+			t.Fatalf("Apply = %+v, want file finding suppressed", got)
+		}
+	})
+
+	t.Run("directive after code does not suppress a file finding", func(t *testing.T) {
+		d := wellFormed(3, "security/eval")
+		got := Apply([]Directive{d}, diag.Diagnostics{fileFinding("security/eval")}, known, "test.zsh")
+		if len(got) != 2 || got[0].RuleID != "security/eval" || got[1].RuleID != RuleUnused {
+			t.Fatalf("Apply = %+v, want file finding and unused suppression", got)
+		}
+	})
+}
+
+func TestCollectMarksOnlyHeaderDirectivesForFileScope(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{name: "first line", src: "# zsh-lint disable=plugin/function-namespace\nprint ok\n", want: true},
+		{name: "after shebang and comments", src: "#!/usr/bin/env zsh\n# context\n# zsh-lint disable=plugin/function-namespace\nprint ok\n", want: true},
+		{name: "after code", src: "print one\n# zsh-lint disable=plugin/function-namespace\nprint two\n", want: false},
+		{name: "trailing", src: "print one # zsh-lint disable=plugin/function-namespace\n", want: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			directives := Collect(mustParse(t, test.src))
+			if len(directives) != 1 {
+				t.Fatalf("Collect() count = %d, want 1", len(directives))
+			}
+			if directives[0].Header != test.want {
+				t.Errorf("Header = %v, want %v", directives[0].Header, test.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- add strict, versioned project configuration with explicit source profiles and namespaces
- add the opt-in `plugin/function-namespace` hint rule for plugin and Zi annex sources
- support file-level diagnostics and header suppression for autoload basenames
- preserve the existing unconfigured analyzer and default rule set
- reject explicit null source roles during strict configuration decoding

## Corpus evaluation

Evaluated the current 20-file reference corpus from fresh `main` checkouts of `src`, `zd`, `zunit`, `z-a-meta-plugins`, `zsh-fancy-completions`, and `zsh-eza`.

- 20 of 20 native Zsh syntax checks passed
- 20 of 20 parser surveys passed
- zero error or warning diagnostics
- exactly five new namespace hints, all documented legacy autoload names under `zsh-fancy-completions/functions/`
- no source suppressions were required

`zsh-fancy-completions` declares both of its real namespaces, `zfc` and `zsh-fancy-completions`, so the canonical unload function is not misclassified.

## Verification

- `go build ./...`
- `go vet ./...`
- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- generated Go reference documentation successfully
- `git diff --check`

Closes #133
Closes #151
