### PR TITLE
fix(rules): activate project unload validation

### DIFF
--- a/cmd/zsh-lint/main_test.go
+++ b/cmd/zsh-lint/main_test.go
@@ -176,6 +176,41 @@ func TestRunConfigurationActivatesProjectProfile(t *testing.T) {
 	}
 }
 
+func TestRunConfiguredProjectUnloadLifecycle(t *testing.T) {
+	root := t.TempDir()
+	config := filepath.Join(root, "zsh-lint.json")
+	entry := filepath.Join(root, "example.plugin.zsh")
+	unload := filepath.Join(root, "lib", "state.zsh")
+	writeFile(t, config, cliConfig)
+	writeFile(t, entry, "add-zsh-hook precmd _example_tick\n")
+	writeFile(t, unload, "example_plugin_unload() { unfunction example_plugin_unload }\n")
+
+	tests := []struct {
+		name        string
+		inputs      []string
+		wantFinding bool
+	}{
+		{name: "missing unload function", inputs: []string{entry}, wantFinding: true},
+		{name: "unload function in another source", inputs: []string{entry, unload}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			args := append([]string{"--config", config}, test.inputs...)
+			var stdout, stderr bytes.Buffer
+			if exit := run(args, &stdout, &stderr); exit != 0 {
+				t.Fatalf("run() exit = %d, want 0 for hint-only project finding; stderr = %q", exit, stderr.String())
+			}
+			gotFinding := strings.Contains(stdout.String(), "[plugin/project-unload-lifecycle]")
+			if gotFinding != test.wantFinding {
+				t.Errorf("project unload finding = %v, want %v; stdout = %q", gotFinding, test.wantFinding, stdout.String())
+			}
+			if stderr.Len() != 0 {
+				t.Errorf("stderr = %q, want empty", stderr.String())
+			}
+		})
+	}
+}
+
 func TestRunConfiguredMetadataOverridesLegacyPathHeuristics(t *testing.T) {
 	const toolConfig = `{
   "version": 1,

--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -67,6 +67,7 @@ func configuredProjectRules() []analyzer.Rule {
 		FunctionScopedOptions{},
 		ZeroHandling{},
 		UnloadFunction{},
+		ProjectUnloadLifecycle{},
 		FpathHygiene{},
 		FunctionNamespace{},
 		RepeatedExternalCommand{},

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -70,6 +70,7 @@ func TestRuleSetSelection(t *testing.T) {
 		"plugin/function-scoped-options",
 		"plugin/zero-handling",
 		"plugin/unload-function",
+		"plugin/project-unload-lifecycle",
 		"plugin/fpath-hygiene",
 		"plugin/function-namespace",
 		"performance/repeated-external-command",


### PR DESCRIPTION
Closes #181.

## Summary

- activate `plugin/project-unload-lifecycle` in the configured `z-shell/project@1` profile;
- cover the missing unload function through the CLI;
- cover an exact unload definition supplied by another configured source;
- pin the corrected profile membership in the rule-set contract test.

## Verification

- `go test ./...`
- `go vet ./...`
- `git diff --check`
