### PR TITLE
fix(wikidoc): preserve generated fence languages

### DIFF
--- a/internal/wikidoc/wikidoc.go
+++ b/internal/wikidoc/wikidoc.go
@@ -30,7 +30,8 @@ var (
 //     and closing <a> tags are stripped (inner text, if any, is preserved).
 //  3. Unwrap angle-bracketed link destinations (](<#Run>) → ](#Run)).
 //  4. Normalize leading tabs to four spaces for Markdown indentation.
-//  5. Convert indented code blocks to fenced blocks that MDX parses as code.
+//  5. Convert indented code blocks to language-tagged fenced blocks that MDX
+//     parses as code and the wiki accepts.
 //  6. Escape bare <, >, {, } on prose lines (not inside fenced code).
 //  7. Restore gomarkdoc's escaped inline-code spans, removing Markdown
 //     punctuation escapes and decoding entities only inside paired spans.
@@ -106,6 +107,7 @@ func fenceIndentedCodeBlocks(s string) string {
 			continue
 		}
 
+		blockStart := i
 		block := make([]string, 0, 1)
 		for i < len(lines) && strings.HasPrefix(lines[i], "    ") {
 			block = append(block, strings.TrimPrefix(lines[i], "    "))
@@ -119,12 +121,30 @@ func fenceIndentedCodeBlocks(s string) string {
 			continue
 		}
 
-		out = append(out, "```")
+		out = append(out, "```"+indentedCodeLanguage(lines, blockStart))
 		out = append(out, block...)
 		out = append(out, "```")
 	}
 
 	return strings.Join(out, "\n")
+}
+
+// indentedCodeLanguage classifies gomarkdoc's generated blocks. Rule examples
+// immediately follow the fixed Bad:/Good: schema and contain Zsh. Package
+// imports and Go declarations use Go, which is also the safe default for new
+// gomarkdoc sections that do not use the rule-example schema.
+func indentedCodeLanguage(lines []string, blockStart int) string {
+	for i := blockStart - 1; i >= 0; i-- {
+		switch strings.TrimSpace(lines[i]) {
+		case "":
+			continue
+		case "Bad:", "Good:":
+			return "zsh"
+		default:
+			return "go"
+		}
+	}
+	return "go"
 }
 
 // demoteHeadings shifts generated Markdown headings down three levels. Markdown

--- a/internal/wikidoc/wikidoc_test.go
+++ b/internal/wikidoc/wikidoc_test.go
@@ -266,7 +266,22 @@ func TestSanitize_DemoteHeadings(t *testing.T) {
 func TestSanitize_FenceIndentedCode(t *testing.T) {
 	input := "\tfunc render() { print ok; }\n\t  print done\n\t\n\nProse"
 	got := wikidoc.Sanitize(input)
-	want := "```\nfunc render() { print ok; }\n  print done\n```\n\nProse"
+	want := "```go\nfunc render() { print ok; }\n  print done\n```\n\nProse"
+	if got != want {
+		t.Errorf("Sanitize(%q) = %q; want %q", input, got, want)
+	}
+}
+
+// TestSanitize_FenceIndentedCodeLanguages verifies generated Go declarations
+// and Zsh rule examples receive the explicit languages required by the wiki.
+func TestSanitize_FenceIndentedCodeLanguages(t *testing.T) {
+	input := "## func Run\n\n\tfunc Run() int\n\n" +
+		"Bad:\n\n\tprint -r -- $value\n\n" +
+		"Good:\n\n\tprint -r -- \"$value\""
+	got := wikidoc.Sanitize(input)
+	want := "##### func Run\n\n```go\nfunc Run() int\n```\n\n" +
+		"Bad:\n\n```zsh\nprint -r -- $value\n```\n\n" +
+		"Good:\n\n```zsh\nprint -r -- \"$value\"\n```"
 	if got != want {
 		t.Errorf("Sanitize(%q) = %q; want %q", input, got, want)
 	}
@@ -298,7 +313,7 @@ func TestSanitize_EscapeProseChars(t *testing.T) {
 func TestSanitize_IndentedCodePreservesContent(t *testing.T) {
 	input := "\tfunc F(a <T>) {}"
 	got := wikidoc.Sanitize(input)
-	want := "```\nfunc F(a <T>) {}\n```"
+	want := "```go\nfunc F(a <T>) {}\n```"
 	if got != want {
 		t.Errorf("Sanitize should fence tab-indented code without escaping it; got: %q, want: %q", got, want)
 	}
@@ -318,7 +333,7 @@ func TestSanitize_FencedCodeNotEscaped(t *testing.T) {
 func TestSanitize_FourSpaceIndentFenced(t *testing.T) {
 	input := "    func F(a <T>) {}"
 	got := wikidoc.Sanitize(input)
-	want := "```\nfunc F(a <T>) {}\n```"
+	want := "```go\nfunc F(a <T>) {}\n```"
 	if got != want {
 		t.Errorf("Sanitize should fence 4-space-indented code; got: %q, want: %q", got, want)
 	}


### PR DESCRIPTION
## Summary

- classify gomarkdoc indented blocks as `zsh` only when they follow the rule documentation's `Bad:` or `Good:` schema
- tag package imports and Go declarations as `go`
- add regression coverage for both generated languages

## Verification

- `go build ./...`
- `go vet ./...`
- `go test ./...`
- generated the full reference with gomarkdoc, injected it into the wiki page, and passed the wiki code-fence validator with 76 explicit `go` or `zsh` fences

Fixes #167
