### PR TITLE
feat(profiles): complete advisory quality validators

### DIFF
--- a/cmd/zsh-lint/main.go
+++ b/cmd/zsh-lint/main.go
@@ -77,6 +77,9 @@ func run(args []string, stdout, stderr io.Writer) int {
 	}
 
 	an := analyzer.New(activeRules...)
+	if sourceContexts != nil {
+		return runConfiguredProject(an, names, sourceContexts, jsonOut, stdout, stderr)
+	}
 	var all diag.Diagnostics
 	var exitNonZero bool
 
@@ -139,6 +142,65 @@ func run(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 
+	if exitNonZero {
+		return 1
+	}
+	return 0
+}
+
+func runConfiguredProject(
+	an *analyzer.Analyzer,
+	names []string,
+	contexts []projectconfig.SourceContext,
+	jsonOut bool,
+	stdout io.Writer,
+	stderr io.Writer,
+) int {
+	inputs := make([]analyzer.ProjectInput, 0, len(names))
+	var all diag.Diagnostics
+	exitNonZero := false
+	for index, name := range names {
+		fileHandle, err := os.Open(name)
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "%s: %v\n", name, err)
+			exitNonZero = true
+			continue
+		}
+		file, err := parse.Parse(fileHandle, name)
+		_ = fileHandle.Close()
+		if err != nil {
+			exitNonZero = true
+			if jsonOut {
+				all = append(all, parseErrDiag(name, err))
+			} else {
+				_, _ = fmt.Fprintln(stdout, formatErr(name, err))
+			}
+			continue
+		}
+		inputs = append(inputs, analyzer.ProjectInput{File: file, Path: name, Source: contexts[index]})
+	}
+	diagnostics := an.AnalyzeProject(inputs)
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Severity <= diag.Warning {
+			exitNonZero = true
+		}
+		if jsonOut {
+			continue
+		}
+		if diagnostic.Range.IsValid() {
+			_, _ = fmt.Fprintf(stdout, "%s:%d:%d: [%s] %s\n", diagnostic.File, diagnostic.Range.Start.Line, diagnostic.Range.Start.Column, diagnostic.RuleID, diagnostic.Message)
+		} else {
+			_, _ = fmt.Fprintf(stdout, "%s: [%s] %s\n", diagnostic.File, diagnostic.RuleID, diagnostic.Message)
+		}
+	}
+	if jsonOut {
+		all = append(all, diagnostics...)
+		all.Sort()
+		if err := diag.WriteJSON(stdout, len(names), all); err != nil {
+			_, _ = fmt.Fprintf(stderr, "zsh-lint: encoding JSON: %v\n", err)
+			return 2
+		}
+	}
 	if exitNonZero {
 		return 1
 	}

--- a/docs/project/project-configuration.md
+++ b/docs/project/project-configuration.md
@@ -21,8 +21,12 @@ deterministic rule set. They are deliberately separate so a schema correction
 does not silently change rule membership, and a rule-profile revision does not
 silently change configuration syntax.
 
-The configured profile contains the generic rules plus the existing plugin
-lifecycle rules and `plugin/function-namespace`. Rules that need project
+The configured profile contains correctness rules, the organization-approved
+`style/prefer-double-brackets` advisory style rule, the existing plugin
+lifecycle rules, `plugin/function-namespace`, and evidence-gated advisory
+performance rules. The legacy `style/backquotes` and `style/function-decl`
+rules remain available only in unconfigured compatibility mode because no
+organization policy currently adopts those preferences. Rules that need project
 context use explicit `project.kind`, source `profile`, and source `role`
 metadata. Paths cannot override configured metadata. The legacy path heuristics
 remain available only on invocations without `--config`.
@@ -36,6 +40,18 @@ In project profile version 1:
   sources; and
 - `plugin/function-namespace` retains its documented plugin and Zi annex
   sourced-library and autoload-function boundary.
+
+Configured invocations analyze their complete explicit input list as one
+project. The `plugin/project-unload-lifecycle` validator can therefore match a
+persistent registration in an entrypoint to an exact `*_plugin_unload`
+definition in another configured source. Files omitted from the command are
+intentionally outside that proof boundary.
+
+The `performance/repeated-external-command` rule applies only to configured
+`autoload-function` sources with the `completion` role. It reports Info
+findings for a conservative allowlist of known external commands inside loops.
+Its cost model is N process creations for N iterations; remediation still
+requires workload measurement when the command result varies per iteration.
 
 Theme projects do not inherit plugin lifecycle contracts in this profile. A
 future theme contract requires an explicit profile decision.

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -30,6 +30,13 @@ func (a *Analyzer) Analyze(file *parse.File, path string) diag.Diagnostics {
 // execution-profile metadata. Analyze remains the compatibility entry point
 // for callers that do not use project configuration.
 func (a *Analyzer) AnalyzeSource(file *parse.File, path string, source projectconfig.SourceContext) diag.Diagnostics {
+	if source.Configured() {
+		return a.AnalyzeProject([]ProjectInput{{File: file, Path: path, Source: source}})
+	}
+	return a.analyzeSource(file, path, source, true)
+}
+
+func (a *Analyzer) analyzeSource(file *parse.File, path string, source projectconfig.SourceContext, applySuppressions bool) diag.Diagnostics {
 	ctx := NewContextWithSource(file, path, source)
 	ast := file.AST()
 
@@ -62,7 +69,7 @@ func (a *Analyzer) AnalyzeSource(file *parse.File, path string, source projectco
 	// Pass 3: inline suppression (docs/project/suppression.md). Applying it
 	// here keeps human and JSON output consistent: suppressed findings are
 	// dropped and meta/* findings appended before the single final sort.
-	if ast != nil {
+	if ast != nil && applySuppressions {
 		known := make(map[diag.RuleID]bool, len(a.rules))
 		for _, rule := range a.rules {
 			known[rule.ID()] = true
@@ -72,6 +79,49 @@ func (a *Analyzer) AnalyzeSource(file *parse.File, path string, source projectco
 
 	ctx.Diagnostics.Sort()
 	return ctx.Diagnostics
+}
+
+// AnalyzeProject runs per-file analysis and then project rules over the
+// complete explicit configured input set.
+func (a *Analyzer) AnalyzeProject(inputs []ProjectInput) diag.Diagnostics {
+	var diagnostics diag.Diagnostics
+	for _, input := range inputs {
+		diagnostics = append(diagnostics, a.analyzeSource(input.File, input.Path, input.Source, false)...)
+	}
+	project := &ProjectContext{Inputs: append([]ProjectInput(nil), inputs...)}
+	for _, rule := range a.rules {
+		if projectRule, ok := rule.(ProjectRule); ok {
+			projectRule.AnalyzeProject(project)
+		}
+	}
+	known := make(map[diag.RuleID]bool, len(a.rules))
+	for _, rule := range a.rules {
+		known[rule.ID()] = true
+	}
+	for _, input := range inputs {
+		var attributed diag.Diagnostics
+		var remaining diag.Diagnostics
+		for _, diagnostic := range diagnostics {
+			if diagnostic.File == input.Path {
+				attributed = append(attributed, diagnostic)
+			} else {
+				remaining = append(remaining, diagnostic)
+			}
+		}
+		for _, diagnostic := range project.Diagnostics {
+			if diagnostic.File == input.Path {
+				attributed = append(attributed, diagnostic)
+			}
+		}
+		diagnostics = append(remaining, suppress.Apply(
+			suppress.Collect(input.File),
+			attributed,
+			known,
+			input.Path,
+		)...)
+	}
+	diagnostics.Sort()
+	return diagnostics
 }
 
 func needsScope(rules []Rule) bool {

--- a/internal/analyzer/context.go
+++ b/internal/analyzer/context.go
@@ -20,6 +20,20 @@ type Context struct {
 	Scope *scope.Map
 }
 
+// ProjectContext provides the complete configured input set and accumulates
+// source-positioned project-validator findings.
+type ProjectContext struct {
+	Inputs      []ProjectInput
+	Diagnostics diag.Diagnostics
+}
+
+// Report adds a project-validator finding attributed to one input.
+func (c *ProjectContext) Report(input ProjectInput, pos, end syntax.Pos, ruleID diag.RuleID, sev diag.Severity, msg string) {
+	context := NewContextWithSource(input.File, input.Path, input.Source)
+	context.Report(pos, end, ruleID, sev, msg)
+	c.Diagnostics = append(c.Diagnostics, context.Diagnostics...)
+}
+
 // NewContext creates a new analysis context for a file.
 func NewContext(file *parse.File, path string) *Context {
 	return NewContextWithSource(file, path, projectconfig.SourceContext{})

--- a/internal/analyzer/rule.go
+++ b/internal/analyzer/rule.go
@@ -2,6 +2,8 @@ package analyzer
 
 import (
 	"github.com/z-shell/zsh-lint/internal/diag"
+	"github.com/z-shell/zsh-lint/internal/parse"
+	"github.com/z-shell/zsh-lint/internal/projectconfig"
 	"mvdan.cc/sh/v3/syntax"
 )
 
@@ -27,4 +29,18 @@ type FileRule interface {
 // unless at least one registered rule opts in.
 type ScopeAwareRule interface {
 	NeedsScope() bool
+}
+
+// ProjectInput is one parsed, explicitly configured source in a project
+// analysis invocation.
+type ProjectInput struct {
+	File   *parse.File
+	Path   string
+	Source projectconfig.SourceContext
+}
+
+// ProjectRule evaluates invariants that require more than one configured
+// source file. Per-file Analyze methods remain responsible for local findings.
+type ProjectRule interface {
+	AnalyzeProject(ctx *ProjectContext)
 }

--- a/internal/rules/fpath_hygiene.go
+++ b/internal/rules/fpath_hygiene.go
@@ -67,11 +67,30 @@ func (rule FpathHygiene) Analyze(ctx *analyzer.Context, node syntax.Node) {
 	if ctx.Source.Configured() && !sourcedPluginRuleApplies(ctx) {
 		return
 	}
+	if ctx.Source.Configured() {
+		file, ok := node.(*syntax.File)
+		if !ok {
+			return
+		}
+		invoked := make(map[*syntax.FuncDecl]bool)
+		for _, invocation := range ctx.File.AnonymousInvocations() {
+			invoked[invocation.Function] = true
+		}
+		for _, stmt := range file.Stmts {
+			walkExecutedEntrypoint(stmt, invoked, func(call *syntax.CallExpr) {
+				rule.analyzeCall(ctx, call)
+			})
+		}
+		return
+	}
 	call, ok := node.(*syntax.CallExpr)
 	if !ok {
 		return
 	}
+	rule.analyzeCall(ctx, call)
+}
 
+func (rule FpathHygiene) analyzeCall(ctx *analyzer.Context, call *syntax.CallExpr) {
 	for _, assign := range call.Assigns {
 		if assign == nil || assign.Name == nil {
 			continue
@@ -105,6 +124,18 @@ func (rule FpathHygiene) Analyze(ctx *analyzer.Context, node syntax.Node) {
 			checkFpathElement(ctx, assign.Value, rule.ID())
 		}
 	}
+}
+
+func walkExecutedEntrypoint(node syntax.Node, invoked map[*syntax.FuncDecl]bool, visit func(*syntax.CallExpr)) {
+	syntax.Walk(node, func(current syntax.Node) bool {
+		if function, ok := current.(*syntax.FuncDecl); ok {
+			return function.Name == nil && len(function.Names) == 0 && invoked[function]
+		}
+		if call, ok := current.(*syntax.CallExpr); ok {
+			visit(call)
+		}
+		return true
+	})
 }
 
 func arrayContainsFpathReference(array *syntax.ArrayExpr) bool {

--- a/internal/rules/fpath_hygiene_test.go
+++ b/internal/rules/fpath_hygiene_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/z-shell/zsh-lint/internal/analyzer"
 	"github.com/z-shell/zsh-lint/internal/diag"
 	"github.com/z-shell/zsh-lint/internal/parse"
+	"github.com/z-shell/zsh-lint/internal/projectconfig"
 )
 
 func TestFpathHygiene(t *testing.T) {
@@ -76,6 +77,50 @@ fpath=( "${0:h}/functions" )
 			}
 			if len(relevant) != tt.wantDiag {
 				t.Fatalf("got %d diagnostics, want %d: %v", len(relevant), tt.wantDiag, relevant)
+			}
+		})
+	}
+}
+
+func TestConfiguredFpathHygieneExecutionScope(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want int
+	}{
+		{
+			name: "direct top-level assignment",
+			src:  "fpath=( /tmp/functions )\n",
+			want: 1,
+		},
+		{
+			name: "top-level conditional assignment",
+			src:  "if true; then fpath=( /tmp/functions ); fi\n",
+			want: 1,
+		},
+		{
+			name: "named function definition is not executed",
+			src:  "helper() { fpath=( /tmp/functions ) }\n",
+		},
+		{
+			name: "invoked anonymous function is executed",
+			src:  "() { fpath=( /tmp/functions ) } argument\n",
+			want: 1,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			file, err := parse.Parse(strings.NewReader(test.src), "plugin.zsh")
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			got := analyzer.New(FpathHygiene{}).AnalyzeSource(
+				file,
+				"plugin.zsh",
+				configuredSource(projectconfig.KindPlugin, projectconfig.ProfileSourcedLibrary, ""),
+			)
+			if len(got) != test.want {
+				t.Fatalf("diagnostics = %+v, want %d", got, test.want)
 			}
 		})
 	}

--- a/internal/rules/profile_test.go
+++ b/internal/rules/profile_test.go
@@ -65,12 +65,11 @@ func TestConfiguredPluginRuleApplicability(t *testing.T) {
 			context: configuredSource(projectconfig.KindPlugin, projectconfig.ProfileAutoloadFunction, ""),
 		},
 		{
-			name:    "sourced annex activates unload lifecycle",
+			name:    "sourced annex defers unload presence to project validator",
 			rule:    UnloadFunction{},
 			source:  "add-zsh-hook precmd _example_precmd\n",
 			path:    "annex.zsh",
 			context: configuredSource(projectconfig.KindZiAnnex, projectconfig.ProfileSourcedLibrary, ""),
-			want:    1,
 		},
 		{
 			name:    "library metadata disables unload lifecycle",

--- a/internal/rules/repeated_external_command.go
+++ b/internal/rules/repeated_external_command.go
@@ -1,0 +1,83 @@
+package rules
+
+import (
+	"github.com/z-shell/zsh-lint/internal/analyzer"
+	"github.com/z-shell/zsh-lint/internal/diag"
+	"github.com/z-shell/zsh-lint/internal/projectconfig"
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// RepeatedExternalCommand reports known external commands in completion loops.
+//
+// ID: `performance/repeated-external-command`
+//
+// Name: Repeated external command in completion loop
+//
+// Summary: Reports a conservative allowlist of commands that necessarily
+// create a process when they occur in a loop in a configured completion source.
+//
+// Why: A loop with N iterations creates N external processes for each reported
+// call. Process creation is the dominant fixed cost even when the command does
+// little work. Hoist invariant work, use Zsh-native parameter operations, or
+// measure and retain the call when its result genuinely varies per iteration.
+//
+// Severity: Info. The cost model is certain, but whether it matters depends on
+// iteration count, command work, and the interactive completion workload.
+//
+// False positives: A command whose result must be recomputed for each item may
+// be intentional. Measure the completion path before changing behavior.
+type RepeatedExternalCommand struct{}
+
+func (RepeatedExternalCommand) ID() diag.RuleID {
+	return "performance/repeated-external-command"
+}
+
+func (RepeatedExternalCommand) Name() string {
+	return "Repeated external command in completion loop"
+}
+
+func (rule RepeatedExternalCommand) Analyze(ctx *analyzer.Context, node syntax.Node) {
+	file, ok := node.(*syntax.File)
+	if !ok || !ctx.Source.Configured() || ctx.Source.Profile != projectconfig.ProfileAutoloadFunction ||
+		ctx.Source.Role != projectconfig.RoleCompletion {
+		return
+	}
+	seen := make(map[uint]bool)
+	syntax.Walk(file, func(current syntax.Node) bool {
+		switch loop := current.(type) {
+		case *syntax.ForClause:
+			rule.reportLoopCalls(ctx, loop.Do, seen)
+		case *syntax.WhileClause:
+			rule.reportLoopCalls(ctx, loop.Do, seen)
+		}
+		return true
+	})
+}
+
+func (rule RepeatedExternalCommand) reportLoopCalls(ctx *analyzer.Context, statements []*syntax.Stmt, seen map[uint]bool) {
+	for _, statement := range statements {
+		syntax.Walk(statement, func(current syntax.Node) bool {
+			call, ok := current.(*syntax.CallExpr)
+			if !ok || len(call.Args) == 0 {
+				return true
+			}
+			name := getWordLiteral(call.Args[0])
+			if !knownExternalCommand(name) || seen[call.Pos().Offset()] {
+				return true
+			}
+			seen[call.Pos().Offset()] = true
+			ctx.Report(call.Pos(), call.End(), rule.ID(), diag.Info,
+				"External command '"+name+"' runs once per completion-loop iteration; hoist invariant work or measure the interactive cost")
+			return true
+		})
+	}
+}
+
+func knownExternalCommand(name string) bool {
+	switch name {
+	case "awk", "cut", "find", "git", "grep", "sed", "sort", "tr":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/rules/repeated_external_command_test.go
+++ b/internal/rules/repeated_external_command_test.go
@@ -1,0 +1,56 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/z-shell/zsh-lint/internal/analyzer"
+	"github.com/z-shell/zsh-lint/internal/diag"
+	"github.com/z-shell/zsh-lint/internal/parse"
+	"github.com/z-shell/zsh-lint/internal/projectconfig"
+)
+
+func TestRepeatedExternalCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  string
+		context projectconfig.SourceContext
+		want    int
+	}{
+		{
+			name:    "external command in completion loop",
+			source:  "for item in one two; do git status --short; done\n",
+			context: configuredSource(projectconfig.KindPlugin, projectconfig.ProfileAutoloadFunction, projectconfig.RoleCompletion),
+			want:    1,
+		},
+		{
+			name:    "zsh builtin is ignored",
+			source:  "for item in one two; do print -r -- $item; done\n",
+			context: configuredSource(projectconfig.KindPlugin, projectconfig.ProfileAutoloadFunction, projectconfig.RoleCompletion),
+		},
+		{
+			name:    "non-completion source is outside contract",
+			source:  "for item in one two; do git status --short; done\n",
+			context: configuredSource(projectconfig.KindPlugin, projectconfig.ProfileAutoloadFunction, ""),
+		},
+		{
+			name:   "unconfigured source is outside opt-in profile",
+			source: "while true; do grep pattern file; done\n",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			file, err := parse.Parse(strings.NewReader(test.source), "completion")
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			diagnostics := analyzer.New(RepeatedExternalCommand{}).AnalyzeSource(file, "completion", test.context)
+			if len(diagnostics) != test.want {
+				t.Fatalf("diagnostics = %+v, want %d", diagnostics, test.want)
+			}
+			if test.want > 0 && diagnostics[0].Severity != diag.Info {
+				t.Fatalf("severity = %v, want info", diagnostics[0].Severity)
+			}
+		})
+	}
+}

--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -31,7 +31,7 @@ func Default() []analyzer.Rule {
 func ForProfile(profile Profile) ([]analyzer.Rule, error) {
 	switch profile {
 	case ProjectProfileV1:
-		return append(genericRules(), configuredProjectRules()...), nil
+		return configuredProjectRules(), nil
 	default:
 		return nil, fmt.Errorf("unsupported rule profile %q", profile)
 	}
@@ -53,10 +53,22 @@ func legacyProjectRules() []analyzer.Rule {
 		FunctionScopedOptions{},
 		ZeroHandling{},
 		UnloadFunction{},
+		ProjectUnloadLifecycle{},
 		FpathHygiene{},
 	}
 }
 
 func configuredProjectRules() []analyzer.Rule {
-	return append(legacyProjectRules(), FunctionNamespace{})
+	return []analyzer.Rule{
+		UnquotedVar{},
+		PreferDoubleBrackets{},
+		EvalUsage{},
+		SpecialParamShadow{},
+		FunctionScopedOptions{},
+		ZeroHandling{},
+		UnloadFunction{},
+		FpathHygiene{},
+		FunctionNamespace{},
+		RepeatedExternalCommand{},
+	}
 }

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -59,9 +59,21 @@ func TestRuleSetSelection(t *testing.T) {
 		"plugin/function-scoped-options",
 		"plugin/zero-handling",
 		"plugin/unload-function",
+		"plugin/project-unload-lifecycle",
 		"plugin/fpath-hygiene",
 	}
-	profileIDs := append(append([]diag.RuleID(nil), defaultIDs...), "plugin/function-namespace")
+	profileIDs := []diag.RuleID{
+		"quoting/unquoted-var",
+		"style/prefer-double-brackets",
+		"security/eval",
+		"compat/special-param-shadow",
+		"plugin/function-scoped-options",
+		"plugin/zero-handling",
+		"plugin/unload-function",
+		"plugin/fpath-hygiene",
+		"plugin/function-namespace",
+		"performance/repeated-external-command",
+	}
 
 	if got := ruleIDs(Default()); !equalRuleIDs(got, defaultIDs) {
 		t.Fatalf("Default IDs = %v, want %v", got, defaultIDs)

--- a/internal/rules/unload_function.go
+++ b/internal/rules/unload_function.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/z-shell/zsh-lint/internal/analyzer"
 	"github.com/z-shell/zsh-lint/internal/diag"
+	"github.com/z-shell/zsh-lint/internal/projectconfig"
 	"mvdan.cc/sh/v3/syntax"
 )
 
@@ -17,9 +18,9 @@ import (
 // Summary: Checks configured plugin and Zi annex sourced-library entrypoints
 // that register persistent shell hooks or widgets for a namespaced unload
 // function (`*_plugin_unload`), and checks that defined unload functions
-// cleanly unfunction themselves upon completion. This remains a per-file
-// check: project-wide registration and cleanup matching requires aggregation.
-// Unconfigured analysis retains the legacy path heuristic.
+// cleanly unfunction themselves upon completion. Configured multi-file
+// invocations aggregate registration and unload presence across the project;
+// unconfigured analysis retains the legacy per-file path heuristic.
 //
 // Why: The Zsh Plugin Standard specifies that plugins with persistent side
 // effects (hooks via `add-zsh-hook`, line-editor widgets via
@@ -93,7 +94,7 @@ func (rule UnloadFunction) Analyze(ctx *analyzer.Context, node syntax.Node) {
 	})
 
 	// Check if hooks are registered without any unload function in the file
-	if len(hookRegistrations) > 0 && len(unloadFuncs) == 0 {
+	if !ctx.Source.Configured() && len(hookRegistrations) > 0 && len(unloadFuncs) == 0 {
 		for _, call := range hookRegistrations {
 			ctx.Report(
 				call.Pos(),
@@ -108,6 +109,62 @@ func (rule UnloadFunction) Analyze(ctx *analyzer.Context, node syntax.Node) {
 	// Inspect hygiene of defined unload functions
 	for _, fn := range unloadFuncs {
 		checkUnloadFunctionHygiene(ctx, fn, rule.ID())
+	}
+}
+
+// ProjectUnloadLifecycle checks configured registration and unload presence
+// across every source supplied in one project invocation.
+type ProjectUnloadLifecycle struct{}
+
+func (ProjectUnloadLifecycle) ID() diag.RuleID {
+	return "plugin/project-unload-lifecycle"
+}
+
+func (ProjectUnloadLifecycle) Name() string {
+	return "Project-wide unload lifecycle completeness"
+}
+
+func (ProjectUnloadLifecycle) Analyze(_ *analyzer.Context, _ syntax.Node) {}
+
+func (rule ProjectUnloadLifecycle) AnalyzeProject(ctx *analyzer.ProjectContext) {
+	var registrations []struct {
+		input analyzer.ProjectInput
+		call  *syntax.CallExpr
+	}
+	hasUnload := false
+	for _, input := range ctx.Inputs {
+		if !configuredPluginSource(input.Source, projectconfig.ProfileSourcedLibrary) {
+			continue
+		}
+		syntax.Walk(input.File.AST(), func(node syntax.Node) bool {
+			switch value := node.(type) {
+			case *syntax.FuncDecl:
+				if value.Name != nil && strings.HasSuffix(value.Name.Value, "_plugin_unload") {
+					hasUnload = true
+				}
+			case *syntax.CallExpr:
+				if isHookRegistrationCall(value) {
+					registrations = append(registrations, struct {
+						input analyzer.ProjectInput
+						call  *syntax.CallExpr
+					}{input: input, call: value})
+				}
+			}
+			return true
+		})
+	}
+	if hasUnload {
+		return
+	}
+	for _, registration := range registrations {
+		ctx.Report(
+			registration.input,
+			registration.call.Pos(),
+			registration.call.End(),
+			rule.ID(),
+			diag.Hint,
+			"Project registers persistent hooks or widgets but no configured source defines an exact '<name>_plugin_unload' function",
+		)
 	}
 }
 

--- a/internal/rules/unload_function.go
+++ b/internal/rules/unload_function.go
@@ -17,8 +17,9 @@ import (
 // Summary: Checks configured plugin and Zi annex sourced-library entrypoints
 // that register persistent shell hooks or widgets for a namespaced unload
 // function (`*_plugin_unload`), and checks that defined unload functions
-// cleanly unfunction themselves upon completion. Unconfigured analysis retains
-// the legacy path heuristic.
+// cleanly unfunction themselves upon completion. This remains a per-file
+// check: project-wide registration and cleanup matching requires aggregation.
+// Unconfigured analysis retains the legacy path heuristic.
 //
 // Why: The Zsh Plugin Standard specifies that plugins with persistent side
 // effects (hooks via `add-zsh-hook`, line-editor widgets via
@@ -80,7 +81,7 @@ func (rule UnloadFunction) Analyze(ctx *analyzer.Context, node syntax.Node) {
 	syntax.Walk(file, func(n syntax.Node) bool {
 		switch x := n.(type) {
 		case *syntax.FuncDecl:
-			if x.Name != nil && strings.HasSuffix(x.Name.Value, "_unload") {
+			if x.Name != nil && strings.HasSuffix(x.Name.Value, "_plugin_unload") {
 				unloadFuncs = append(unloadFuncs, x)
 			}
 		case *syntax.CallExpr:
@@ -124,6 +125,18 @@ func isHookRegistrationCall(call *syntax.CallExpr) bool {
 			}
 		}
 		return true
+	}
+	if cmdName == "zle" {
+		hasNew := false
+		for _, arg := range call.Args[1:] {
+			switch getWordLiteral(arg) {
+			case "-D":
+				return false
+			case "-N":
+				hasNew = true
+			}
+		}
+		return hasNew
 	}
 	return false
 }
@@ -176,20 +189,29 @@ func isSelfUnfunctionArg(w *syntax.Word, fnName string) bool {
 		return false
 	}
 	argLit := getWordLiteral(w)
-	if argLit == fnName || argLit == "$0" || strings.Contains(argLit, fnName) {
+	if argLit == fnName {
 		return true
 	}
-	found := false
-	syntax.Walk(w, func(n syntax.Node) bool {
-		if pe, ok := n.(*syntax.ParamExp); ok {
-			if pe.Param != nil && (pe.Param.Value == "0" || pe.Param.Value == fnName) {
-				found = true
-				return false
-			}
+	return wordIsExactParameter(w, "0") || wordIsExactParameter(w, fnName)
+}
+
+func wordIsExactParameter(w *syntax.Word, name string) bool {
+	if w == nil || len(w.Parts) != 1 {
+		return false
+	}
+	part := w.Parts[0]
+	if quoted, ok := part.(*syntax.DblQuoted); ok {
+		if len(quoted.Parts) != 1 {
+			return false
 		}
-		return true
-	})
-	return found
+		part = quoted.Parts[0]
+	}
+	param, ok := part.(*syntax.ParamExp)
+	return ok && param.Param != nil && param.Param.Value == name &&
+		param.Flags == nil && !param.Excl && !param.Length && !param.Width &&
+		!param.IsSet && param.NestedParam == nil && param.Index == nil &&
+		len(param.Modifiers) == 0 && param.Slice == nil && param.Repl == nil &&
+		param.Names == 0 && param.Exp == nil
 }
 
 func isIndiscriminateFunctionsWipe(w *syntax.Word) bool {

--- a/internal/rules/unload_function_test.go
+++ b/internal/rules/unload_function_test.go
@@ -14,92 +14,55 @@ func TestUnloadFunction(t *testing.T) {
 		name     string
 		src      string
 		path     string
-		wantDiag int
-		wantSev  diag.Severity
+		want     int
+		severity diag.Severity
 	}{
-		{
-			name: "hook registered without unload function",
-			src: `autoload -Uz add-zsh-hook
-add-zsh-hook precmd _my_precmd
-`,
-			path:     "my-plugin.plugin.zsh",
-			wantDiag: 1,
-			wantSev:  diag.Hint,
-		},
-		{
-			name: "unload function missing self-unfunction",
-			src: `my_plugin_unload() {
-  autoload -Uz add-zsh-hook
-  add-zsh-hook -d precmd _my_precmd
-  unfunction _my_precmd
-}
-`,
-			path:     "my-plugin.plugin.zsh",
-			wantDiag: 1,
-			wantSev:  diag.Hint,
-		},
-		{
-			name: "unload function with indiscriminate function wipe",
-			src: `my_plugin_unload() {
-  unfunction ${(k)functions}
-  unfunction my_plugin_unload
-}
-`,
-			path:     "my-plugin.plugin.zsh",
-			wantDiag: 1,
-			wantSev:  diag.Warning,
-		},
-		{
-			name: "compliant hook and unload function",
-			src: `autoload -Uz add-zsh-hook
-add-zsh-hook precmd _my_precmd
-
-my_plugin_unload() {
-  autoload -Uz add-zsh-hook
-  add-zsh-hook -d precmd _my_precmd
-  unfunction _my_precmd my_plugin_unload
-}
-`,
-			path:     "my-plugin.plugin.zsh",
-			wantDiag: 0,
-		},
-		{
-			name: "file inside functions directory",
-			src: `add-zsh-hook precmd _my_precmd
-`,
-			path:     "functions/.handler",
-			wantDiag: 0,
-		},
-		{
-			name: "suppressed hook finding",
-			src: `# zsh-lint disable=plugin/unload-function -- static plugin
-add-zsh-hook precmd _my_precmd
-`,
-			path:     "my-plugin.plugin.zsh",
-			wantDiag: 0,
-		},
+		{name: "hook registered without unload function", src: "autoload -Uz add-zsh-hook\nadd-zsh-hook precmd _my_precmd\n", path: "my-plugin.plugin.zsh", want: 1, severity: diag.Hint},
+		{name: "unload function missing self-unfunction", src: "my_plugin_unload() {\n  add-zsh-hook -d precmd _my_precmd\n  unfunction _my_precmd\n}\n", path: "my-plugin.plugin.zsh", want: 1, severity: diag.Hint},
+		{name: "unload function with indiscriminate function wipe", src: "my_plugin_unload() {\n  unfunction ${(k)functions}\n  unfunction my_plugin_unload\n}\n", path: "my-plugin.plugin.zsh", want: 1, severity: diag.Warning},
+		{name: "compliant hook and unload function", src: "add-zsh-hook precmd _my_precmd\nmy_plugin_unload() {\n  add-zsh-hook -d precmd _my_precmd\n  unfunction _my_precmd my_plugin_unload\n}\n", path: "my-plugin.plugin.zsh"},
+		{name: "file inside functions directory", src: "add-zsh-hook precmd _my_precmd\n", path: "functions/.handler"},
+		{name: "suppressed hook finding", src: "# zsh-lint disable=plugin/unload-function -- static plugin\nadd-zsh-hook precmd _my_precmd\n", path: "my-plugin.plugin.zsh"},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			file, err := parse.Parse(strings.NewReader(tt.src), tt.path)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			file, err := parse.Parse(strings.NewReader(test.src), test.path)
 			if err != nil {
-				t.Fatalf("Parse failed: %v", err)
+				t.Fatalf("parse: %v", err)
 			}
-			diags := analyzer.New(UnloadFunction{}).Analyze(file, tt.path)
-			var relevant diag.Diagnostics
-			for _, d := range diags {
-				if d.RuleID == "plugin/unload-function" {
-					relevant = append(relevant, d)
-				}
+			diagnostics := analyzer.New(UnloadFunction{}).Analyze(file, test.path)
+			if len(diagnostics) != test.want {
+				t.Fatalf("diagnostics = %+v, want %d", diagnostics, test.want)
 			}
-			if len(relevant) != tt.wantDiag {
-				t.Fatalf("got %d diagnostics, want %d: %v", len(relevant), tt.wantDiag, relevant)
+			if test.want > 0 && diagnostics[0].Severity != test.severity {
+				t.Fatalf("severity = %v, want %v", diagnostics[0].Severity, test.severity)
 			}
-			if tt.wantDiag > 0 && tt.wantSev != 0 {
-				if relevant[0].Severity != tt.wantSev {
-					t.Errorf("severity = %v, want %v", relevant[0].Severity, tt.wantSev)
-				}
+		})
+	}
+}
+
+func TestUnloadFunctionExactLifecycleMatching(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want int
+	}{
+		{name: "near-miss unload suffix does not satisfy lifecycle", src: "add-zsh-hook precmd _tick\nexample_unload() { unfunction example_unload }\n", want: 1},
+		{name: "substring does not satisfy self removal", src: "example_plugin_unload() { unfunction prefix-example_plugin_unload-suffix }\n", want: 1},
+		{name: "exact parameter satisfies self removal", src: "example_plugin_unload() { unfunction \"$0\" }\n"},
+		{name: "zle widget registration requires unload", src: "zle -N example-widget example_widget\n", want: 1},
+		{name: "zle widget deletion is not registration", src: "zle -D example-widget\n"},
+		{name: "hook deletion is not registration", src: "add-zsh-hook -d precmd _tick\n"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			file, err := parse.Parse(strings.NewReader(test.src), "plugin.zsh")
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			diagnostics := analyzer.New(UnloadFunction{}).Analyze(file, "plugin.zsh")
+			if len(diagnostics) != test.want {
+				t.Fatalf("diagnostics = %+v, want %d", diagnostics, test.want)
 			}
 		})
 	}

--- a/internal/rules/unload_function_test.go
+++ b/internal/rules/unload_function_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/z-shell/zsh-lint/internal/analyzer"
 	"github.com/z-shell/zsh-lint/internal/diag"
 	"github.com/z-shell/zsh-lint/internal/parse"
+	"github.com/z-shell/zsh-lint/internal/projectconfig"
 )
 
 func TestUnloadFunction(t *testing.T) {
@@ -38,6 +39,31 @@ func TestUnloadFunction(t *testing.T) {
 				t.Fatalf("severity = %v, want %v", diagnostics[0].Severity, test.severity)
 			}
 		})
+	}
+}
+
+func TestProjectUnloadLifecycleAcrossFiles(t *testing.T) {
+	entry, err := parse.Parse(strings.NewReader("add-zsh-hook precmd _tick\n"), "plugin.zsh")
+	if err != nil {
+		t.Fatalf("parse entry: %v", err)
+	}
+	unload, err := parse.Parse(strings.NewReader("example_plugin_unload() { unfunction example_plugin_unload }\n"), "lib/state.zsh")
+	if err != nil {
+		t.Fatalf("parse unload: %v", err)
+	}
+	source := configuredSource(projectconfig.KindPlugin, projectconfig.ProfileSourcedLibrary, "")
+	an := analyzer.New(UnloadFunction{}, ProjectUnloadLifecycle{})
+	diagnostics := an.AnalyzeProject([]analyzer.ProjectInput{
+		{File: entry, Path: "plugin.zsh", Source: source},
+		{File: unload, Path: "lib/state.zsh", Source: source},
+	})
+	if len(diagnostics) != 0 {
+		t.Fatalf("cross-file unload diagnostics = %+v, want none", diagnostics)
+	}
+
+	diagnostics = an.AnalyzeProject([]analyzer.ProjectInput{{File: entry, Path: "plugin.zsh", Source: source}})
+	if len(diagnostics) != 1 || diagnostics[0].RuleID != "plugin/project-unload-lifecycle" {
+		t.Fatalf("missing project unload diagnostics = %+v, want one project finding", diagnostics)
 	}
 }
 

--- a/internal/rules/zero_handling.go
+++ b/internal/rules/zero_handling.go
@@ -16,29 +16,33 @@ import (
 // Name: Zero-handling idiom in plugin entrypoint
 //
 // Summary: Reports direct uses of `$0` at the top level of configured plugin
-// and Zi annex sourced-library entrypoints before `$0` has been initialized
-// using prompt expansions (`${(%):-%N}` or `${(%):-%x}`). Unconfigured
-// analysis retains the legacy path heuristic.
+// and Zi annex sourced-library entrypoints. Configured analysis also reports
+// assignment to special parameter `0`, because sourced entrypoints must not
+// replace caller state. Unconfigured analysis retains the legacy path heuristic.
 //
 // Why: When a Zsh plugin is sourced, positional parameter `$0` evaluates to the
 // name of the shell (`zsh` or `-zsh`) rather than the path of the sourced script,
-// unless `FUNCTION_ARGZERO` is active. Plugin entrypoints must initialize `$0`
-// using prompt expansion `${(%):-%N}` or `${(%):-%x}` (optionally with `$ZERO`
-// fallback) before using `$0` to derive directories or autoload paths.
+// unless `FUNCTION_ARGZERO` is active. Configured plugin entrypoints must
+// resolve the source path with prompt expansion `${(%):-%N}` or
+// `${(%):-%x}` (optionally with `$ZERO` fallback) and pass it into a
+// localized scope instead of assigning to caller-visible special parameter
+// `0`.
 // See https://wiki.zshell.dev/community/zsh_plugin_standard#zero-handling.
 //
 // Bad:
 //
 //	fpath+=( "${0:h}/functions" )
 //
-// Good:
+// Good (configured sourced entrypoint):
 //
-//	0="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"
-//	0="${${(M)0:#/*}:-$PWD/$0}"
-//	fpath+=( "${0:h}/functions" )
+//	() {
+//	  local source_path=$1
+//	  fpath+=( "${source_path:h}/functions" )
+//	} "${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"
 //
-// Severity: Warning. Deriving paths from uninitialized `$0` in a sourced plugin
-// leads to incorrect directory paths or runtime loading failures.
+// Severity: Warning. Deriving paths from uninitialized `$0` can load the
+// wrong path; assigning to `0` can replace caller state or fail when
+// `POSIX_ARGZERO` makes it read-only.
 //
 // False positives: Scripts intended solely for direct execution (not sourcing)
 // or functions where `$0` refers to the function name. Suppress with a reason.
@@ -47,9 +51,8 @@ import (
 // `# zsh-lint disable=plugin/zero-handling -- <reason>` on the finding line or
 // immediately before the next non-comment, non-blank source line.
 //
-// Corpus evidence: `z-a-meta-plugins/z-a-meta-plugins.plugin.zsh:7` uses the
-// compliant `0="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"` idiom before
-// referencing `${0:h}` on line 12.
+// Corpus evidence: z-a-meta-plugins, zsh-fancy-completions, and zsh-eza use
+// the caller-preserving anonymous-function argument pattern.
 type ZeroHandling struct{}
 
 func (ZeroHandling) ID() diag.RuleID {
@@ -73,7 +76,14 @@ func (rule ZeroHandling) Analyze(ctx *analyzer.Context, node syntax.Node) {
 			continue
 		}
 
-		// Check if this statement initializes 0 with prompt expansion or $ZERO
+		if ctx.Source.Configured() && reportConfiguredZeroAssignment(ctx, stmt, rule.ID()) {
+			// Avoid cascading path-use findings after the primary caller-state
+			// violation on the assignment itself.
+			zeroInitialized = true
+			continue
+		}
+
+		// Preserve the legacy unconfigured initialization contract.
 		if isZeroInitializationStatement(stmt) {
 			zeroInitialized = true
 			continue
@@ -84,6 +94,29 @@ func (rule ZeroHandling) Analyze(ctx *analyzer.Context, node syntax.Node) {
 			checkUninitializedZeroInStmt(ctx, stmt, rule.ID())
 		}
 	}
+}
+
+func reportConfiguredZeroAssignment(ctx *analyzer.Context, stmt *syntax.Stmt, ruleID diag.RuleID) bool {
+	call, ok := stmt.Cmd.(*syntax.CallExpr)
+	if !ok {
+		return false
+	}
+	reported := false
+	for _, assign := range call.Assigns {
+		if assign != nil && assign.Name != nil && assign.Name.Value == "0" {
+			ctx.Report(assign.Pos(), assign.End(), ruleID, diag.Warning,
+				"Do not assign to special parameter '0' in a sourced entrypoint; pass the resolved source path into a localized anonymous function")
+			reported = true
+		}
+	}
+	for _, arg := range call.Args {
+		if isZeroAssignmentWord(arg) {
+			ctx.Report(arg.Pos(), arg.End(), ruleID, diag.Warning,
+				"Do not assign to special parameter '0' in a sourced entrypoint; pass the resolved source path into a localized anonymous function")
+			reported = true
+		}
+	}
+	return reported
 }
 
 func sourcedPluginRuleApplies(ctx *analyzer.Context) bool {
@@ -155,7 +188,7 @@ func hasPromptExpansionOrZeroInWord(word *syntax.Word) bool {
 			}
 		}
 		if lit, ok := n.(*syntax.Lit); ok {
-			if strings.Contains(lit.Value, "%N") || strings.Contains(lit.Value, "%x") || strings.Contains(lit.Value, "ZERO") {
+			if lit.Value == "%N" || lit.Value == "%x" {
 				found = true
 				return false
 			}

--- a/internal/rules/zero_handling_test.go
+++ b/internal/rules/zero_handling_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/z-shell/zsh-lint/internal/analyzer"
 	"github.com/z-shell/zsh-lint/internal/diag"
 	"github.com/z-shell/zsh-lint/internal/parse"
+	"github.com/z-shell/zsh-lint/internal/projectconfig"
 )
 
 func TestZeroHandling(t *testing.T) {
@@ -16,78 +17,62 @@ func TestZeroHandling(t *testing.T) {
 		path     string
 		wantDiag int
 	}{
-		{
-			name: "uninitialized 0 in fpath addition",
-			src: `fpath+=( "${0:h}/functions" )
-`,
-			path:     "my-plugin.plugin.zsh",
-			wantDiag: 1,
-		},
-		{
-			name: "uninitialized 0 in variable assignment",
-			src: `PLUGIN_DIR="${0:h}"
-`,
-			path:     "my-plugin.plugin.zsh",
-			wantDiag: 1,
-		},
+		{name: "uninitialized 0 in fpath addition", src: "fpath+=( \"${0:h}/functions\" )\n", path: "my-plugin.plugin.zsh", wantDiag: 1},
+		{name: "uninitialized 0 in variable assignment", src: "PLUGIN_DIR=\"${0:h}\"\n", path: "my-plugin.plugin.zsh", wantDiag: 1},
 		{
 			name: "compliant ZERO idiom initialization",
-			src: `0="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"
-0="${${(M)0:#/*}:-$PWD/$0}"
-fpath+=( "${0:h}/functions" )
-`,
-			path:     "my-plugin.plugin.zsh",
-			wantDiag: 0,
+			src:  "0=\"${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}\"\n0=\"${${(M)0:#/*}:-$PWD/$0}\"\nfpath+=( \"${0:h}/functions\" )\n",
+			path: "my-plugin.plugin.zsh",
 		},
-		{
-			name: "compliant prompt expansion initialization",
-			src: `0="${(%):-%N}"
-fpath+=( "${0:h}/functions" )
-`,
-			path:     "my-plugin.plugin.zsh",
-			wantDiag: 0,
-		},
-		{
-			name: "usage of 0 inside function body",
-			src: `my_func() {
-  print -r -- "Function name: $0"
-}
-`,
-			path:     "my-plugin.plugin.zsh",
-			wantDiag: 0,
-		},
-		{
-			name: "file inside functions directory",
-			src: `print -r -- "Arg zero: $0"
-`,
-			path:     "functions/.handler",
-			wantDiag: 0,
-		},
-		{
-			name: "suppressed finding",
-			src: `# zsh-lint disable=plugin/zero-handling -- direct execution script
-fpath+=( "${0:h}/functions" )
-`,
-			path:     "my-plugin.plugin.zsh",
-			wantDiag: 0,
-		},
+		{name: "compliant prompt expansion initialization", src: "0=\"${(%):-%N}\"\nfpath+=( \"${0:h}/functions\" )\n", path: "my-plugin.plugin.zsh"},
+		{name: "usage of 0 inside function body", src: "my_func() { print -r -- \"Function name: $0\" }\n", path: "my-plugin.plugin.zsh"},
+		{name: "file inside functions directory", src: "print -r -- \"Arg zero: $0\"\n", path: "functions/.handler"},
+		{name: "suppressed finding", src: "# zsh-lint disable=plugin/zero-handling -- direct execution script\nfpath+=( \"${0:h}/functions\" )\n", path: "my-plugin.plugin.zsh"},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			file, err := parse.Parse(strings.NewReader(tt.src), tt.path)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			file, err := parse.Parse(strings.NewReader(test.src), test.path)
 			if err != nil {
-				t.Fatalf("Parse failed: %v", err)
+				t.Fatalf("parse: %v", err)
 			}
-			diags := analyzer.New(ZeroHandling{}).Analyze(file, tt.path)
+			diagnostics := analyzer.New(ZeroHandling{}).Analyze(file, test.path)
 			var relevant diag.Diagnostics
-			for _, d := range diags {
-				if d.RuleID == "plugin/zero-handling" {
-					relevant = append(relevant, d)
+			for _, diagnostic := range diagnostics {
+				if diagnostic.RuleID == "plugin/zero-handling" {
+					relevant = append(relevant, diagnostic)
 				}
 			}
-			if len(relevant) != tt.wantDiag {
-				t.Errorf("got %d diagnostics, want %d: %v", len(relevant), tt.wantDiag, relevant)
+			if len(relevant) != test.wantDiag {
+				t.Fatalf("diagnostics = %+v, want %d", relevant, test.wantDiag)
+			}
+		})
+	}
+}
+
+func TestConfiguredZeroHandlingPreservesCallerState(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want int
+	}{
+		{name: "top-level zero assignment is rejected", src: "0=\"${(%):-%N}\"\nfpath+=( \"${0:h}/functions\" )\n", want: 1},
+		{name: "canonical anonymous function argument is accepted", src: "() {\n  local source_path=$1\n  fpath+=( \"${source_path:h}/functions\" )\n} \"${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}\"\n"},
+		{name: "named function zero is not entrypoint location", src: "helper() { print -r -- \"$0\" }\n"},
+		{name: "literal tokens do not initialize zero", src: "print -r -- 'ZERO %N %x'\nfpath+=( \"${0:h}/functions\" )\n", want: 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			file, err := parse.Parse(strings.NewReader(test.src), "plugin.zsh")
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			diagnostics := analyzer.New(ZeroHandling{}).AnalyzeSource(
+				file,
+				"plugin.zsh",
+				configuredSource(projectconfig.KindPlugin, projectconfig.ProfileSourcedLibrary, ""),
+			)
+			if len(diagnostics) != test.want {
+				t.Fatalf("diagnostics = %+v, want %d", diagnostics, test.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- correct configured caller-state, unload matching, and executed-entrypoint fpath analysis
- make the configured versioned profile include only the organization-approved advisory style rule
- add an Info-only completion-loop external-process diagnostic with an explicit N-process cost model
- add a multi-file project-analysis interface and cross-file unload lifecycle validator

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go build ./cmd/...`
- `actionlint`
- native `zsh -f -n` across repository Zsh sources
- `git diff --check`

The configured corpus currently fails only because z-a-meta-plugins #53 is green but awaiting its repository-required human review. Its main branch still contains the two caller-state assignments this PR is designed to reject.

Closes #160.
Closes #161.
Closes #162.
Closes #135.
Closes #136.
Closes #137.
