### PR TITLE
fix(wikidoc): classify qualified rule examples (#167)

### DIFF
--- a/internal/wikidoc/wikidoc.go
+++ b/internal/wikidoc/wikidoc.go
@@ -130,21 +130,44 @@ func fenceIndentedCodeBlocks(s string) string {
 }
 
 // indentedCodeLanguage classifies gomarkdoc's generated blocks. Rule examples
-// immediately follow the fixed Bad:/Good: schema and contain Zsh. Package
-// imports and Go declarations use Go, which is also the safe default for new
-// gomarkdoc sections that do not use the rule-example schema.
+// immediately follow Bad:/Good: labels, optionally with a parenthetical
+// qualifier, and contain Zsh. Package imports and Go declarations use Go,
+// which is also the safe default for new gomarkdoc sections that do not use the
+// rule-example schema.
 func indentedCodeLanguage(lines []string, blockStart int) string {
 	for i := blockStart - 1; i >= 0; i-- {
-		switch strings.TrimSpace(lines[i]) {
-		case "":
+		line := strings.TrimSpace(lines[i])
+		switch {
+		case line == "":
 			continue
-		case "Bad:", "Good:":
+		case isRuleExampleLabel(line):
 			return "zsh"
 		default:
 			return "go"
 		}
 	}
 	return "go"
+}
+
+func isRuleExampleLabel(line string) bool {
+	for _, label := range []string{"Bad", "Good"} {
+		if line == label+":" {
+			return true
+		}
+
+		detail, found := strings.CutPrefix(line, label+" ")
+		if !found || !strings.HasSuffix(detail, ":") {
+			continue
+		}
+		detail = strings.TrimSuffix(detail, ":")
+		if strings.HasPrefix(detail, "(") && strings.HasSuffix(detail, ")") {
+			return true
+		}
+		if strings.HasPrefix(detail, `\(`) && strings.HasSuffix(detail, `\)`) {
+			return true
+		}
+	}
+	return false
 }
 
 // demoteHeadings shifts generated Markdown headings down three levels. Markdown

--- a/internal/wikidoc/wikidoc_test.go
+++ b/internal/wikidoc/wikidoc_test.go
@@ -277,11 +277,16 @@ func TestSanitize_FenceIndentedCode(t *testing.T) {
 func TestSanitize_FenceIndentedCodeLanguages(t *testing.T) {
 	input := "## func Run\n\n\tfunc Run() int\n\n" +
 		"Bad:\n\n\tprint -r -- $value\n\n" +
-		"Good:\n\n\tprint -r -- \"$value\""
+		"Good:\n\n\tprint -r -- \"$value\"\n\n" +
+		"Good \\(configured sourced entrypoint\\):\n\n\t() { print -r -- \"$1\" } \"$value\"\n\n" +
+		"Bad (unconfigured script):\n\n\t0=$PWD/script.zsh"
 	got := wikidoc.Sanitize(input)
 	want := "##### func Run\n\n```go\nfunc Run() int\n```\n\n" +
 		"Bad:\n\n```zsh\nprint -r -- $value\n```\n\n" +
-		"Good:\n\n```zsh\nprint -r -- \"$value\"\n```"
+		"Good:\n\n```zsh\nprint -r -- \"$value\"\n```\n\n" +
+		"Good \\(configured sourced entrypoint\\):\n\n```zsh\n" +
+		"() { print -r -- \"$1\" } \"$value\"\n```\n\n" +
+		"Bad (unconfigured script):\n\n```zsh\n0=$PWD/script.zsh\n```"
 	if got != want {
 		t.Errorf("Sanitize(%q) = %q; want %q", input, got, want)
 	}


### PR DESCRIPTION
## Summary

- classify qualified `Good` and `Bad` rule-example labels as Zsh
- support both gomarkdoc-escaped and unescaped parenthetical qualifiers
- retain Go as the default for declarations and unrelated indented blocks

## Verification

- focused regression failed before the implementation and passes after it
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- end-to-end gomarkdoc generation: 59 `go` fences and 22 `zsh` fences
- affected configured sourced-entrypoint example now uses `zsh`
- wiki code-fence validation passed against the generated page
- `git diff --check`
- signed commit `c08c9891f1316890f82757875337f37ab0bb5a68`

This must land and refresh z-shell/wiki#875 before that generated-doc PR is merged.

Related to #167
