### PR TITLE
fix(parser): support anonymous function arguments

### DIFF
--- a/docs/project/parser-gap-workflow.md
+++ b/docs/project/parser-gap-workflow.md
@@ -97,3 +97,11 @@ the adapter verifies the original AST structure, invalid-syntax behavior, and
 every source position before returning the complete tree. This exception does
 not permit general source rewriting or consuming separators from the
 full-file retry.
+
+When an upstream AST has no field for a native construct, the parser result may
+retain source-mapped typed syntax nodes as explicit `parse.File` metadata. This
+exception requires the same exact-error gate and byte-preserving retry, plus a
+stable association with the owning AST node. Consumers must inspect the typed
+metadata rather than recover masked source text. Anonymous-function invocation
+words use this boundary because mvdan/sh v3.13.1 represents the declaration but
+has no field for its invocation arguments.

--- a/internal/parse/anonymous_function_args.go
+++ b/internal/parse/anonymous_function_args.go
@@ -1,0 +1,278 @@
+package parse
+
+import (
+	"bytes"
+	"errors"
+	"sort"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+type anonymousInvocationCandidate struct {
+	close int
+	words []*syntax.Word
+}
+
+// parseAnonymousFunctionArgs closes the native-Zsh gap where an anonymous
+// function declaration is immediately followed by invocation words. The full
+// retry masks only those words with same-width spaces. Each masked word is
+// parsed separately at its original offset and retained as typed metadata.
+func parseAnonymousFunctionArgs(
+	src []byte,
+	name string,
+	firstErr error,
+) (*syntax.File, []AnonymousInvocation, error) {
+	masked := bytes.Clone(src)
+	currentErr := firstErr
+	seen := make(map[int]bool)
+	var candidates []anonymousInvocationCandidate
+
+	for {
+		close, end, words, ok := anonymousFunctionInvocationCandidate(src, name, currentErr)
+		if !ok {
+			close, end, words, ok = fallbackAnonymousFunctionInvocationCandidate(src, name, seen)
+		}
+		if !ok || seen[close] {
+			return nil, nil, firstErr
+		}
+		seen[close] = true
+		candidates = append(candidates, anonymousInvocationCandidate{close: close, words: words})
+		for offset := close + 1; offset < end; offset++ {
+			if masked[offset] != '\n' {
+				masked[offset] = ' '
+			}
+		}
+
+		tree, err := parseCompatibleTree(masked, name)
+		if err != nil {
+			currentErr = err
+			continue
+		}
+		invocations, ok := bindAnonymousInvocations(tree, candidates)
+		if !ok {
+			return nil, nil, firstErr
+		}
+		return tree, invocations, nil
+	}
+}
+
+func fallbackAnonymousFunctionInvocationCandidate(
+	src []byte,
+	name string,
+	seen map[int]bool,
+) (int, int, []*syntax.Word, bool) {
+	for close, b := range src {
+		if b != '}' || seen[close] {
+			continue
+		}
+		wordStart := close + 1
+		for wordStart < len(src) && (src[wordStart] == ' ' || src[wordStart] == '\t') {
+			wordStart++
+		}
+		if wordStart == close+1 || wordStart >= len(src) || src[wordStart] == '\n' || src[wordStart] == ';' {
+			continue
+		}
+		end, ok := anonymousInvocationEnd(src, wordStart)
+		if !ok {
+			continue
+		}
+		words, ok := parseAnonymousInvocationWords(src, name, close, end)
+		if !ok || !prefixEndsWithAnonymousFunction(src, name, close) {
+			continue
+		}
+		return close, end, words, true
+	}
+	return 0, 0, nil, false
+}
+
+func prefixEndsWithAnonymousFunction(src []byte, name string, close int) bool {
+	prefix := bytes.Clone(src)
+	for offset := close + 1; offset < len(prefix); offset++ {
+		if prefix[offset] != '\n' {
+			prefix[offset] = ' '
+		}
+	}
+	tree, err := parseCompatibleTree(prefix, name)
+	if err != nil {
+		return false
+	}
+	found := false
+	syntax.Walk(tree, func(node syntax.Node) bool {
+		decl, ok := node.(*syntax.FuncDecl)
+		if ok && decl.Name == nil && len(decl.Names) == 0 && int(decl.End().Offset())-1 == close {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func anonymousFunctionInvocationCandidate(
+	src []byte,
+	name string,
+	parseFailure error,
+) (int, int, []*syntax.Word, bool) {
+	var parseErr syntax.ParseError
+	if !errors.As(parseFailure, &parseErr) || parseErr.Text != tryAlwaysParseError {
+		return 0, 0, nil, false
+	}
+	seed := int(parseErr.Pos.Offset())
+	if seed >= len(src) {
+		seed = len(src) - 1
+	}
+	if seed < 0 {
+		return 0, 0, nil, false
+	}
+
+	lineStart := bytes.LastIndexByte(src[:seed+1], '\n') + 1
+	close := seed
+	for close >= lineStart && (src[close] == ' ' || src[close] == '\t') {
+		close--
+	}
+	if close < lineStart || src[close] != '}' {
+		close = bytes.LastIndexByte(src[lineStart:seed+1], '}')
+		if close < 0 {
+			return 0, 0, nil, false
+		}
+		close += lineStart
+	}
+
+	wordStart := close + 1
+	for wordStart < len(src) && (src[wordStart] == ' ' || src[wordStart] == '\t') {
+		wordStart++
+	}
+	if wordStart >= len(src) || src[wordStart] == '\n' || src[wordStart] == ';' {
+		return 0, 0, nil, false
+	}
+	end, ok := anonymousInvocationEnd(src, wordStart)
+	if !ok {
+		return 0, 0, nil, false
+	}
+	words, ok := parseAnonymousInvocationWords(src, name, close, end)
+	if !ok {
+		return 0, 0, nil, false
+	}
+	return close, end, words, true
+}
+
+func anonymousInvocationEnd(src []byte, start int) (int, bool) {
+	var quote byte
+	escaped := false
+	parenDepth := 0
+	braceDepth := 0
+	bracketDepth := 0
+
+	for offset := start; offset < len(src); offset++ {
+		b := src[offset]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if quote != 0 {
+			switch {
+			case b == '\\' && quote != '\'':
+				escaped = true
+			case b == quote:
+				quote = 0
+			}
+			continue
+		}
+
+		switch b {
+		case '\\':
+			escaped = true
+		case '\'', '"', '`':
+			quote = b
+		case '(':
+			parenDepth++
+		case ')':
+			if parenDepth > 0 {
+				parenDepth--
+			}
+		case '{':
+			braceDepth++
+		case '}':
+			if braceDepth > 0 {
+				braceDepth--
+			}
+		case '[':
+			bracketDepth++
+		case ']':
+			if bracketDepth > 0 {
+				bracketDepth--
+			}
+		case '\n', ';':
+			if parenDepth == 0 && braceDepth == 0 && bracketDepth == 0 {
+				return offset, true
+			}
+		}
+	}
+	return len(src), quote == 0 && !escaped && parenDepth == 0 && braceDepth == 0 && bracketDepth == 0
+}
+
+func parseAnonymousInvocationWords(src []byte, name string, close, end int) ([]*syntax.Word, bool) {
+	island := make([]byte, len(src))
+	for offset, b := range src {
+		if b == '\n' {
+			island[offset] = '\n'
+		} else {
+			island[offset] = ' '
+		}
+	}
+	island[close] = ':'
+	copy(island[close+1:end], src[close+1:end])
+	tree, err := parseCompatibleTree(island, name)
+	if err != nil {
+		return nil, false
+	}
+	for _, stmt := range tree.Stmts {
+		call, ok := stmt.Cmd.(*syntax.CallExpr)
+		if !ok || len(call.Args) < 2 || getParseWordLiteral(call.Args[0]) != ":" {
+			continue
+		}
+		return append([]*syntax.Word(nil), call.Args[1:]...), true
+	}
+	return nil, false
+}
+
+func bindAnonymousInvocations(
+	tree *syntax.File,
+	candidates []anonymousInvocationCandidate,
+) ([]AnonymousInvocation, bool) {
+	functionsByClose := make(map[int]*syntax.FuncDecl)
+	syntax.Walk(tree, func(node syntax.Node) bool {
+		decl, ok := node.(*syntax.FuncDecl)
+		if ok && decl.Name == nil && len(decl.Names) == 0 {
+			functionsByClose[int(decl.End().Offset())-1] = decl
+		}
+		return true
+	})
+
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].close < candidates[j].close })
+	invocations := make([]AnonymousInvocation, 0, len(candidates))
+	for _, candidate := range candidates {
+		decl := functionsByClose[candidate.close]
+		if decl == nil {
+			return nil, false
+		}
+		invocations = append(invocations, AnonymousInvocation{
+			Function: decl,
+			Words:    candidate.words,
+		})
+	}
+	return invocations, true
+}
+
+func getParseWordLiteral(word *syntax.Word) string {
+	if word == nil {
+		return ""
+	}
+	var value bytes.Buffer
+	for _, part := range word.Parts {
+		if lit, ok := part.(*syntax.Lit); ok {
+			value.WriteString(lit.Value)
+		}
+	}
+	return value.String()
+}

--- a/internal/parse/anonymous_function_args_test.go
+++ b/internal/parse/anonymous_function_args_test.go
@@ -1,0 +1,165 @@
+package parse
+
+import (
+	"strings"
+	"testing"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+func TestAnonymousFunctionInvocationArguments(t *testing.T) {
+	source := `() {
+  builtin emulate -L zsh
+  typeset -r source_path=$1
+} "${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}" second
+`
+	file, err := Parse(strings.NewReader(source), "entrypoint.zsh")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	invocations := file.AnonymousInvocations()
+	if len(invocations) != 1 {
+		t.Fatalf("invocation count = %d, want 1", len(invocations))
+	}
+	if invocations[0].Function == nil || invocations[0].Function.Name != nil {
+		t.Fatal("invocation is not paired with its anonymous function")
+	}
+	if len(invocations[0].Words) != 2 {
+		t.Fatalf("word count = %d, want 2", len(invocations[0].Words))
+	}
+	if got := getParseWordLiteral(invocations[0].Words[1]); got != "second" {
+		t.Fatalf("second word = %q, want second", got)
+	}
+	wantOffset := strings.Index(source, `"${ZERO`)
+	if got := int(invocations[0].Words[0].Pos().Offset()); got != wantOffset {
+		t.Fatalf("first word offset = %d, want %d", got, wantOffset)
+	}
+
+	parameters := map[string]bool{}
+	syntax.Walk(invocations[0].Words[0], func(node syntax.Node) bool {
+		if expansion, ok := node.(*syntax.ParamExp); ok && expansion.Param != nil {
+			parameters[expansion.Param.Value] = true
+		}
+		return true
+	})
+	for _, name := range []string{"ZERO", "0", "ZSH_ARGZERO"} {
+		if !parameters[name] {
+			t.Errorf("first word did not retain parameter %q", name)
+		}
+	}
+}
+
+func TestNestedAnonymousFunctionInvocationArguments(t *testing.T) {
+	source := `() {
+  () {
+    print -r -- "$1"
+  } inner
+} outer
+`
+	file, err := Parse(strings.NewReader(source), "nested.zsh")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	invocations := file.AnonymousInvocations()
+	if len(invocations) != 2 {
+		t.Fatalf("invocation count = %d, want 2", len(invocations))
+	}
+	if got := getParseWordLiteral(invocations[0].Words[0]); got != "inner" {
+		t.Fatalf("first invocation word = %q, want inner", got)
+	}
+	if got := getParseWordLiteral(invocations[1].Words[0]); got != "outer" {
+		t.Fatalf("second invocation word = %q, want outer", got)
+	}
+}
+
+func TestRepeatedAnonymousFunctionInvocationArguments(t *testing.T) {
+	source := "() { :; } one\n() { :; } two\n"
+	file, err := Parse(strings.NewReader(source), "repeated.zsh")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if got := len(file.AnonymousInvocations()); got != 2 {
+		t.Fatalf("invocation count = %d, want 2", got)
+	}
+}
+
+func TestAnonymousFunctionArgumentsComposeWithEarlierAdapters(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{
+			name: "alternate if",
+			source: `() {
+  if [[ -n $value ]] {
+    print -r -- "$value"
+  }
+} argument
+`,
+		},
+		{
+			name: "associative subscript",
+			source: `() {
+  (( ${+functions[.handler]} ))
+} argument
+`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			file, err := Parse(strings.NewReader(test.source), "composed.zsh")
+			if err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+			invocations := file.AnonymousInvocations()
+			if len(invocations) != 1 {
+				t.Fatalf("invocation count = %d, want 1", len(invocations))
+			}
+			if got := getParseWordLiteral(invocations[0].Words[0]); got != "argument" {
+				t.Fatalf("invocation word = %q, want argument", got)
+			}
+		})
+	}
+}
+
+func TestAnonymousFunctionInvocationControls(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{name: "named function", source: "named() { :; } argument\n"},
+		{name: "ordinary block", source: "{ :; } argument\n"},
+		{name: "unterminated word", source: "() { :; } \"unterminated\n"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, originalErr := parseTree([]byte(test.source), "invalid.zsh")
+			if originalErr == nil {
+				t.Fatal("control source did not reproduce an upstream parse error")
+			}
+			_, err := Parse(strings.NewReader(test.source), "invalid.zsh")
+			if err == nil {
+				t.Fatal("Parse() accepted control source")
+			}
+			if err.Error() != originalErr.Error() {
+				t.Fatalf("Parse() error = %q, want original %q", err, originalErr)
+			}
+		})
+	}
+}
+
+func TestAnonymousFunctionTextControlsRemainOrdinary(t *testing.T) {
+	source := `print -r -- '} argument'
+# } argument
+cat <<'BODY'
+} argument
+BODY
+`
+	file, err := Parse(strings.NewReader(source), "text-controls.zsh")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if got := len(file.AnonymousInvocations()); got != 0 {
+		t.Fatalf("invocation count = %d, want 0", got)
+	}
+}

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -22,8 +22,18 @@ import (
 
 // File is the parsed source produced by the front end.
 type File struct {
-	tree  *syntax.File
-	lines []string
+	tree                 *syntax.File
+	lines                []string
+	anonymousInvocations []AnonymousInvocation
+}
+
+// AnonymousInvocation pairs an anonymous function declaration with the words
+// passed when Zsh invokes it immediately. mvdan/sh v3.13.1 has no AST field
+// for these words, so the compatibility front end retains them as typed syntax
+// nodes with their original source positions.
+type AnonymousInvocation struct {
+	Function *syntax.FuncDecl
+	Words    []*syntax.Word
 }
 
 // AST returns the underlying mvdan.cc/sh syntax tree.
@@ -41,12 +51,51 @@ func (f *File) Lines() []string {
 	return f.lines
 }
 
+// AnonymousInvocations returns immediate anonymous-function invocations found
+// by the Zsh compatibility front end. The returned slice is independent; its
+// syntax nodes are shared with the immutable parse result.
+func (f *File) AnonymousInvocations() []AnonymousInvocation {
+	return append([]AnonymousInvocation(nil), f.anonymousInvocations...)
+}
+
 func parseTree(src []byte, name string) (*syntax.File, error) {
 	parser := syntax.NewParser(
 		syntax.KeepComments(true),
 		syntax.Variant(syntax.LangZsh),
 	)
 	return parser.Parse(bytes.NewReader(src), name)
+}
+
+type compatibilityParser func([]byte, string, error) (*syntax.File, error)
+
+// parseCompatibleTree applies the established byte-preserving adapters in
+// order. Anonymous-function invocation arguments are handled separately
+// because their words live in File metadata rather than the upstream AST.
+func parseCompatibleTree(src []byte, name string) (*syntax.File, error) {
+	tree, err := parseTree(src, name)
+	if err == nil {
+		return tree, nil
+	}
+	adapters := []compatibilityParser{
+		parseNestedConditionalAlternation,
+		parseAlternateIfBrace,
+		parseAssociativeSubscript,
+		parseRCExpandCaret,
+		parseReverseSubscript,
+		parseParamGlobToggle,
+		parseFdVarRedirect,
+		parseMultiNameFor,
+		parseTryAlways,
+		parseGroupedCasePattern,
+		parseANSICHeredocDelimiter,
+	}
+	for _, adapter := range adapters {
+		tree, err = adapter(src, name, err)
+		if err == nil {
+			return tree, nil
+		}
+	}
+	return nil, err
 }
 
 // Parse parses a single Zsh source read from r, using name in error
@@ -56,46 +105,21 @@ func Parse(r io.Reader, name string) (*File, error) {
 	if err != nil {
 		return nil, err
 	}
-	tree, err := parseTree(src, name)
+	tree, err := parseCompatibleTree(src, name)
+	var anonymousInvocations []AnonymousInvocation
 	if err != nil {
-		tree, err = parseNestedConditionalAlternation(src, name, err)
+		tree, anonymousInvocations, err = parseAnonymousFunctionArgs(src, name, err)
 		if err != nil {
-			tree, err = parseAlternateIfBrace(src, name, err)
-			if err != nil {
-				tree, err = parseAssociativeSubscript(src, name, err)
-				if err != nil {
-					tree, err = parseRCExpandCaret(src, name, err)
-					if err != nil {
-						tree, err = parseReverseSubscript(src, name, err)
-						if err != nil {
-							tree, err = parseParamGlobToggle(src, name, err)
-							if err != nil {
-								tree, err = parseFdVarRedirect(src, name, err)
-								if err != nil {
-									tree, err = parseMultiNameFor(src, name, err)
-									if err != nil {
-										tree, err = parseTryAlways(src, name, err)
-										if err != nil {
-											tree, err = parseGroupedCasePattern(src, name, err)
-											if err != nil {
-												tree, err = parseANSICHeredocDelimiter(src, name, err)
-												if err != nil {
-													return nil, err
-												}
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
+			return nil, err
 		}
 	}
 	if err := validateConditionalPatterns(src, name); err != nil {
 		return nil, err
 	}
 	text := strings.TrimSuffix(string(src), "\n")
-	return &File{tree: tree, lines: strings.Split(text, "\n")}, nil
+	return &File{
+		tree:                 tree,
+		lines:                strings.Split(text, "\n"),
+		anonymousInvocations: anonymousInvocations,
+	}, nil
 }

--- a/internal/survey/corpus_test.go
+++ b/internal/survey/corpus_test.go
@@ -15,6 +15,7 @@ import (
 // (issue #14): new fixtures can be added freely without touching this test.
 var requiredFixtures = []string{
 	"ok-alternate-if-brace.zsh",
+	"ok-anonymous-function-arguments.zsh",
 	"ok-ansic-heredoc.zsh",
 	"ok-assoc-subscript-keys.zsh",
 	"ok-baseline.zsh",

--- a/internal/survey/testdata/corpus/ok-anonymous-function-arguments.zsh
+++ b/internal/survey/testdata/corpus/ok-anonymous-function-arguments.zsh
@@ -1,0 +1,9 @@
+# -*- mode: zsh; sh-indentation: 2; indent-tabs-mode: nil; sh-basic-offset: 2; -*-
+# vim: ft=zsh sw=2 ts=2 et
+
+# Regression fixture for issue #163.
+() {
+  builtin emulate -L zsh
+  typeset -r source_path=$1
+  print -r -- "$source_path"
+} "${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"


### PR DESCRIPTION
Closes #163.

## Summary

- add an exact-error parser adapter for native-Zsh anonymous-function invocation arguments
- retain invocation words as typed parser metadata paired with the owning anonymous declaration
- preserve byte offsets and original errors for unsupported controls
- make the adapter compose with the existing compatibility boundary
- add minimized corpus, nested, repeated, composition, position, AST-evidence, and invalid-control coverage

## Validation

- `go test ./...` passed
- `go test -race ./...` passed
- `go vet ./...` passed
- CLI build and `go generate ./...` passed without drift
- native Zsh syntax passed for the new corpus fixture
- all three migration entrypoints parse with this revision
- actionlint passed
- golangci-lint passed with no issues
- local Trunk gitleaks could not launch because its pinned cache binary was absent; hosted Trunk remains authoritative for that adapter

This parser prerequisite unblocks z-shell/z-a-meta-plugins#52, z-shell/zsh-fancy-completions#55, and z-shell/zsh-eza#108 before `plugin/zero-handling` enforcement in #160.
