### PR TITLE
feat: add configured rule-profile foundation

### DIFF
--- a/.github/workflows/corpus-gate.yml
+++ b/.github/workflows/corpus-gate.yml
@@ -9,6 +9,8 @@ on:
       - "cmd/**"
       - "docs/project/corpus.md"
       - "docs/project/corpus-paths.txt"
+      - "docs/project/corpus-configs/**"
+      - "docs/project/configured-corpus-expected.json"
       - "go.mod"
       - "go.sum"
       - "internal/**"
@@ -18,6 +20,8 @@ on:
       - "cmd/**"
       - "docs/project/corpus.md"
       - "docs/project/corpus-paths.txt"
+      - "docs/project/corpus-configs/**"
+      - "docs/project/configured-corpus-expected.json"
       - "go.mod"
       - "go.sum"
       - "internal/**"
@@ -156,4 +160,164 @@ jobs:
           if [[ $analyzer_status -ne 0 ]]; then
             echo "::error::zsh-lint exited with status $analyzer_status."
             exit "$analyzer_status"
+          fi
+
+  configured-corpus:
+    name: Configured corpus
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out zsh-lint
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: zsh-lint
+          persist-credentials: false
+
+      - name: Check out src
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: z-shell/src
+          ref: main
+          path: corpus/src
+          persist-credentials: false
+
+      - name: Check out zd
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: z-shell/zd
+          ref: main
+          path: corpus/zd
+          persist-credentials: false
+
+      - name: Check out zunit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: z-shell/zunit
+          ref: main
+          path: corpus/zunit
+          persist-credentials: false
+
+      - name: Check out z-a-meta-plugins
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: z-shell/z-a-meta-plugins
+          ref: main
+          path: corpus/z-a-meta-plugins
+          persist-credentials: false
+
+      - name: Check out zsh-fancy-completions
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: z-shell/zsh-fancy-completions
+          ref: main
+          path: corpus/zsh-fancy-completions
+          persist-credentials: false
+
+      - name: Check out zsh-eza
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: z-shell/zsh-eza
+          ref: main
+          path: corpus/zsh-eza
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.25"
+          cache-dependency-path: zsh-lint/go.sum
+
+      - name: Build configured analyzer
+        working-directory: zsh-lint
+        run: go build -o "$RUNNER_TEMP/zsh-lint" ./cmd/zsh-lint
+
+      - name: Record configured corpus revisions
+        working-directory: corpus
+        run: |
+          for repository in src zd zunit z-a-meta-plugins zsh-fancy-completions zsh-eza; do
+            printf '%s ' "$repository"
+            git -C "$repository" rev-parse HEAD
+          done
+
+      - name: Verify configured corpus classifications
+        working-directory: corpus
+        shell: bash
+        run: |
+          set -euo pipefail
+          repositories=(src zd zunit z-a-meta-plugins zsh-fancy-completions zsh-eza)
+          diagnostic_files=()
+
+          for repository in "${repositories[@]}"; do
+            config_source="../zsh-lint/docs/project/corpus-configs/$repository.json"
+            config="$repository/.zsh-lint-corpus.json"
+            cp "$config_source" "$config"
+
+            mapfile -t roots < <(sed -n "s#^$repository/##p" ../zsh-lint/docs/project/corpus-paths.txt)
+            if [[ ${#roots[@]} -eq 0 ]]; then
+              echo "::error::No configured corpus roots found for $repository."
+              exit 1
+            fi
+
+            input_roots=()
+            for root in "${roots[@]}"; do
+              input_roots+=("$repository/$root")
+            done
+            mapfile -d '' files < <(find "${input_roots[@]}" -type f -print0 | sort -z)
+            if [[ ${#files[@]} -eq 0 ]]; then
+              echo "::error::No configured corpus files found for $repository."
+              exit 1
+            fi
+
+            diagnostics="$RUNNER_TEMP/configured-$repository.json"
+            analyzer_status=0
+            "$RUNNER_TEMP/zsh-lint" --format=json --config "$config" "${files[@]}" > "$diagnostics" || analyzer_status=$?
+            if [[ $analyzer_status -ne 0 ]]; then
+              jq . "$diagnostics"
+              echo "::error::Configured zsh-lint for $repository exited with status $analyzer_status."
+              exit "$analyzer_status"
+            fi
+            diagnostic_files+=("$diagnostics")
+          done
+
+          jq -s '{
+            version: 1,
+            summary: {
+              files: ([.[].summary.files] | add),
+              diagnostics: ([.[].summary.diagnostics] | add),
+              errors: ([.[].summary.errors] | add),
+              warnings: ([.[].summary.warnings] | add),
+              infos: ([.[].summary.infos] | add),
+              hints: ([.[].summary.hints] | add)
+            },
+            diagnostics: ([.[].diagnostics[]] | sort_by(.file, (.range.start.line // 0), (.range.start.column // 0), .rule))
+          }' "${diagnostic_files[@]}" > "$RUNNER_TEMP/configured-corpus.json"
+          jq . "$RUNNER_TEMP/configured-corpus.json"
+
+          if ! jq -e '.summary.errors == 0 and .summary.warnings == 0' "$RUNNER_TEMP/configured-corpus.json" >/dev/null; then
+            echo "::error::The configured corpus contains error- or warning-level diagnostics."
+            exit 1
+          fi
+
+          expected=../zsh-lint/docs/project/configured-corpus-expected.json
+          if ! jq -e 'all(.[]; (.classification | type == "string" and length > 0))' "$expected" >/dev/null; then
+            echo "::error::Every configured corpus finding needs a non-empty classification."
+            exit 1
+          fi
+
+          jq '[.[] | {repository, path, rule, severity, line}] | sort_by(.repository, .path, (.line // 0), .rule)' \
+            "$expected" > "$RUNNER_TEMP/configured-expected-identities.json"
+          jq '[.diagnostics[] |
+            (.file | split("/")) as $parts |
+            {
+              repository: $parts[0],
+              path: ($parts[1:] | join("/")),
+              rule: .rule,
+              severity: .severity,
+              line: (.range.start.line // null)
+            }
+          ] | sort_by(.repository, .path, (.line // 0), .rule)' \
+            "$RUNNER_TEMP/configured-corpus.json" > "$RUNNER_TEMP/configured-actual-identities.json"
+
+          if ! diff -u "$RUNNER_TEMP/configured-expected-identities.json" "$RUNNER_TEMP/configured-actual-identities.json"; then
+            echo "::error::Configured corpus diagnostics changed; review and classify every difference."
+            exit 1
           fi

--- a/cmd/zsh-lint/main.go
+++ b/cmd/zsh-lint/main.go
@@ -60,7 +60,11 @@ func run(args []string, stdout, stderr io.Writer) int {
 			_, _ = fmt.Fprintf(stderr, "zsh-lint: configuration: %v\n", err)
 			return 2
 		}
-		activeRules = append(activeRules, rules.ProjectProfile(config.Version)...)
+		activeRules, err = rules.ForProfile(rules.CurrentProjectProfile)
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "zsh-lint: rule profile: %v\n", err)
+			return 2
+		}
 		sourceContexts = make([]projectconfig.SourceContext, len(names))
 		for index, name := range names {
 			context, err := config.Resolve(name)

--- a/cmd/zsh-lint/main_test.go
+++ b/cmd/zsh-lint/main_test.go
@@ -176,6 +176,42 @@ func TestRunConfigurationActivatesProjectProfile(t *testing.T) {
 	}
 }
 
+func TestRunConfiguredMetadataOverridesLegacyPathHeuristics(t *testing.T) {
+	const toolConfig = `{
+  "version": 1,
+  "project": {
+    "kind": "tool",
+    "minimum_zsh": "5.8",
+    "function_namespaces": []
+  },
+  "sources": [
+    {"root": "functions", "profile": "autoload-function"}
+  ]
+}`
+	root := t.TempDir()
+	config := filepath.Join(root, "zsh-lint.json")
+	script := filepath.Join(root, "functions", "handler")
+	writeFile(t, config, toolConfig)
+	writeFile(t, script, "rehash\n")
+
+	var stdout, stderr bytes.Buffer
+	if exit := run([]string{"--config", config, script}, &stdout, &stderr); exit != 0 {
+		t.Fatalf("configured run() exit = %d, want 0; stdout = %q, stderr = %q", exit, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "[plugin/") {
+		t.Errorf("configured tool stdout = %q, want no plugin diagnostic", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if exit := run([]string{script}, &stdout, &stderr); exit != 0 {
+		t.Fatalf("unconfigured run() exit = %d, want 0; stderr = %q", exit, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "[plugin/function-scoped-options]") {
+		t.Errorf("unconfigured stdout = %q, want legacy path diagnostic", stdout.String())
+	}
+}
+
 func writeFile(t *testing.T, filename, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(filename), 0o755); err != nil {

--- a/docs/project/configured-corpus-expected.json
+++ b/docs/project/configured-corpus-expected.json
@@ -1,0 +1,98 @@
+[
+  {
+    "repository": "zsh-eza",
+    "path": "functions/.zsh-eza",
+    "rule": "plugin/function-scoped-options",
+    "severity": "hint",
+    "line": 10,
+    "classification": "accepted legacy autoload body; advisory migration candidate"
+  },
+  {
+    "repository": "zsh-fancy-completions",
+    "path": "functions/.complete_menu",
+    "rule": "plugin/function-namespace",
+    "severity": "hint",
+    "line": null,
+    "classification": "accepted legacy autoload name; no source suppression"
+  },
+  {
+    "repository": "zsh-fancy-completions",
+    "path": "functions/.completion-prediction",
+    "rule": "plugin/function-namespace",
+    "severity": "hint",
+    "line": null,
+    "classification": "accepted legacy autoload name; no source suppression"
+  },
+  {
+    "repository": "zsh-fancy-completions",
+    "path": "functions/.completion-prediction",
+    "rule": "plugin/function-scoped-options",
+    "severity": "hint",
+    "line": 5,
+    "classification": "accepted legacy autoload body; advisory migration candidate"
+  },
+  {
+    "repository": "zsh-fancy-completions",
+    "path": "functions/.expand-or-complete-with-dots",
+    "rule": "plugin/function-namespace",
+    "severity": "hint",
+    "line": null,
+    "classification": "accepted legacy autoload name; no source suppression"
+  },
+  {
+    "repository": "zsh-fancy-completions",
+    "path": "functions/.force_rehash",
+    "rule": "plugin/function-namespace",
+    "severity": "hint",
+    "line": null,
+    "classification": "accepted legacy autoload name; no source suppression"
+  },
+  {
+    "repository": "zsh-fancy-completions",
+    "path": "functions/.force_rehash",
+    "rule": "plugin/function-scoped-options",
+    "severity": "hint",
+    "line": 4,
+    "classification": "accepted legacy autoload body; advisory migration candidate"
+  },
+  {
+    "repository": "zsh-fancy-completions",
+    "path": "functions/.man_glob",
+    "rule": "plugin/function-namespace",
+    "severity": "hint",
+    "line": null,
+    "classification": "accepted legacy autoload name; no source suppression"
+  },
+  {
+    "repository": "zsh-fancy-completions",
+    "path": "lib/state.zsh",
+    "rule": "security/eval",
+    "severity": "info",
+    "line": 81,
+    "classification": "accepted existing generic advisory in project-owned state restoration"
+  },
+  {
+    "repository": "zsh-fancy-completions",
+    "path": "lib/state.zsh",
+    "rule": "security/eval",
+    "severity": "info",
+    "line": 86,
+    "classification": "accepted existing generic advisory in project-owned state restoration"
+  },
+  {
+    "repository": "zsh-fancy-completions",
+    "path": "lib/state.zsh",
+    "rule": "security/eval",
+    "severity": "info",
+    "line": 93,
+    "classification": "accepted existing generic advisory in project-owned state restoration"
+  },
+  {
+    "repository": "zsh-fancy-completions",
+    "path": "lib/state.zsh",
+    "rule": "security/eval",
+    "severity": "info",
+    "line": 98,
+    "classification": "accepted existing generic advisory in project-owned state restoration"
+  }
+]

--- a/docs/project/corpus-configs/src.json
+++ b/docs/project/corpus-configs/src.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "project": {
+    "kind": "library",
+    "minimum_zsh": "5.8.1",
+    "function_namespaces": []
+  },
+  "sources": [{ "root": "public/zsh", "profile": "sourced-library" }]
+}

--- a/docs/project/corpus-configs/z-a-meta-plugins.json
+++ b/docs/project/corpus-configs/z-a-meta-plugins.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "project": {
+    "kind": "zi-annex",
+    "minimum_zsh": "5.9.2",
+    "function_namespaces": ["za-meta-plugins"]
+  },
+  "sources": [
+    { "root": "z-a-meta-plugins.plugin.zsh", "profile": "sourced-library" },
+    { "root": "functions", "profile": "autoload-function" }
+  ]
+}

--- a/docs/project/corpus-configs/zd.json
+++ b/docs/project/corpus-configs/zd.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "project": {
+    "kind": "tool",
+    "minimum_zsh": "5.5.1",
+    "function_namespaces": []
+  },
+  "sources": [{ "root": "docker", "profile": "test-fixture" }]
+}

--- a/docs/project/corpus-configs/zsh-eza.json
+++ b/docs/project/corpus-configs/zsh-eza.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "project": {
+    "kind": "plugin",
+    "minimum_zsh": "5.9.2",
+    "function_namespaces": ["zsh-eza"]
+  },
+  "sources": [
+    { "root": "zsh-eza.plugin.zsh", "profile": "sourced-library" },
+    { "root": "functions", "profile": "autoload-function" }
+  ]
+}

--- a/docs/project/corpus-configs/zsh-fancy-completions.json
+++ b/docs/project/corpus-configs/zsh-fancy-completions.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "project": {
+    "kind": "plugin",
+    "minimum_zsh": "5.9.2",
+    "function_namespaces": ["zfc", "zsh-fancy-completions"]
+  },
+  "sources": [
+    {
+      "root": "zsh-fancy-completions.plugin.zsh",
+      "profile": "sourced-library"
+    },
+    { "root": "functions", "profile": "autoload-function" },
+    { "root": "lib", "profile": "sourced-library" }
+  ]
+}

--- a/docs/project/corpus-configs/zunit.json
+++ b/docs/project/corpus-configs/zunit.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "project": {
+    "kind": "tool",
+    "minimum_zsh": "5.5.1",
+    "function_namespaces": []
+  },
+  "sources": [{ "root": "build.zsh", "profile": "standalone-executable" }]
+}

--- a/docs/project/corpus.md
+++ b/docs/project/corpus.md
@@ -14,6 +14,12 @@ the rationale for those entries. `.github/workflows/corpus-gate.yml` checks out
 the six repositories at their `main` branches, records the resolved revisions,
 and applies the strict gate to the exact discovered file set.
 
+`corpus-configs/` contains reviewed, non-enrollment configurations for a
+second configured-profile pass. The workflow copies each fixture into its
+repository checkout so configuration-relative containment remains identical to
+a real invocation. These fixtures do not enroll or modify the source
+repositories. Repository enrollment remains separate work under #138.
+
 ## Layout assumption
 
 Entries are paths relative to a checkout root containing the listed
@@ -37,6 +43,24 @@ Inclusion rationale, per family: the corpus deliberately spans the loader
 (`z-a-meta-plugins`), and user-facing plugins (completions, eza) so parser
 gaps found here generalize across the organization's Zsh styles.
 
+### Configured survey metadata
+
+The configured fixtures use the narrowest project kind and source profile
+supported by current repository evidence. Their compatibility floors have
+explicit provenance:
+
+| Repository              | Configured floor | Evidence                                                                                                           |
+| ----------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `src`                   | 5.8.1            | `public/sh/install_zpmod.sh` declares `ZSH_REQUIRED="5.8.1"`.                                                      |
+| `zd`                    | 5.5.1            | The documented and automated compatibility matrix starts at 5.5.1.                                                 |
+| `zunit`                 | 5.5.1            | `.github/workflows/test-matrix.yml` starts its compatibility matrix at 5.5.1.                                      |
+| `z-a-meta-plugins`      | 5.9.2            | Conservative non-enrollment survey floor backed by native 5.9.2 validation; no lower repository floor is inferred. |
+| `zsh-fancy-completions` | 5.9.2            | Conservative non-enrollment survey floor backed by native 5.9.2 validation; no lower repository floor is inferred. |
+| `zsh-eza`               | 5.9.2            | Conservative non-enrollment survey floor backed by native 5.9.2 validation; no lower repository floor is inferred. |
+
+The 5.9.2 survey values are not compatibility claims for older versions and
+must not be copied into repository enrollment without repository-owned review.
+
 ## Running the gate
 
 The `Corpus Gate` workflow is the canonical automated execution. It runs on
@@ -49,6 +73,14 @@ dispatch. It performs all of these checks:
 - the parser survey reports no failures; and
 - the semantic analyzer reports zero errors and zero warnings.
 
+The independent `Configured corpus` job then runs one explicit configuration
+per repository and aggregates deterministic JSON. Every diagnostic must match
+the reviewed identity in `configured-corpus-expected.json`. Known Info and Hint
+findings remain advisory. Configuration errors, parser errors, error or warning
+diagnostics, unknown findings, disappeared findings, or line drift fail the
+job and require review. The expected file records a rationale for every known
+finding and no source suppression is introduced.
+
 For a local run, arrange the repositories as siblings under `$CORPUS_ROOT`,
 build `cmd/zsh-lint-survey` and `cmd/zsh-lint`, then execute the same commands
 from the workflow. Directory entries are passed through NUL-delimited
@@ -56,9 +88,11 @@ from the workflow. Directory entries are passed through NUL-delimited
 
 ## Changing the corpus
 
-Add or remove roots by updating `corpus-paths.txt` and the matching rationale
-row in this file. Review any changed discovered-file count explicitly and
+Add or remove roots by updating `corpus-paths.txt`, the matching rationale row
+in this file, the affected configured fixture, and the configured diagnostic
+classification. Review any changed discovered-file count explicitly and
 update the workflow's expected count in the same change. A fresh parser-only
 survey is insufficient: every corpus change must re-run the complete native,
-parser, analyzer, and no-suppression gate. Reports under `docs/project/` record
-the revisions they ran against, so older reports stay interpretable.
+parser, unconfigured analyzer, configured analyzer, classification, and
+no-suppression gates. Reports under `docs/project/` record the revisions they
+ran against, so older reports stay interpretable.

--- a/docs/project/project-configuration.md
+++ b/docs/project/project-configuration.md
@@ -14,10 +14,31 @@ zsh-lint --format=json --config zsh-lint.json plugin.zsh
 Invocations without `--config` preserve the unconfigured behavior and default
 rule set.
 
-A valid version 1 configuration also activates the version 1 project-aware
-rule profile. The current profile adds `plugin/function-namespace`; it remains
-inactive without `--config` and evaluates only configured plugin or Zi annex
-sources with explicit function namespaces.
+A valid schema version 1 configuration activates the independent
+`z-shell/project@1` rule profile. Configuration schema versions describe the
+accepted metadata document; rule-profile versions describe a complete,
+deterministic rule set. They are deliberately separate so a schema correction
+does not silently change rule membership, and a rule-profile revision does not
+silently change configuration syntax.
+
+The configured profile contains the generic rules plus the existing plugin
+lifecycle rules and `plugin/function-namespace`. Rules that need project
+context use explicit `project.kind`, source `profile`, and source `role`
+metadata. Paths cannot override configured metadata. The legacy path heuristics
+remain available only on invocations without `--config`.
+
+In project profile version 1:
+
+- `plugin/function-scoped-options` applies to plugin and Zi annex
+  `autoload-function` sources, including the `completion` role;
+- `plugin/zero-handling`, `plugin/unload-function`, and
+  `plugin/fpath-hygiene` apply to plugin and Zi annex `sourced-library`
+  sources; and
+- `plugin/function-namespace` retains its documented plugin and Zi annex
+  sourced-library and autoload-function boundary.
+
+Theme projects do not inherit plugin lifecycle contracts in this profile. A
+future theme contract requires an explicit profile decision.
 
 ## Version 1 format
 

--- a/internal/rules/fpath_hygiene.go
+++ b/internal/rules/fpath_hygiene.go
@@ -14,9 +14,10 @@ import (
 //
 // Name: fpath manipulation hygiene in plugin entrypoints
 //
-// Summary: Detects destructive assignments to `fpath` that overwrite existing
-// autoload paths, additions of non-function directories (`bin/`, `tests/`), and
-// hardcoded user paths.
+// Summary: In configured plugin and Zi annex sourced-library entrypoints,
+// detects destructive assignments to `fpath` that overwrite existing autoload
+// paths, additions of non-function directories (`bin/`, `tests/`), and
+// hardcoded user paths. Unconfigured analysis retains its legacy applicability.
 //
 // Why: Sourced Zsh plugins must not destructively replace `fpath` (which removes
 // standard system and user function directories), add hardcoded user machine paths,
@@ -63,6 +64,9 @@ func (FpathHygiene) Name() string {
 }
 
 func (rule FpathHygiene) Analyze(ctx *analyzer.Context, node syntax.Node) {
+	if ctx.Source.Configured() && !sourcedPluginRuleApplies(ctx) {
+		return
+	}
 	call, ok := node.(*syntax.CallExpr)
 	if !ok {
 		return

--- a/internal/rules/function_scoped_options.go
+++ b/internal/rules/function_scoped_options.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/z-shell/zsh-lint/internal/analyzer"
 	"github.com/z-shell/zsh-lint/internal/diag"
+	"github.com/z-shell/zsh-lint/internal/projectconfig"
 	"mvdan.cc/sh/v3/syntax"
 )
 
@@ -15,9 +16,11 @@ import (
 //
 // Name: Function files should scope shell options
 //
-// Summary: Reports executable files beneath a `functions` directory when
-// neither `builtin emulate -L zsh` nor `setopt local_options` appears before
-// the first non-guard top-level statement.
+// Summary: For configured plugin and Zi annex projects, reports autoload
+// function sources when neither `builtin emulate -L zsh` nor
+// `setopt local_options` appears before the first non-guard top-level
+// statement. Unconfigured analysis retains the legacy `functions` path
+// heuristic.
 //
 // Why: Zsh functions inherit the caller's option state. The Zsh manual
 // documents `LOCAL_OPTIONS` as restoring options on function return, while
@@ -74,7 +77,7 @@ func (FunctionScopedOptions) Name() string {
 
 func (rule FunctionScopedOptions) Analyze(ctx *analyzer.Context, node syntax.Node) {
 	file, ok := node.(*syntax.File)
-	if !ok || !hasFunctionsPathSegment(ctx.FilePath) {
+	if !ok || !functionScopedOptionsApplies(ctx) {
 		return
 	}
 
@@ -97,6 +100,13 @@ func (rule FunctionScopedOptions) Analyze(ctx *analyzer.Context, node syntax.Nod
 		)
 		return
 	}
+}
+
+func functionScopedOptionsApplies(ctx *analyzer.Context) bool {
+	if ctx.Source.Configured() {
+		return configuredPluginSource(ctx.Source, projectconfig.ProfileAutoloadFunction)
+	}
+	return hasFunctionsPathSegment(ctx.FilePath)
 }
 
 func hasFunctionsPathSegment(path string) bool {

--- a/internal/rules/profile.go
+++ b/internal/rules/profile.go
@@ -1,0 +1,19 @@
+package rules
+
+import "github.com/z-shell/zsh-lint/internal/projectconfig"
+
+// configuredPluginSource reports whether explicit project metadata selects a
+// plugin lifecycle contract for one of the supplied source profiles. Theme
+// projects are intentionally excluded until a focused contract is approved.
+func configuredPluginSource(source projectconfig.SourceContext, profiles ...projectconfig.Profile) bool {
+	if !source.Configured() ||
+		(source.ProjectKind != projectconfig.KindPlugin && source.ProjectKind != projectconfig.KindZiAnnex) {
+		return false
+	}
+	for _, profile := range profiles {
+		if source.Profile == profile {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rules/profile_test.go
+++ b/internal/rules/profile_test.go
@@ -1,0 +1,150 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/z-shell/zsh-lint/internal/analyzer"
+	"github.com/z-shell/zsh-lint/internal/diag"
+	"github.com/z-shell/zsh-lint/internal/parse"
+	"github.com/z-shell/zsh-lint/internal/projectconfig"
+)
+
+func TestConfiguredPluginRuleApplicability(t *testing.T) {
+	tests := []struct {
+		name    string
+		rule    analyzer.Rule
+		source  string
+		path    string
+		context projectconfig.SourceContext
+		want    int
+	}{
+		{
+			name:    "autoload metadata activates function scoping outside functions path",
+			rule:    FunctionScopedOptions{},
+			source:  "rehash\n",
+			path:    "autoload/handler",
+			context: configuredSource(projectconfig.KindPlugin, projectconfig.ProfileAutoloadFunction, ""),
+			want:    1,
+		},
+		{
+			name:    "completion role retains autoload function scoping",
+			rule:    FunctionScopedOptions{},
+			source:  "rehash\n",
+			path:    "completions/_example",
+			context: configuredSource(projectconfig.KindPlugin, projectconfig.ProfileAutoloadFunction, projectconfig.RoleCompletion),
+			want:    1,
+		},
+		{
+			name:    "sourced metadata disables function scoping beneath functions path",
+			rule:    FunctionScopedOptions{},
+			source:  "rehash\n",
+			path:    "functions/plugin.zsh",
+			context: configuredSource(projectconfig.KindPlugin, projectconfig.ProfileSourcedLibrary, ""),
+		},
+		{
+			name:    "tool metadata disables function scoping",
+			rule:    FunctionScopedOptions{},
+			source:  "rehash\n",
+			path:    "functions/handler",
+			context: configuredSource(projectconfig.KindTool, projectconfig.ProfileAutoloadFunction, ""),
+		},
+		{
+			name:    "sourced plugin activates zero handling beneath functions path",
+			rule:    ZeroHandling{},
+			source:  "fpath+=( \"${0:h}/functions\" )\n",
+			path:    "functions/plugin.zsh",
+			context: configuredSource(projectconfig.KindPlugin, projectconfig.ProfileSourcedLibrary, ""),
+			want:    1,
+		},
+		{
+			name:    "autoload metadata disables zero handling",
+			rule:    ZeroHandling{},
+			source:  "fpath+=( \"${0:h}/functions\" )\n",
+			path:    "plugin.zsh",
+			context: configuredSource(projectconfig.KindPlugin, projectconfig.ProfileAutoloadFunction, ""),
+		},
+		{
+			name:    "sourced annex activates unload lifecycle",
+			rule:    UnloadFunction{},
+			source:  "add-zsh-hook precmd _example_precmd\n",
+			path:    "annex.zsh",
+			context: configuredSource(projectconfig.KindZiAnnex, projectconfig.ProfileSourcedLibrary, ""),
+			want:    1,
+		},
+		{
+			name:    "library metadata disables unload lifecycle",
+			rule:    UnloadFunction{},
+			source:  "add-zsh-hook precmd _example_precmd\n",
+			path:    "plugin.zsh",
+			context: configuredSource(projectconfig.KindLibrary, projectconfig.ProfileSourcedLibrary, ""),
+		},
+		{
+			name:    "sourced plugin activates fpath hygiene",
+			rule:    FpathHygiene{},
+			source:  "fpath=( \"${0:h}/functions\" )\n",
+			path:    "plugin.zsh",
+			context: configuredSource(projectconfig.KindPlugin, projectconfig.ProfileSourcedLibrary, ""),
+			want:    1,
+		},
+		{
+			name:    "application metadata disables fpath hygiene",
+			rule:    FpathHygiene{},
+			source:  "fpath=( \"${0:h}/functions\" )\n",
+			path:    "plugin.zsh",
+			context: configuredSource(projectconfig.KindApplication, projectconfig.ProfileSourcedLibrary, ""),
+		},
+		{
+			name:    "theme is not inferred as plugin",
+			rule:    FpathHygiene{},
+			source:  "fpath=( \"${0:h}/functions\" )\n",
+			path:    "theme.plugin.zsh",
+			context: configuredSource(projectconfig.KindTheme, projectconfig.ProfileSourcedLibrary, ""),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			file, err := parse.Parse(strings.NewReader(test.source), test.path)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			diagnostics := analyzer.New(test.rule).AnalyzeSource(file, test.path, test.context)
+			if got := len(diagnostics); got != test.want {
+				t.Fatalf("diagnostics = %+v (count %d), want %d", diagnostics, got, test.want)
+			}
+		})
+	}
+}
+
+func TestInactiveConfiguredRuleSuppressionIsKnown(t *testing.T) {
+	const source = "# zsh-lint disable=plugin/zero-handling -- tool source\nprint ok\n"
+	file, err := parse.Parse(strings.NewReader(source), "tool.zsh")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	ruleSet, err := ForProfile(CurrentProjectProfile)
+	if err != nil {
+		t.Fatalf("ForProfile: %v", err)
+	}
+	diagnostics := analyzer.New(ruleSet...).AnalyzeSource(
+		file,
+		"tool.zsh",
+		configuredSource(projectconfig.KindTool, projectconfig.ProfileSourcedLibrary, ""),
+	)
+	if len(diagnostics) != 1 || diagnostics[0].RuleID != diag.RuleID("meta/unused-suppression") {
+		t.Fatalf("diagnostics = %+v, want one unused suppression", diagnostics)
+	}
+	if strings.Contains(diagnostics[0].Message, "unknown rule ID") {
+		t.Errorf("inactive registered rule was treated as unknown: %q", diagnostics[0].Message)
+	}
+}
+
+func configuredSource(kind projectconfig.ProjectKind, profile projectconfig.Profile, role projectconfig.SourceRole) projectconfig.SourceContext {
+	return projectconfig.SourceContext{
+		ConfigVersion: projectconfig.CurrentVersion,
+		ProjectKind:   kind,
+		Profile:       profile,
+		Role:          role,
+	}
+}

--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -1,31 +1,62 @@
 package rules
 
 import (
+	"fmt"
+
 	"github.com/z-shell/zsh-lint/internal/analyzer"
-	"github.com/z-shell/zsh-lint/internal/projectconfig"
+)
+
+// Profile identifies one complete, versioned configured rule set. Profile
+// versions are owned by the rule registry and are independent from project
+// configuration schema versions.
+type Profile string
+
+const (
+	// ProjectProfileV1 is the first configured Z-Shell project rule profile.
+	ProjectProfileV1 Profile = "z-shell/project@1"
+
+	// CurrentProjectProfile is selected for validated project configurations in
+	// this release.
+	CurrentProjectProfile = ProjectProfileV1
 )
 
 // Default returns the default set of static analysis rules.
 func Default() []analyzer.Rule {
+	return append(genericRules(), legacyProjectRules()...)
+}
+
+// ForProfile returns the complete rule set associated with a configured rule
+// profile. Unknown profiles fail explicitly rather than silently disabling
+// configured rules.
+func ForProfile(profile Profile) ([]analyzer.Rule, error) {
+	switch profile {
+	case ProjectProfileV1:
+		return append(genericRules(), configuredProjectRules()...), nil
+	default:
+		return nil, fmt.Errorf("unsupported rule profile %q", profile)
+	}
+}
+
+func genericRules() []analyzer.Rule {
 	return []analyzer.Rule{
 		UnquotedVar{},
 		Backquotes{},
 		PreferDoubleBrackets{},
 		EvalUsage{},
 		FuncDeclStyle{},
-		FunctionScopedOptions{},
 		SpecialParamShadow{},
+	}
+}
+
+func legacyProjectRules() []analyzer.Rule {
+	return []analyzer.Rule{
+		FunctionScopedOptions{},
 		ZeroHandling{},
 		UnloadFunction{},
 		FpathHygiene{},
 	}
 }
 
-// ProjectProfile returns the opt-in rules associated with one validated
-// project-configuration version. These rules are not part of Default.
-func ProjectProfile(version int) []analyzer.Rule {
-	if version != projectconfig.CurrentVersion {
-		return nil
-	}
-	return []analyzer.Rule{FunctionNamespace{}}
+func configuredProjectRules() []analyzer.Rule {
+	return append(legacyProjectRules(), FunctionNamespace{})
 }

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -48,63 +48,75 @@ func TestRuleSeverities(t *testing.T) {
 	}
 }
 
-func TestDefaultIncludesFunctionScopedOptions(t *testing.T) {
-	for _, rule := range Default() {
-		if rule.ID() == "plugin/function-scoped-options" {
-			return
-		}
+func TestRuleSetSelection(t *testing.T) {
+	defaultIDs := []diag.RuleID{
+		"quoting/unquoted-var",
+		"style/backquotes",
+		"style/prefer-double-brackets",
+		"security/eval",
+		"style/function-decl",
+		"compat/special-param-shadow",
+		"plugin/function-scoped-options",
+		"plugin/zero-handling",
+		"plugin/unload-function",
+		"plugin/fpath-hygiene",
 	}
-	t.Fatal("Default rules do not include plugin/function-scoped-options")
+	profileIDs := append(append([]diag.RuleID(nil), defaultIDs...), "plugin/function-namespace")
+
+	if got := ruleIDs(Default()); !equalRuleIDs(got, defaultIDs) {
+		t.Fatalf("Default IDs = %v, want %v", got, defaultIDs)
+	}
+	profile, err := ForProfile(ProjectProfileV1)
+	if err != nil {
+		t.Fatalf("ForProfile(%q): %v", ProjectProfileV1, err)
+	}
+	if got := ruleIDs(profile); !equalRuleIDs(got, profileIDs) {
+		t.Fatalf("profile IDs = %v, want %v", got, profileIDs)
+	}
+	assertUniqueRuleIDs(t, profile)
+
+	if _, err := ForProfile(Profile("z-shell/project@2")); err == nil {
+		t.Fatal("ForProfile(unknown) succeeded, want error")
+	}
+
+	profile[0] = FunctionNamespace{}
+	again, err := ForProfile(CurrentProjectProfile)
+	if err != nil {
+		t.Fatalf("ForProfile(CurrentProjectProfile): %v", err)
+	}
+	if got := again[0].ID(); got != "quoting/unquoted-var" {
+		t.Fatalf("profile selection reused caller-mutated slice: first ID = %q", got)
+	}
 }
 
-func TestDefaultIncludesSpecialParamShadow(t *testing.T) {
-	for _, rule := range Default() {
-		if rule.ID() == "compat/special-param-shadow" {
-			return
-		}
+func ruleIDs(rules []analyzer.Rule) []diag.RuleID {
+	ids := make([]diag.RuleID, len(rules))
+	for index, rule := range rules {
+		ids[index] = rule.ID()
 	}
-	t.Fatal("Default rules do not include compat/special-param-shadow")
+	return ids
 }
 
-func TestDefaultIncludesZeroHandling(t *testing.T) {
-	for _, rule := range Default() {
-		if rule.ID() == "plugin/zero-handling" {
-			return
+func equalRuleIDs(got, want []diag.RuleID) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for index := range got {
+		if got[index] != want[index] {
+			return false
 		}
 	}
-	t.Fatal("Default rules do not include plugin/zero-handling")
+	return true
 }
 
-func TestDefaultIncludesUnloadFunction(t *testing.T) {
-	for _, rule := range Default() {
-		if rule.ID() == "plugin/unload-function" {
-			return
+func assertUniqueRuleIDs(t *testing.T, rules []analyzer.Rule) {
+	t.Helper()
+	seen := make(map[diag.RuleID]bool, len(rules))
+	for _, rule := range rules {
+		if seen[rule.ID()] {
+			t.Fatalf("duplicate rule ID %q", rule.ID())
 		}
-	}
-	t.Fatal("Default rules do not include plugin/unload-function")
-}
-
-func TestDefaultIncludesFpathHygiene(t *testing.T) {
-	for _, rule := range Default() {
-		if rule.ID() == "plugin/fpath-hygiene" {
-			return
-		}
-	}
-	t.Fatal("Default rules do not include plugin/fpath-hygiene")
-}
-
-func TestFunctionNamespaceIsOptIn(t *testing.T) {
-	for _, rule := range Default() {
-		if rule.ID() == "plugin/function-namespace" {
-			t.Fatal("Default includes opt-in plugin/function-namespace")
-		}
-	}
-	profile := ProjectProfile(1)
-	if len(profile) != 1 || profile[0].ID() != "plugin/function-namespace" {
-		t.Fatalf("ProjectProfile(1) = %v, want plugin/function-namespace", profile)
-	}
-	if profile := ProjectProfile(2); len(profile) != 0 {
-		t.Fatalf("ProjectProfile(2) = %v, want no rules", profile)
+		seen[rule.ID()] = true
 	}
 }
 

--- a/internal/rules/unload_function.go
+++ b/internal/rules/unload_function.go
@@ -14,9 +14,11 @@ import (
 //
 // Name: Unload function convention and hygiene
 //
-// Summary: Checks that plugins registering persistent shell hooks or widgets
-// define a namespaced unload function (`*_plugin_unload`), and that defined
-// unload functions cleanly unfunction themselves upon completion.
+// Summary: Checks configured plugin and Zi annex sourced-library entrypoints
+// that register persistent shell hooks or widgets for a namespaced unload
+// function (`*_plugin_unload`), and checks that defined unload functions
+// cleanly unfunction themselves upon completion. Unconfigured analysis retains
+// the legacy path heuristic.
 //
 // Why: The Zsh Plugin Standard specifies that plugins with persistent side
 // effects (hooks via `add-zsh-hook`, line-editor widgets via
@@ -67,7 +69,7 @@ func (UnloadFunction) Name() string {
 
 func (rule UnloadFunction) Analyze(ctx *analyzer.Context, node syntax.Node) {
 	file, ok := node.(*syntax.File)
-	if !ok || hasFunctionsPathSegment(ctx.FilePath) {
+	if !ok || !sourcedPluginRuleApplies(ctx) {
 		return
 	}
 

--- a/internal/rules/zero_handling.go
+++ b/internal/rules/zero_handling.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/z-shell/zsh-lint/internal/analyzer"
 	"github.com/z-shell/zsh-lint/internal/diag"
+	"github.com/z-shell/zsh-lint/internal/projectconfig"
 	"mvdan.cc/sh/v3/syntax"
 )
 
@@ -14,9 +15,10 @@ import (
 //
 // Name: Zero-handling idiom in plugin entrypoint
 //
-// Summary: Reports direct uses of `$0` at the top level of plugin scripts
-// before `$0` has been initialized using prompt expansions (`${(%):-%N}` or
-// `${(%):-%x}`).
+// Summary: Reports direct uses of `$0` at the top level of configured plugin
+// and Zi annex sourced-library entrypoints before `$0` has been initialized
+// using prompt expansions (`${(%):-%N}` or `${(%):-%x}`). Unconfigured
+// analysis retains the legacy path heuristic.
 //
 // Why: When a Zsh plugin is sourced, positional parameter `$0` evaluates to the
 // name of the shell (`zsh` or `-zsh`) rather than the path of the sourced script,
@@ -60,7 +62,7 @@ func (ZeroHandling) Name() string {
 
 func (rule ZeroHandling) Analyze(ctx *analyzer.Context, node syntax.Node) {
 	file, ok := node.(*syntax.File)
-	if !ok || hasFunctionsPathSegment(ctx.FilePath) {
+	if !ok || !sourcedPluginRuleApplies(ctx) {
 		return
 	}
 
@@ -82,6 +84,13 @@ func (rule ZeroHandling) Analyze(ctx *analyzer.Context, node syntax.Node) {
 			checkUninitializedZeroInStmt(ctx, stmt, rule.ID())
 		}
 	}
+}
+
+func sourcedPluginRuleApplies(ctx *analyzer.Context) bool {
+	if ctx.Source.Configured() {
+		return configuredPluginSource(ctx.Source, projectconfig.ProfileSourcedLibrary)
+	}
+	return !hasFunctionsPathSegment(ctx.FilePath)
 }
 
 func isZeroInitializationStatement(stmt *syntax.Stmt) bool {

--- a/internal/workflowcontract/corpus_gate_test.go
+++ b/internal/workflowcontract/corpus_gate_test.go
@@ -1,9 +1,12 @@
 package workflowcontract
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/z-shell/zsh-lint/internal/projectconfig"
 )
 
 func TestCorpusManifestIsExactAndContained(t *testing.T) {
@@ -36,10 +39,10 @@ func TestCorpusManifestIsExactAndContained(t *testing.T) {
 
 func TestCorpusGateUsesReadOnlyMainCheckouts(t *testing.T) {
 	workflow := readRepositoryFile(t, ".github", "workflows", "corpus-gate.yml")
-	if got := strings.Count(workflow, "uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"); got != 7 {
-		t.Fatalf("corpus gate must use seven pinned checkout steps; got %d", got)
+	if got := strings.Count(workflow, "uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1"); got != 14 {
+		t.Fatalf("two corpus jobs must use fourteen pinned checkout steps; got %d", got)
 	}
-	if got := strings.Count(workflow, "persist-credentials: false"); got != 7 {
+	if got := strings.Count(workflow, "persist-credentials: false"); got != 14 {
 		t.Fatalf("every corpus checkout must disable persisted credentials; got %d", got)
 	}
 
@@ -48,8 +51,8 @@ func TestCorpusGateUsesReadOnlyMainCheckouts(t *testing.T) {
 			"          ref: main\n" +
 			"          path: corpus/" + repository + "\n" +
 			"          persist-credentials: false"
-		if !strings.Contains(workflow, want) {
-			t.Errorf("corpus checkout for %s must use its main branch and isolated path", repository)
+		if got := strings.Count(workflow, want); got != 2 {
+			t.Errorf("both corpus jobs must check out %s from main in its isolated path; got %d", repository, got)
 		}
 	}
 }
@@ -69,6 +72,55 @@ func TestCorpusGateRunsTheFullReadinessContract(t *testing.T) {
 	} {
 		if !strings.Contains(workflow, required) {
 			t.Errorf("corpus gate is missing required contract fragment %q", required)
+		}
+	}
+}
+
+func TestConfiguredCorpusContract(t *testing.T) {
+	workflow := readRepositoryFile(t, ".github", "workflows", "corpus-gate.yml")
+	for _, required := range []string{
+		"configured-corpus:",
+		"name: Configured corpus",
+		`config_source="../zsh-lint/docs/project/corpus-configs/$repository.json"`,
+		`"$RUNNER_TEMP/zsh-lint" --format=json --config "$config" "${files[@]}"`,
+		`configured-corpus-expected.json`,
+		`.summary.errors == 0 and .summary.warnings == 0`,
+		`Configured corpus diagnostics changed; review and classify every difference.`,
+	} {
+		if !strings.Contains(workflow, required) {
+			t.Errorf("configured corpus gate is missing required contract fragment %q", required)
+		}
+	}
+
+	repositories := []string{"src", "zd", "zunit", "z-a-meta-plugins", "zsh-fancy-completions", "zsh-eza"}
+	for _, repository := range repositories {
+		path := repositoryFilePath(t, "docs", "project", "corpus-configs", repository+".json")
+		config, err := projectconfig.Load(path)
+		if err != nil {
+			t.Errorf("configured corpus fixture %s is invalid: %v", repository, err)
+			continue
+		}
+		if config.Version != projectconfig.CurrentVersion {
+			t.Errorf("configured corpus fixture %s uses schema %d, want %d", repository, config.Version, projectconfig.CurrentVersion)
+		}
+	}
+
+	var expected []struct {
+		Repository     string `json:"repository"`
+		Path           string `json:"path"`
+		Rule           string `json:"rule"`
+		Severity       string `json:"severity"`
+		Classification string `json:"classification"`
+	}
+	if err := json.Unmarshal([]byte(readRepositoryFile(t, "docs", "project", "configured-corpus-expected.json")), &expected); err != nil {
+		t.Fatalf("decode configured corpus classifications: %v", err)
+	}
+	if len(expected) == 0 {
+		t.Fatal("configured corpus classifications must not be empty")
+	}
+	for index, finding := range expected {
+		if finding.Repository == "" || finding.Path == "" || finding.Rule == "" || finding.Severity == "" || finding.Classification == "" {
+			t.Errorf("configured corpus classification %d has an empty required field: %+v", index, finding)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- decouple the complete configured rule profile `z-shell/project@1` from configuration schema version 1;
- preserve the exact unconfigured default rule set and legacy path heuristics;
- make explicit plugin and Zi annex metadata control the four existing lifecycle rules;
- keep inactive configured rule IDs registered so suppressions are known-but-unused;
- add an independent configured corpus job with six reviewed configurations and exact advisory classification drift detection.

## Configured corpus evidence

Verified against the live `main` revisions used by CI:

- `src` `5ac79863d55baf056796e5e3afce5970506b8871`
- `zd` `0fb41d752fbe421282fb9e11e70213e8cbf4c834`
- `zunit` `60fa1d180bb0e4b879d69dc3814c840b54067cac`
- `z-a-meta-plugins` `3ea38ba212f2fcaad0eba2f1fdf8c7e54cf4f504`
- `zsh-fancy-completions` `0f7c07c39bea436671a3dbea0bee2690ee8bd49a`
- `zsh-eza` `242216f714031a5269aa1fc6c9c19ddeb46f01c5`

Results:

- 20 of 20 native Zsh syntax checks passed;
- 20 of 20 parser surveys passed;
- unconfigured analyzer: 0 errors, 0 warnings, 4 Infos, 3 Hints;
- configured analyzer: 0 errors, 0 warnings, 4 Infos, 8 Hints;
- all 12 configured advisory findings have reviewed identities and classifications;
- no source suppressions were introduced.

## Validation

- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go vet ./...`
- `go build ./...`
- generated Go reference documentation is non-empty
- `actionlint .github/workflows/*.yml`
- `git diff --check`
- commit signature verified

Closes #156
Refs #131, #134, #135, #136, #137, and #138.
