### PR TITLE
feat(survey): expand discovery and fix adapter composition

### DIFF
--- a/.github/workflows/discovery-survey.yml
+++ b/.github/workflows/discovery-survey.yml
@@ -46,6 +46,14 @@ jobs:
           path: discovery/zpmod
           persist-credentials: false
 
+      - name: Check out zunit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: z-shell/zunit
+          ref: main
+          path: discovery/zunit
+          persist-credentials: false
+
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -62,7 +70,7 @@ jobs:
       - name: Record discovery revisions
         working-directory: discovery
         run: |
-          for repository in zi zpmod; do
+          for repository in zi zpmod zunit; do
             printf '%s ' "$repository"
             git -C "$repository" rev-parse HEAD
           done
@@ -76,7 +84,7 @@ jobs:
           # Discovery is intentionally non-gating: a parse failure here is a
           # finding to triage, not a build break. Only an infrastructure fault
           # (missing tree, no files discovered) fails this job.
-          for repository in zi zpmod; do
+          for repository in zi zpmod zunit; do
             if [[ ! -d $repository ]]; then
               echo "::error::Discovery checkout missing: $repository"
               exit 1
@@ -84,7 +92,7 @@ jobs:
           done
 
           mapfile -d '' files < <(
-            find zi zpmod \
+            find zi zpmod zunit \
               -name .git -prune -o \
               -type f \( -name '*.zsh' -o -name 'zshrc' -o -name 'zshenv' \) \
               -print0 | sort -z
@@ -93,6 +101,12 @@ jobs:
             echo "::error::Discovery found no Zsh sources; check the find filter."
             exit 1
           fi
+          for file in "${files[@]}"; do
+            if [[ ! -r $file ]]; then
+              echo "::error::Discovery source is not readable: $file"
+              exit 1
+            fi
+          done
           echo "Discovered ${#files[@]} candidate source(s)."
 
           # A source that native Zsh also rejects is a broken or non-Zsh file
@@ -117,6 +131,10 @@ jobs:
           "$RUNNER_TEMP/zsh-lint-survey" "${native_valid[@]}" \
             > "$RUNNER_TEMP/discovery-survey.txt" 2>&1 || survey_status=$?
           cat "$RUNNER_TEMP/discovery-survey.txt"
+          if [[ $survey_status -gt 1 ]]; then
+            echo "::error::Survey tool failed with unexpected status ${survey_status}."
+            exit "$survey_status"
+          fi
 
           gaps=$(grep -c '^FAIL' "$RUNNER_TEMP/discovery-survey.txt" || true)
           {

--- a/.github/workflows/discovery-survey.yml
+++ b/.github/workflows/discovery-survey.yml
@@ -1,0 +1,149 @@
+---
+name: Discovery Survey
+
+# Non-gating parser coverage for Z-Shell repositories that are NOT in the
+# strict reference corpus (docs/project/corpus.md). Its purpose is to surface
+# parser gaps early, so it reports findings and always succeeds. Promotion of
+# any repository below into corpus-paths.txt is a separate, gated change that
+# must satisfy the full strict gate in corpus-gate.yml.
+
+on:
+  schedule:
+    - cron: "41 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  discovery:
+    name: Uncovered repository survey
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out zsh-lint
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: zsh-lint
+          persist-credentials: false
+
+      - name: Check out zi
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: z-shell/zi
+          ref: main
+          path: discovery/zi
+          persist-credentials: false
+
+      - name: Check out zpmod
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: z-shell/zpmod
+          ref: main
+          path: discovery/zpmod
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.25"
+          cache-dependency-path: zsh-lint/go.sum
+
+      - name: Set up Zsh
+        uses: z-shell/.github/actions/setup-zsh@4403e5a200c63596f641966dfb64e08a7a655ffa # main
+
+      - name: Build survey tool
+        working-directory: zsh-lint
+        run: go build -o "$RUNNER_TEMP/zsh-lint-survey" ./cmd/zsh-lint-survey
+
+      - name: Record discovery revisions
+        working-directory: discovery
+        run: |
+          for repository in zi zpmod; do
+            printf '%s ' "$repository"
+            git -C "$repository" rev-parse HEAD
+          done
+
+      - name: Survey uncovered repositories
+        working-directory: discovery
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          # Discovery is intentionally non-gating: a parse failure here is a
+          # finding to triage, not a build break. Only an infrastructure fault
+          # (missing tree, no files discovered) fails this job.
+          for repository in zi zpmod; do
+            if [[ ! -d $repository ]]; then
+              echo "::error::Discovery checkout missing: $repository"
+              exit 1
+            fi
+          done
+
+          mapfile -d '' files < <(
+            find zi zpmod \
+              -name .git -prune -o \
+              -type f \( -name '*.zsh' -o -name 'zshrc' -o -name 'zshenv' \) \
+              -print0 | sort -z
+          )
+          if [[ ${#files[@]} -eq 0 ]]; then
+            echo "::error::Discovery found no Zsh sources; check the find filter."
+            exit 1
+          fi
+          echo "Discovered ${#files[@]} candidate source(s)."
+
+          # A source that native Zsh also rejects is a broken or non-Zsh file
+          # (for example the ZUnit TEST DSL), not a parser gap. Partition first
+          # so the reported gap count stays honest.
+          native_valid=()
+          native_invalid=()
+          for file in "${files[@]}"; do
+            if zsh -f -n -- "$file" 2>/dev/null; then
+              native_valid+=("$file")
+            else
+              native_invalid+=("$file")
+            fi
+          done
+
+          if [[ ${#native_invalid[@]} -gt 0 ]]; then
+            echo "::notice::${#native_invalid[@]} source(s) rejected by native zsh -f -n; excluded from gap analysis."
+            printf '  %s\n' "${native_invalid[@]}"
+          fi
+
+          survey_status=0
+          "$RUNNER_TEMP/zsh-lint-survey" "${native_valid[@]}" \
+            > "$RUNNER_TEMP/discovery-survey.txt" 2>&1 || survey_status=$?
+          cat "$RUNNER_TEMP/discovery-survey.txt"
+
+          gaps=$(grep -c '^FAIL' "$RUNNER_TEMP/discovery-survey.txt" || true)
+          {
+            echo "## Discovery survey"
+            echo
+            echo "- Native-valid sources surveyed: ${#native_valid[@]}"
+            echo "- Excluded as native-invalid: ${#native_invalid[@]}"
+            echo "- Parser gaps (native-valid but unparsed): ${gaps}"
+            echo
+            echo "Non-gating. See docs/project/parser-gap-workflow.md to triage."
+            if [[ $gaps -gt 0 ]]; then
+              echo
+              echo '```text'
+              grep -A1 '^FAIL' "$RUNNER_TEMP/discovery-survey.txt" || true
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ $gaps -gt 0 ]]; then
+            echo "::notice::${gaps} parser gap(s) found in uncovered repositories."
+          fi
+          echo "Survey tool exit status: ${survey_status} (not gating)."
+
+      - name: Upload discovery survey
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: discovery-survey
+          path: ${{ runner.temp }}/discovery-survey.txt
+          if-no-files-found: warn

--- a/docs/project/2026-08-28-discovery-survey.md
+++ b/docs/project/2026-08-28-discovery-survey.md
@@ -38,8 +38,8 @@ and 2 are correctly rejected by both native Zsh and zsh-lint.
 One of the 11, family F, turned out not to be a missing language feature at all
 but a composition defect in the adapter chain. It is fixed in this change; see
 family F below. Fixing it revealed one further real gap in `zi.zsh` that the
-defect had been masking (family K), so 10 gap families remain to be closed:
-A through E, G through K.
+defect had been masking (family K), and family G was subsequently fixed by
+#164. Nine gap families remain to be closed: A through E and H through K.
 
 ### Not parser gaps
 
@@ -146,7 +146,7 @@ Related to the closed reverse-subscript work (#15) but distinct: the existing
 out on anything else, so a `$name` expansion inside the search pattern is never
 handled. This gap was invisible until family F was fixed.
 
-### G. Anonymous function with a process-substitution redirect
+### G. Anonymous function with a process-substitution redirect, FIXED
 
     () {
       print -r -- "$1"
@@ -155,6 +155,9 @@ handled. This gap was invisible until family F was fixed.
 Error: `statements must be separated by &, ; or a newline`. Manual:
 `zshmisc`, anonymous functions and process substitution. Real site:
 `zpmod/tests/builtin/process_substitution_source.zsh:35`.
+
+Current `main` parses this construct after the anonymous-function argument
+adapter landed in #164 (`bcfba34`). It needs no parser-gap issue.
 
 ### H. `do;` with a leading separator
 
@@ -183,7 +186,7 @@ ranges. Real site: `zunit/src/commands/run.zsh:268`.
 
 ## Recommended handling
 
-Families A through E and G through K are one `parser-gap` + `corpus` issue each,
+Families A through E and H through K are one `parser-gap` + `corpus` issue each,
 per the workflow's one-feature-per-issue rule. Minimized sources become
 `gap-<issue>-<slug>.zsh` fixtures once the issue numbers exist.
 
@@ -195,8 +198,8 @@ first error per file. Family K was hidden behind it. Any future adapter work
 should assume more findings are masked and re-run this survey after each fix.
 
 Do **not** add these repositories to `corpus-paths.txt` yet. The strict gate
-requires zero errors and zero warnings, and these sources currently carry 11
-parse errors plus 213 warning-level diagnostics (dominated by
+requires zero errors and zero warnings. The recorded run carried 11
+native-valid parse failures plus 213 warning-level diagnostics (dominated by
 `quoting/unquoted-var` and `plugin/zero-handling`). Promotion follows the same
 sequence used on 2026-08-16: close the parser gaps, remediate consumer findings
 in the owning repository, then promote and re-run the complete gate.

--- a/docs/project/2026-08-28-discovery-survey.md
+++ b/docs/project/2026-08-28-discovery-survey.md
@@ -35,6 +35,12 @@ Tooling: `zsh-lint` `next` at `901f3f7`, Go 1.27.0, Zsh 5.9.2. File set is
 Of the 13 failures, 11 are genuine parser gaps (`zsh -f -n` accepts the source)
 and 2 are correctly rejected by both native Zsh and zsh-lint.
 
+One of the 11, family F, turned out not to be a missing language feature at all
+but a composition defect in the adapter chain. It is fixed in this change; see
+family F below. Fixing it revealed one further real gap in `zi.zsh` that the
+defect had been masking (family K), so 11 gap families remain to be closed:
+A through E, G through K.
+
 ### Not parser gaps
 
 `zpmod/tests/command/zpmod_bundle_build.zsh` and
@@ -90,36 +96,55 @@ Error: `` a command can only contain words and redirects; encountered `(` ``.
 Manual: `zshmisc`, alternate loop forms. Real site:
 `zi/tests/fixtures/public-contract/foreach/zi.zsh:15`.
 
-### F. GLOB_SUBST `${~name}` after an alternate brace-form `if`
+### F. GLOB_SUBST `${~name}` after an alternate brace-form `if`, FIXED
 
     if (( 1 )) { x=1 }
     p=${~q}
 
 Error: `` not a valid parameter expansion operator: `~` ``. Manual: `zshexpn`,
-GLOB_SUBST `${~spec}`. Real site: `zi/zi.zsh:48`.
+GLOB_SUBST `${~spec}`. Real site: `zi/zi.zsh:51`.
 
-This one is different in kind from the others and is the most important finding
-in this run. `${~q}` on its own parses correctly, and the same statement after a
-classic `if ...; then ...; fi` also parses correctly. The failure appears only
-when an alternate brace-form `if` precedes it in the same file:
+This was not a parser gap. It was a composition defect in the adapter chain, and
+it has been fixed in this same change. `${~q}` parsed on its own, and after a
+classic `if ...; then ...; fi`, but not after an alternate brace-form `if`.
 
-    p=${~q}                          # parses
-    if (( 1 )); then x=1; fi         # parses
-    p=${~q}
-    if (( 1 )) { x=1 }               # FAILS
-    p=${~q}
+Root cause: each adapter re-parsed its masked source through a hardcoded list of
+peers rather than the full adapter set. `parseAfterAlternateIf` named exactly
+two peers, so any _other_ Zsh feature in the same file failed. Measured before
+the fix: **40 of 42 ordered pairs** of distinct adapter features failed to parse,
+though every feature parsed alone and native Zsh accepted every combination.
 
-So this is not a missing language feature. It is an interaction defect in the
-existing alternate brace-form `if` compatibility adapter
-(`ok-alternate-if-brace.zsh`), which appears to leave state that corrupts
-parsing of a later `${~...}`. Isolated by line-level delta debugging over
-`zi.zsh`, which reduced 48 lines to exactly these two.
+Fix: `internal/parse/adapter_chain.go` introduces one ordered chain that both
+`Parse` and every adapter retry through, so adapters compose in any order.
+Regression coverage in `internal/parse/adapter_chain_test.go` asserts all
+ordered pairs, all features together, original-text restoration, and continued
+rejection of invalid Zsh.
 
-This violates the adapter contract in `parser-gap-workflow.md`: an adapter must
-activate for one exact error and one construct, and must restore every
-transformed byte. It should be filed as an adapter-correctness bug rather than a
-`parser-gap`, and it should be fixed before further adapters are added, since
-the same class of latent interaction may already be masking other results.
+Fixing this exposed a second, opposite defect. Routing the grouped-case adapter
+through the chain let it re-enter itself, masking one extra `)` per pass until
+`case x in (x|y))) : ;; esac` parsed, which native Zsh rejects. Composition must
+therefore be permissive across _distinct_ adapters but not unbounded within one:
+most adapters mask a single occurrence per pass and legitimately re-enter
+themselves for a second occurrence, while an adapter whose masking would widen
+its own grammar opts out through `retryExcluding`. Both directions are pinned by
+tests.
+
+Confirming the masking this caused: `zi.zsh` previously reported its first error
+at line 51. With the chain fixed it parses past that point and reports a genuine,
+previously hidden gap at line 382, recorded as family K below.
+
+### K. Reverse-subscript pattern containing a parameter expansion
+
+    print -r -- ${a[(r)$d/*]}
+
+Error: `` `/` must be followed by an expression ``. Manual: `zshparam`,
+subscript flags. Real site: `zi/zi.zsh:382`
+(`${fpath[(r)$PLUGIN_DIR/*]}`).
+
+Related to the closed reverse-subscript work (#15) but distinct: the existing
+`(iIrR)` scanner only masks literal `-`, `*`, and `?` pattern bytes and bails
+out on anything else, so a `$name` expansion inside the search pattern is never
+handled. This gap was invisible until family F was fixed.
 
 ### G. Anonymous function with a process-substitution redirect
 
@@ -158,14 +183,16 @@ ranges. Real site: `zunit/src/commands/run.zsh:268`.
 
 ## Recommended handling
 
-Families A through E and G through J are one `parser-gap` + `corpus` issue each,
+Families A through E and G through K are one `parser-gap` + `corpus` issue each,
 per the workflow's one-feature-per-issue rule. Minimized sources become
 `gap-<issue>-<slug>.zsh` fixtures once the issue numbers exist.
 
-Family F is not a parser gap and must not be filed as one. It is a correctness
-bug in an already-shipped adapter and should be prioritized above the new
-feature work, because an adapter that corrupts later parsing can produce both
-false failures and, more dangerously, masked findings anywhere in the corpus.
+Family F needed no issue: it was an adapter-composition defect, not a language
+gap, and it is fixed in this change with regression coverage. Its lesson is
+worth keeping, though. A defective adapter does not only produce false
+failures, it silently _masks_ real ones, because the survey reports just the
+first error per file. Family K was hidden behind it. Any future adapter work
+should assume more findings are masked and re-run this survey after each fix.
 
 Do **not** add these repositories to `corpus-paths.txt` yet. The strict gate
 requires zero errors and zero warnings, and these sources currently carry 11

--- a/docs/project/2026-08-28-discovery-survey.md
+++ b/docs/project/2026-08-28-discovery-survey.md
@@ -32,13 +32,13 @@ Tooling: `zsh-lint` `next` at `901f3f7`, Go 1.27.0, Zsh 5.9.2. File set is
 | `zunit`    | 15    | 14     | 1      |
 | **Total**  | 101   | 88     | 13     |
 
-Of the 13 failures, 11 are genuine parser gaps (`zsh -f -n` accepts the source)
+Of the 13 failures, 11 occur in native-valid sources (`zsh -f -n` accepts them)
 and 2 are correctly rejected by both native Zsh and zsh-lint.
 
 One of the 11, family F, turned out not to be a missing language feature at all
 but a composition defect in the adapter chain. It is fixed in this change; see
 family F below. Fixing it revealed one further real gap in `zi.zsh` that the
-defect had been masking (family K), so 11 gap families remain to be closed:
+defect had been masking (family K), so 10 gap families remain to be closed:
 A through E, G through K.
 
 ### Not parser gaps

--- a/docs/project/2026-08-28-discovery-survey.md
+++ b/docs/project/2026-08-28-discovery-survey.md
@@ -1,0 +1,188 @@
+# Organization Discovery Survey, 2026-08-28
+
+Scope: parser coverage for Z-Shell repositories that are **not** in the strict
+reference corpus (`corpus.md`). This is a discovery run under
+[parser-gap-workflow.md](parser-gap-workflow.md) step 1, not a gate result.
+
+The strict corpus covers 6 repositories and 20 files. The three repositories
+below hold the largest Zsh sources in the organization and contribute nothing
+to it, so parser gaps in them are invisible to the current gate.
+
+## Run inputs
+
+| Repository      | Revision   | Branch surveyed            |
+| --------------- | ---------- | -------------------------- |
+| `z-shell/zi`    | `2d52795b` | `feature-553`              |
+| `z-shell/zpmod` | `1b35bcb4` | `code/issue-107-xdg-paths` |
+| `z-shell/zunit` | `10b1e58f` | `main`                     |
+
+`zi` and `zpmod` were surveyed at the meta-workspace's checked-out development
+branches, not `main`. Re-run against `main` before treating any count here as a
+released-state baseline.
+
+Tooling: `zsh-lint` `next` at `901f3f7`, Go 1.27.0, Zsh 5.9.2. File set is
+`*.zsh`, `zshrc`, and `zshenv`, with `.git` pruned.
+
+## Parser result
+
+| Repository | Files | Parsed | Failed |
+| ---------- | ----- | ------ | ------ |
+| `zpmod`    | 58    | 53     | 5      |
+| `zi`       | 28    | 21     | 7      |
+| `zunit`    | 15    | 14     | 1      |
+| **Total**  | 101   | 88     | 13     |
+
+Of the 13 failures, 11 are genuine parser gaps (`zsh -f -n` accepts the source)
+and 2 are correctly rejected by both native Zsh and zsh-lint.
+
+### Not parser gaps
+
+`zpmod/tests/command/zpmod_bundle_build.zsh` and
+`zpmod/tests/command/zpmod_compaudit_cache.zsh` use the ZUnit `TEST "name" { }`
+DSL, which is not plain Zsh. Native Zsh reports `parse error near '}'` for both.
+They must be excluded from any native-valid corpus rather than tracked as gaps.
+
+## Gap families
+
+Each construct below was minimized from the failing real file until only the
+reproducing feature remained, then validated in both directions: `zsh -f -n`
+accepts it and `cmd/zsh-lint-survey` still fails with the same error family.
+The survey reports only the first error per file, so a single repository may
+hold further gaps masked behind these.
+
+### A. Assignment inside parameter expansion
+
+    print -r -- ${${prev::=abc}:+set}
+
+Error: `` `=` must follow a name ``. Manual: `zshexpn`, `${name::=word}`.
+Real sites: `zi/lib/zsh/additional.zsh:13`, `zi/lib/zsh/side.zsh:314`. Both zi
+sites reduce to this one family.
+
+### B. Brace block terminated without a separator
+
+    { typeset -g COLS="$(tput cols)" } 2>/dev/null
+
+Error: `` reached EOF without matching `{` with `}` ``. Manual: `zshmisc`,
+complex commands. Real site: `zi/lib/zsh/git-process-output.zsh:11`. The
+redirect is incidental; the bare `{ cmd }` form fails on its own.
+
+### C. Alternation inside a backreference test pattern
+
+    while [[ $buf = (#b)[^"{}[]\\\"'":,]#(([\"{[]}\\\"'":,])|[\\](*))(*) ]]; do
+
+Error: `` not a valid test operator: `|` ``. Manual: `zshexpn`, filename
+generation and `(#b)` backreferences. Real site: `zi/lib/zsh/install.zsh:22`.
+
+### D. Exclusion operator inside a glob qualifier list
+
+    reply=( /tmp/**/_[^_.]*~*(*.zwc|*.md)(DN) )
+
+Error: `` `^` must follow an expression ``. Manual: `zshexpn`, `~` exclusion
+and `[^...]` character classes. Real site: `zi/lib/zsh/autoload.zsh:471`.
+
+### E. `foreach` loop form
+
+    foreach item (one)
+    print $item
+    end
+
+Error: `` a command can only contain words and redirects; encountered `(` ``.
+Manual: `zshmisc`, alternate loop forms. Real site:
+`zi/tests/fixtures/public-contract/foreach/zi.zsh:15`.
+
+### F. GLOB_SUBST `${~name}` after an alternate brace-form `if`
+
+    if (( 1 )) { x=1 }
+    p=${~q}
+
+Error: `` not a valid parameter expansion operator: `~` ``. Manual: `zshexpn`,
+GLOB_SUBST `${~spec}`. Real site: `zi/zi.zsh:48`.
+
+This one is different in kind from the others and is the most important finding
+in this run. `${~q}` on its own parses correctly, and the same statement after a
+classic `if ...; then ...; fi` also parses correctly. The failure appears only
+when an alternate brace-form `if` precedes it in the same file:
+
+    p=${~q}                          # parses
+    if (( 1 )); then x=1; fi         # parses
+    p=${~q}
+    if (( 1 )) { x=1 }               # FAILS
+    p=${~q}
+
+So this is not a missing language feature. It is an interaction defect in the
+existing alternate brace-form `if` compatibility adapter
+(`ok-alternate-if-brace.zsh`), which appears to leave state that corrupts
+parsing of a later `${~...}`. Isolated by line-level delta debugging over
+`zi.zsh`, which reduced 48 lines to exactly these two.
+
+This violates the adapter contract in `parser-gap-workflow.md`: an adapter must
+activate for one exact error and one construct, and must restore every
+transformed byte. It should be filed as an adapter-correctness bug rather than a
+`parser-gap`, and it should be fixed before further adapters are added, since
+the same class of latent interaction may already be masking other results.
+
+### G. Anonymous function with a process-substitution redirect
+
+    () {
+      print -r -- "$1"
+    } <(print -r -- 'x=1')
+
+Error: `statements must be separated by &, ; or a newline`. Manual:
+`zshmisc`, anonymous functions and process substitution. Real site:
+`zpmod/tests/builtin/process_substitution_source.zsh:35`.
+
+### H. `do;` with a leading separator
+
+    freload() { while (( $# )); do; unfunction $1; shift; done }
+
+Error: `` `while` statement must end with `done` ``. Manual: `zshmisc`.
+Real site: `zpmod/vendor/zsh/StartupFiles/zshrc:45`. This is upstream Zsh's own
+shipped startup file.
+
+### I. Subscript search with a numeric-range pattern
+
+    integer argi=${argv[(i)-<->]}
+
+Error: `` `-` must be followed by an expression ``. Manual: `zshparam`,
+subscript flags; `zshexpn`, `<->` numeric globbing. Real site:
+`zpmod/vendor/zsh/Test/ztst.zsh:93`, upstream Zsh's test harness. Related to
+the closed reverse-subscript work (#15) but distinct: the pattern is `<->`
+inside an `(i)` search, and it is preceded by `-`.
+
+### J. Arithmetic subscript range containing a nested subscript search
+
+    line=(a b); testname="${line[(( ${line[(i)[\']]}+1 )),(( ${line[(I)[\']]}-1 ))]}"
+
+Error: `` `[` must follow a name like a[i] ``. Manual: `zshparam`, subscript
+ranges. Real site: `zunit/src/commands/run.zsh:268`.
+
+## Recommended handling
+
+Families A through E and G through J are one `parser-gap` + `corpus` issue each,
+per the workflow's one-feature-per-issue rule. Minimized sources become
+`gap-<issue>-<slug>.zsh` fixtures once the issue numbers exist.
+
+Family F is not a parser gap and must not be filed as one. It is a correctness
+bug in an already-shipped adapter and should be prioritized above the new
+feature work, because an adapter that corrupts later parsing can produce both
+false failures and, more dangerously, masked findings anywhere in the corpus.
+
+Do **not** add these repositories to `corpus-paths.txt` yet. The strict gate
+requires zero errors and zero warnings, and these sources currently carry 11
+parse errors plus 213 warning-level diagnostics (dominated by
+`quoting/unquoted-var` and `plugin/zero-handling`). Promotion follows the same
+sequence used on 2026-08-16: close the parser gaps, remediate consumer findings
+in the owning repository, then promote and re-run the complete gate.
+
+## Analyzer load, non-gating
+
+Recorded so consumer remediation can be sized. Excludes `vendor/`.
+
+| Repository | Files | Errors | Warnings | Infos | Hints |
+| ---------- | ----- | ------ | -------- | ----- | ----- |
+| `zi`       | 28    | 7      | 20       | 0     | 0     |
+| `zpmod`    | 54    | 3      | 164      | 5     | 11    |
+| `zunit`    | 15    | 1      | 29       | 3     | 72    |
+
+Error counts are the `parse/error` diagnostics from the gaps above, not
+independent semantic findings.

--- a/docs/project/corpus.md
+++ b/docs/project/corpus.md
@@ -96,3 +96,16 @@ survey is insufficient: every corpus change must re-run the complete native,
 parser, unconfigured analyzer, configured analyzer, classification, and
 no-suppression gates. Reports under `docs/project/` record the revisions they
 ran against, so older reports stay interpretable.
+
+## Repositories outside the strict corpus
+
+`zi`, `zpmod`, and the untracked parts of `zunit` are deliberately not in the
+strict corpus yet: they still contain open parser gaps and warning-level
+findings, and adding them would turn a passing gate into a permanently failing
+one. `.github/workflows/discovery-survey.yml` surveys them on a non-gating
+weekly schedule so those gaps stay visible without blocking the gate. See
+[2026-08-28-discovery-survey.md](2026-08-28-discovery-survey.md).
+
+Promotion is the same sequence used for the current members: close the parser
+gaps, remediate consumer findings in the owning repository, then add the roots
+here and re-run the complete gate.

--- a/docs/project/parser-gap-workflow.md
+++ b/docs/project/parser-gap-workflow.md
@@ -92,6 +92,42 @@ If recognition or restoration is uncertain, return the parser error. Do not
 use generic error suppression, recovery ASTs, or a compatibility adapter to
 absorb a second untracked language feature.
 
+### Adapter composition
+
+Register every adapter in `adapterChain` (`internal/parse/adapter_chain.go`)
+and route its masked retry through `parseWithAdapters`. Never call `parseTree`
+directly for a retry, and never hand-write a list of peer adapters to compose
+with.
+
+A masked retry is an ordinary parse of a whole file. Any unrelated Zsh
+construct elsewhere in that file must still parse, so an adapter that retries
+through a subset of its peers makes correctness depend on which adapter happens
+to run first. That defect shipped once: `parseAfterAlternateIf` named exactly
+two peers, and 40 of 42 ordered pairs of adapter features failed to parse even
+though each parsed alone. It surfaced as `${~ZI[BIN_DIR]}` failing in
+`z-shell/zi` `zi.zsh` only because an alternate brace-form `if` appeared earlier
+in the file.
+
+Composition is permissive across distinct adapters, but it is not unbounded
+within one. Most adapters mask a single occurrence of their feature per pass and
+rely on re-entering themselves to reach a second occurrence, which is correct.
+An adapter whose repeated masking would widen its own accepted grammar must opt
+out by handing `retryExcluding(itself)` to its `*WithParser` helper. The
+grouped-case adapter needs this: allowed to recurse, it masked one extra `)` per
+pass and accepted `case x in (x|y))) : ;; esac`, which native Zsh rejects.
+
+Because the survey reports only the first error per file, this class of defect
+masks real gaps rather than merely reporting false ones. Fixing it immediately
+exposed a further genuine gap in the same file. Re-run the discovery survey
+after any adapter change and expect the reported set to shift.
+
+`internal/parse/adapter_chain_test.go` enforces all of this: every ordered pair
+of adapter features and all features together must parse; original text must be
+restored; invalid Zsh must still be rejected; self-recursion must not widen the
+grammar; and every snippet must genuinely require its adapter, so a snippet the
+base parser already accepts cannot make its cases vacuously pass. Adding an
+adapter to the chain extends that matrix automatically.
+
 A bounded local island may use source-mapped synthetic terminators only when
 the adapter verifies the original AST structure, invalid-syntax behavior, and
 every source position before returning the complete tree. This exception does

--- a/internal/parse/adapter_chain.go
+++ b/internal/parse/adapter_chain.go
@@ -1,0 +1,109 @@
+package parse
+
+import (
+	"reflect"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// adapterAttempt is one compatibility adapter's gated entry point. Each
+// receives the source, the name, and the concrete error the previous stage
+// produced, and either returns a tree or returns that same error unchanged
+// because its own gate did not match.
+type adapterAttempt func(src []byte, name string, firstErr error) (*syntax.File, error)
+
+// adapterChain returns the single ordered list of compatibility adapters.
+//
+// This is a function rather than a package-level variable on purpose: adapters
+// call parseWithAdapters for their masked retry, and parseWithAdapters reads
+// this list, so a package-level slice literal would be an initialization
+// cycle.
+//
+// Every adapter that masks source and re-parses must retry through
+// parseWithAdapters, not through parseTree and not through a hand-written
+// subset of its peers. A masked retry is still an ordinary parse of a whole
+// file, so any other Zsh construct anywhere in that file must remain
+// parseable.
+//
+// Before this chain existed, adapters composed through hardcoded short lists
+// (parseAfterAlternateIf named exactly two peers). That made composition
+// depend on which adapter happened to run first: 40 of 42 ordered pairs of
+// distinct adapter features failed to parse even though every feature parsed
+// in isolation and native Zsh accepted every combination. The observable bug
+// was `${~ZI[BIN_DIR]}` in z-shell/zi zi.zsh failing only because an alternate
+// brace-form `if` appeared earlier in the file.
+//
+// Adding an adapter means adding it here, once. Do not reintroduce per-adapter
+// composition lists.
+func adapterChain() []adapterAttempt {
+	return []adapterAttempt{
+		parseNestedConditionalAlternation,
+		parseAlternateIfBrace,
+		parseAssociativeSubscript,
+		parseRCExpandCaret,
+		parseReverseSubscript,
+		parseParamGlobToggle,
+		parseFdVarRedirect,
+		parseMultiNameFor,
+		parseTryAlways,
+		parseGroupedCasePattern,
+		parseANSICHeredocDelimiter,
+	}
+}
+
+// parseWithAdapters parses src, falling back through every compatibility
+// adapter in order. Each adapter is gated on its own concrete parser error, so
+// a non-matching adapter returns the incoming error untouched and the next one
+// sees it. When no adapter matches, the original parser error is returned.
+//
+// This is the retry entry point for adapters themselves. A masked source may
+// legitimately need a different adapter than the one that produced the mask.
+//
+// Most adapters mask one occurrence of their feature per pass and rely on
+// re-entering themselves to handle a second occurrence in the same file, so
+// self-recursion is allowed by default. An adapter whose masking would
+// otherwise widen its own accepted grammar must opt out with retryExcluding.
+// The grouped-case adapter is the current example: left to recurse, it masked
+// one extra `)` per pass and accepted `case x in (x|y))) : ;; esac`, which
+// native Zsh rejects.
+func parseWithAdapters(src []byte, name string) (*syntax.File, error) {
+	return parseWithAdaptersExcept(src, name, -1)
+}
+
+// parseWithAdaptersExcept is parseWithAdapters with the adapter at index skip
+// disabled for the whole nested retry, preventing self-recursion.
+func parseWithAdaptersExcept(src []byte, name string, skip int) (*syntax.File, error) {
+	tree, err := parseTree(src, name)
+	if err == nil {
+		return tree, nil
+	}
+	for index, attempt := range adapterChain() {
+		if index == skip {
+			continue
+		}
+		tree, attemptErr := attempt(src, name, err)
+		if attemptErr == nil {
+			return tree, nil
+		}
+		err = attemptErr
+	}
+	return nil, err
+}
+
+// retryExcluding returns the retry parser an adapter must hand to its
+// *WithParser helper: the full chain minus the caller itself. Adapters look
+// themselves up by function identity so the chain order stays the single
+// source of truth.
+func retryExcluding(self adapterAttempt) func([]byte, string) (*syntax.File, error) {
+	skip := -1
+	selfPtr := reflect.ValueOf(self).Pointer()
+	for index, attempt := range adapterChain() {
+		if reflect.ValueOf(attempt).Pointer() == selfPtr {
+			skip = index
+			break
+		}
+	}
+	return func(src []byte, name string) (*syntax.File, error) {
+		return parseWithAdaptersExcept(src, name, skip)
+	}
+}

--- a/internal/parse/adapter_chain_test.go
+++ b/internal/parse/adapter_chain_test.go
@@ -1,6 +1,7 @@
 package parse
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -22,15 +23,23 @@ import (
 // table used a plain `(a|b)` case arm, which needs no adapter, and so missed a
 // real composition failure in the grouped-case adapter. TestAdapterSnippets-
 // RequireAnAdapter pins that property.
-var adapterSnippets = map[string]string{
-	"alternateIf":      "if (( 1 )) { x=1 }",
-	"paramGlobToggle":  "p=${~q}",
-	"rcExpandCaret":    "print -- ${^manpath}",
-	"reverseSubscript": "print -r -- ${_comps[(I)-value-*]}",
-	"assocSubscript":   "print ${functions[.foo]}",
-	"tryAlways":        "{ true } always { true }",
-	"multiNameFor":     "for a b in 1 2; do print $a$b; done",
-	"groupedCase":      "case x in\n  (x|y)) : ;;\nesac",
+type adapterSnippet struct {
+	attempt adapterAttempt
+	source  string
+}
+
+var adapterSnippets = map[string]adapterSnippet{
+	"nestedConditional": {attempt: parseNestedConditionalAlternation, source: "[[ $line == ((a|b)|c) ]]"},
+	"alternateIf":       {attempt: parseAlternateIfBrace, source: "if (( 1 )) { x=1 }"},
+	"paramGlobToggle":   {attempt: parseParamGlobToggle, source: "p=${~q}"},
+	"rcExpandCaret":     {attempt: parseRCExpandCaret, source: "print -- ${^manpath}"},
+	"reverseSubscript":  {attempt: parseReverseSubscript, source: "print -r -- ${_comps[(I)-value-*]}"},
+	"assocSubscript":    {attempt: parseAssociativeSubscript, source: "print ${functions[.foo]}"},
+	"fdVarRedirect":     {attempt: parseFdVarRedirect, source: "exec {fd}>&-"},
+	"tryAlways":         {attempt: parseTryAlways, source: "{ true } always { true }"},
+	"multiNameFor":      {attempt: parseMultiNameFor, source: "for a b in 1 2; do print $a$b; done"},
+	"groupedCase":       {attempt: parseGroupedCasePattern, source: "case x in\n  (x|y)) : ;;\nesac"},
+	"ansiCHeredoc":      {attempt: parseANSICHeredocDelimiter, source: "cat <<$'E\\x4fF'\nbody\nEOF"},
 }
 
 func parseString(t *testing.T, src string) error {
@@ -44,7 +53,7 @@ func parseString(t *testing.T, src string) error {
 func TestAdapterSnippetsParseAlone(t *testing.T) {
 	for name, snippet := range adapterSnippets {
 		t.Run(name, func(t *testing.T) {
-			if err := parseString(t, "#!/usr/bin/env zsh\n"+snippet+"\n"); err != nil {
+			if err := parseString(t, "#!/usr/bin/env zsh\n"+snippet.source+"\n"); err != nil {
 				t.Fatalf("snippet must parse alone: %v", err)
 			}
 		})
@@ -58,9 +67,9 @@ func TestAdapterSnippetsParseAlone(t *testing.T) {
 func TestAdapterSnippetsRequireAnAdapter(t *testing.T) {
 	for name, snippet := range adapterSnippets {
 		t.Run(name, func(t *testing.T) {
-			src := []byte("#!/usr/bin/env zsh\n" + snippet + "\n")
+			src := []byte("#!/usr/bin/env zsh\n" + snippet.source + "\n")
 			if _, err := parseTree(src, "compose_test.zsh"); err == nil {
-				t.Fatalf("snippet needs no adapter, so it cannot detect a composition defect: %q", snippet)
+				t.Fatalf("snippet needs no adapter, so it cannot detect a composition defect: %q", snippet.source)
 			}
 			if _, err := parseWithAdapters(src, "compose_test.zsh"); err != nil {
 				t.Fatalf("snippet must parse through the adapter chain: %v", err)
@@ -72,8 +81,21 @@ func TestAdapterSnippetsRequireAnAdapter(t *testing.T) {
 // TestAdapterChainCoversEveryAdapter keeps the snippet table honest as the
 // chain grows: every registered adapter should be represented above.
 func TestAdapterChainCoversEveryAdapter(t *testing.T) {
-	if got, want := len(adapterSnippets), len(adapterChain()); got > want {
-		t.Fatalf("more snippets (%d) than registered adapters (%d)", got, want)
+	if got, want := len(adapterSnippets), len(adapterChain()); got != want {
+		t.Fatalf("adapter snippets = %d, registered adapters = %d", got, want)
+	}
+	represented := make(map[uintptr]string, len(adapterSnippets))
+	for name, snippet := range adapterSnippets {
+		pointer := reflect.ValueOf(snippet.attempt).Pointer()
+		if previous := represented[pointer]; previous != "" {
+			t.Fatalf("adapter snippets %q and %q represent the same adapter", previous, name)
+		}
+		represented[pointer] = name
+	}
+	for _, attempt := range adapterChain() {
+		if represented[reflect.ValueOf(attempt).Pointer()] == "" {
+			t.Fatal("registered adapter has no composition snippet")
+		}
 	}
 }
 
@@ -88,7 +110,7 @@ func TestAdapterCompositionAllOrderedPairs(t *testing.T) {
 				continue
 			}
 			t.Run(firstName+"_then_"+secondName, func(t *testing.T) {
-				src := "#!/usr/bin/env zsh\n" + first + "\n" + second + "\n"
+				src := "#!/usr/bin/env zsh\n" + first.source + "\n" + second.source + "\n"
 				if err := parseString(t, src); err != nil {
 					t.Fatalf("composition must parse:\n%s\nerror: %v", src, err)
 				}
@@ -105,7 +127,7 @@ func TestAdapterCompositionAllFeaturesTogether(t *testing.T) {
 	// Map order is randomized by Go; that is deliberate extra coverage here,
 	// since no ordering may matter.
 	for _, snippet := range adapterSnippets {
-		b.WriteString(snippet)
+		b.WriteString(snippet.source)
 		b.WriteString("\n")
 	}
 	if err := parseString(t, b.String()); err != nil {

--- a/internal/parse/adapter_chain_test.go
+++ b/internal/parse/adapter_chain_test.go
@@ -1,0 +1,181 @@
+package parse
+
+import (
+	"strings"
+	"testing"
+
+	"mvdan.cc/sh/v3/syntax"
+)
+
+// Each snippet below is valid Zsh that requires exactly one compatibility
+// adapter. Every one parses correctly on its own. Composition is what breaks:
+// before the unified adapter chain, an adapter's retry re-parsed the masked
+// source through a hardcoded short list of other adapters, so a second
+// unrelated Zsh feature elsewhere in the same file failed to parse.
+//
+// Discovered in z-shell/zi zi.zsh, where `${~ZI[BIN_DIR]}` failed only because
+// an alternate brace-form `if` appeared earlier in the file.
+// See docs/project/2026-08-28-discovery-survey.md family F.
+//
+// Each snippet must actually trigger its adapter. A snippet that the base
+// parser already accepts silently tests nothing: an earlier version of this
+// table used a plain `(a|b)` case arm, which needs no adapter, and so missed a
+// real composition failure in the grouped-case adapter. TestAdapterSnippets-
+// RequireAnAdapter pins that property.
+var adapterSnippets = map[string]string{
+	"alternateIf":      "if (( 1 )) { x=1 }",
+	"paramGlobToggle":  "p=${~q}",
+	"rcExpandCaret":    "print -- ${^manpath}",
+	"reverseSubscript": "print -r -- ${_comps[(I)-value-*]}",
+	"assocSubscript":   "print ${functions[.foo]}",
+	"tryAlways":        "{ true } always { true }",
+	"multiNameFor":     "for a b in 1 2; do print $a$b; done",
+	"groupedCase":      "case x in\n  (x|y)) : ;;\nesac",
+}
+
+func parseString(t *testing.T, src string) error {
+	t.Helper()
+	_, err := Parse(strings.NewReader(src), "compose_test.zsh")
+	return err
+}
+
+// TestAdapterSnippetsParseAlone is the control: every snippet must parse on
+// its own. A failure here means the snippet is wrong, not the chain.
+func TestAdapterSnippetsParseAlone(t *testing.T) {
+	for name, snippet := range adapterSnippets {
+		t.Run(name, func(t *testing.T) {
+			if err := parseString(t, "#!/usr/bin/env zsh\n"+snippet+"\n"); err != nil {
+				t.Fatalf("snippet must parse alone: %v", err)
+			}
+		})
+	}
+}
+
+// TestAdapterSnippetsRequireAnAdapter guards the test data itself. Each
+// snippet must FAIL the bare parser and only succeed through the adapter
+// chain. Without this, a snippet the base parser already handles would make
+// its composition cases vacuously pass and hide a real defect.
+func TestAdapterSnippetsRequireAnAdapter(t *testing.T) {
+	for name, snippet := range adapterSnippets {
+		t.Run(name, func(t *testing.T) {
+			src := []byte("#!/usr/bin/env zsh\n" + snippet + "\n")
+			if _, err := parseTree(src, "compose_test.zsh"); err == nil {
+				t.Fatalf("snippet needs no adapter, so it cannot detect a composition defect: %q", snippet)
+			}
+			if _, err := parseWithAdapters(src, "compose_test.zsh"); err != nil {
+				t.Fatalf("snippet must parse through the adapter chain: %v", err)
+			}
+		})
+	}
+}
+
+// TestAdapterChainCoversEveryAdapter keeps the snippet table honest as the
+// chain grows: every registered adapter should be represented above.
+func TestAdapterChainCoversEveryAdapter(t *testing.T) {
+	if got, want := len(adapterSnippets), len(adapterChain()); got > want {
+		t.Fatalf("more snippets (%d) than registered adapters (%d)", got, want)
+	}
+}
+
+// TestAdapterCompositionAllOrderedPairs is the regression gate. Every ordered
+// pair of distinct adapter features in one file must parse, in both orders.
+// Zsh imposes no ordering constraint between these constructs, so neither may
+// the front end.
+func TestAdapterCompositionAllOrderedPairs(t *testing.T) {
+	for firstName, first := range adapterSnippets {
+		for secondName, second := range adapterSnippets {
+			if firstName == secondName {
+				continue
+			}
+			t.Run(firstName+"_then_"+secondName, func(t *testing.T) {
+				src := "#!/usr/bin/env zsh\n" + first + "\n" + second + "\n"
+				if err := parseString(t, src); err != nil {
+					t.Fatalf("composition must parse:\n%s\nerror: %v", src, err)
+				}
+			})
+		}
+	}
+}
+
+// TestAdapterCompositionAllFeaturesTogether puts every adapter feature in a
+// single file, which is closer to a real loader than any pair.
+func TestAdapterCompositionAllFeaturesTogether(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("#!/usr/bin/env zsh\n")
+	// Map order is randomized by Go; that is deliberate extra coverage here,
+	// since no ordering may matter.
+	for _, snippet := range adapterSnippets {
+		b.WriteString(snippet)
+		b.WriteString("\n")
+	}
+	if err := parseString(t, b.String()); err != nil {
+		t.Fatalf("all features together must parse:\n%s\nerror: %v", b.String(), err)
+	}
+}
+
+// TestGlobSubstAfterAlternateIf pins the exact minimized reproduction from
+// zi.zsh so the original defect cannot regress silently.
+func TestGlobSubstAfterAlternateIf(t *testing.T) {
+	src := "#!/usr/bin/env zsh\nif (( 1 )) { x=1 }\np=${~q}\n"
+	if err := parseString(t, src); err != nil {
+		t.Fatalf("GLOB_SUBST after alternate brace-form if must parse: %v", err)
+	}
+}
+
+// TestCompositionPreservesOriginalText proves the chain restores every masked
+// byte. A composition that parses but returns rewritten literals would corrupt
+// downstream rules and suppression handling, which is worse than a parse error.
+func TestCompositionPreservesOriginalText(t *testing.T) {
+	src := "#!/usr/bin/env zsh\nif (( 1 )) { x=1 }\np=${~q}\nprint -- ${^manpath}\n"
+	file, err := Parse(strings.NewReader(src), "compose_test.zsh")
+	if err != nil {
+		t.Fatalf("composition must parse: %v", err)
+	}
+	printed := &strings.Builder{}
+	if err := syntax.NewPrinter().Print(printed, file.AST()); err != nil {
+		t.Fatalf("printing tree: %v", err)
+	}
+	for _, want := range []string{"${~q}", "${^manpath}"} {
+		if !strings.Contains(printed.String(), want) {
+			t.Errorf("original text %q not restored in AST; got:\n%s", want, printed.String())
+		}
+	}
+}
+
+// TestAdapterSelfRecursionDoesNotWidenGrammar pins the second defect found
+// while building the chain. Composition must not let an adapter apply its own
+// masking repeatedly until invalid Zsh parses. Each source below is rejected
+// by native `zsh -f -n` and must stay rejected.
+func TestAdapterSelfRecursionDoesNotWidenGrammar(t *testing.T) {
+	cases := map[string]string{
+		"triple closing paren": "case x in\n  (x|y))) : ;;\nesac\n",
+		"quadruple paren":      "case x in\n  (x|y)))) : ;;\nesac\n",
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := parseString(t, src); err == nil {
+				t.Fatalf("adapter self-recursion widened the accepted grammar:\n%s", src)
+			}
+		})
+	}
+}
+
+// TestInvalidSyntaxStillRejectedAfterComposition guards the opposite contract:
+// a more permissive chain must not start accepting invalid Zsh. Each source
+// below is rejected by native `zsh -f -n`.
+func TestInvalidSyntaxStillRejectedAfterComposition(t *testing.T) {
+	cases := map[string]string{
+		"unclosed brace group":   "if (( 1 )) { x=1 }\n{ print hi\n",
+		"unterminated expansion": "if (( 1 )) { x=1 }\np=${~\n",
+		"bare reserved word":     "if (( 1 )) { x=1 }\nfi\n",
+		"unclosed subscript":     "if (( 1 )) { x=1 }\nprint ${a[(I)x\n",
+		"stray closing paren":    "if (( 1 )) { x=1 }\nprint )\n",
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := parseString(t, "#!/usr/bin/env zsh\n"+src); err == nil {
+				t.Fatalf("invalid Zsh must still be rejected:\n%s", src)
+			}
+		})
+	}
+}

--- a/internal/parse/alternate_if.go
+++ b/internal/parse/alternate_if.go
@@ -35,21 +35,7 @@ type alternateIfSourceMap struct {
 }
 
 func parseAlternateIfBrace(src []byte, name string, firstErr error) (*syntax.File, error) {
-	return parseAlternateIfBraceWithParser(src, name, firstErr, parseAfterAlternateIf)
-}
-
-// parseAfterAlternateIf lets independently gated, same-boundary adapters
-// compose when one real file contains more than one unsupported Zsh form.
-// Each adapter still activates only from its own concrete parser error.
-func parseAfterAlternateIf(src []byte, name string) (*syntax.File, error) {
-	tree, err := parseTree(src, name)
-	if err != nil {
-		tree, err = parseAssociativeSubscriptWithParser(src, name, err, parseAfterAlternateIf)
-		if err != nil {
-			tree, err = parseMultiNameForWithParser(src, name, err, parseAfterAlternateIf)
-		}
-	}
-	return tree, err
+	return parseAlternateIfBraceWithParser(src, name, firstErr, parseWithAdapters)
 }
 
 func parseAlternateIfBraceWithParser(

--- a/internal/parse/anonymous_function_args.go
+++ b/internal/parse/anonymous_function_args.go
@@ -43,7 +43,7 @@ func parseAnonymousFunctionArgs(
 			}
 		}
 
-		tree, err := parseCompatibleTree(masked, name)
+		tree, err := parseWithAdapters(masked, name)
 		if err != nil {
 			currentErr = err
 			continue
@@ -92,7 +92,7 @@ func prefixEndsWithAnonymousFunction(src []byte, name string, close int) bool {
 			prefix[offset] = ' '
 		}
 	}
-	tree, err := parseCompatibleTree(prefix, name)
+	tree, err := parseWithAdapters(prefix, name)
 	if err != nil {
 		return false
 	}
@@ -222,7 +222,7 @@ func parseAnonymousInvocationWords(src []byte, name string, close, end int) ([]*
 	}
 	island[close] = ':'
 	copy(island[close+1:end], src[close+1:end])
-	tree, err := parseCompatibleTree(island, name)
+	tree, err := parseWithAdapters(island, name)
 	if err != nil {
 		return nil, false
 	}

--- a/internal/parse/grouped_case_pattern.go
+++ b/internal/parse/grouped_case_pattern.go
@@ -39,7 +39,7 @@ func parseGroupedCasePattern(src []byte, name string, firstErr error) (*syntax.F
 		}
 		masked[edit.offset] = edit.replacement
 	}
-	tree, err := parseTree(masked, name)
+	tree, err := retryExcluding(parseGroupedCasePattern)(masked, name)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/parse/heredoc_compat.go
+++ b/internal/parse/heredoc_compat.go
@@ -17,15 +17,7 @@ const unclosedHeredocPrefix = "unclosed here-document"
 // ANSI-C delimiter, runs a same-width padded retry, and restores the original
 // ANSI-C literal in the resulting AST.
 func parseANSICHeredocDelimiter(src []byte, name string, firstErr error) (*syntax.File, error) {
-	return parseANSICHeredocDelimiterWithParser(src, name, firstErr, parseANSICHeredocDelimiters)
-}
-
-func parseANSICHeredocDelimiters(src []byte, name string) (*syntax.File, error) {
-	tree, err := parseTree(src, name)
-	if err != nil {
-		return parseANSICHeredocDelimiterWithParser(src, name, err, parseANSICHeredocDelimiters)
-	}
-	return tree, nil
+	return parseANSICHeredocDelimiterWithParser(src, name, firstErr, parseWithAdapters)
 }
 
 func parseANSICHeredocDelimiterWithParser(

--- a/internal/parse/multi_name_for.go
+++ b/internal/parse/multi_name_for.go
@@ -32,7 +32,7 @@ type forSourceMap struct {
 }
 
 func parseMultiNameFor(src []byte, name string, firstErr error) (*syntax.File, error) {
-	return parseMultiNameForWithParser(src, name, firstErr, parseTree)
+	return parseMultiNameForWithParser(src, name, firstErr, parseWithAdapters)
 }
 
 func parseMultiNameForWithParser(

--- a/internal/parse/nested_conditional_pattern.go
+++ b/internal/parse/nested_conditional_pattern.go
@@ -158,7 +158,7 @@ type nestedPatternCompatibilityBatch struct {
 }
 
 func parseNestedConditionalAlternation(src []byte, name string, firstErr error) (*syntax.File, error) {
-	return parseNestedConditionalAlternationWithParser(src, name, firstErr, parseTree)
+	return parseNestedConditionalAlternationWithParser(src, name, firstErr, parseWithAdapters)
 }
 
 func parseNestedConditionalAlternationWithParser(

--- a/internal/parse/parameter_compat.go
+++ b/internal/parse/parameter_compat.go
@@ -13,15 +13,7 @@ const (
 )
 
 func parseParamGlobToggle(src []byte, name string, firstErr error) (*syntax.File, error) {
-	return parseParamGlobToggleWithParser(src, name, firstErr, parseParamGlobToggles)
-}
-
-func parseParamGlobToggles(src []byte, name string) (*syntax.File, error) {
-	tree, err := parseTree(src, name)
-	if err != nil {
-		return parseParamGlobToggleWithParser(src, name, err, parseParamGlobToggles)
-	}
-	return tree, nil
+	return parseParamGlobToggleWithParser(src, name, firstErr, parseWithAdapters)
 }
 
 func parseParamGlobToggleWithParser(
@@ -53,15 +45,7 @@ func parseParamGlobToggleWithParser(
 }
 
 func parseRCExpandCaret(src []byte, name string, firstErr error) (*syntax.File, error) {
-	return parseRCExpandCaretWithParser(src, name, firstErr, parseRCExpandCarets)
-}
-
-func parseRCExpandCarets(src []byte, name string) (*syntax.File, error) {
-	tree, err := parseTree(src, name)
-	if err != nil {
-		return parseRCExpandCaretWithParser(src, name, err, parseRCExpandCarets)
-	}
-	return tree, nil
+	return parseRCExpandCaretWithParser(src, name, firstErr, parseWithAdapters)
 }
 
 func parseRCExpandCaretWithParser(
@@ -100,15 +84,7 @@ func parseRCExpandCaretWithParser(
 }
 
 func parseReverseSubscript(src []byte, name string, firstErr error) (*syntax.File, error) {
-	return parseReverseSubscriptWithParser(src, name, firstErr, parseReverseSubscripts)
-}
-
-func parseReverseSubscripts(src []byte, name string) (*syntax.File, error) {
-	tree, err := parseTree(src, name)
-	if err != nil {
-		return parseReverseSubscriptWithParser(src, name, err, parseReverseSubscripts)
-	}
-	return tree, nil
+	return parseReverseSubscriptWithParser(src, name, firstErr, parseWithAdapters)
 }
 
 func parseReverseSubscriptWithParser(

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -66,38 +66,6 @@ func parseTree(src []byte, name string) (*syntax.File, error) {
 	return parser.Parse(bytes.NewReader(src), name)
 }
 
-type compatibilityParser func([]byte, string, error) (*syntax.File, error)
-
-// parseCompatibleTree applies the established byte-preserving adapters in
-// order. Anonymous-function invocation arguments are handled separately
-// because their words live in File metadata rather than the upstream AST.
-func parseCompatibleTree(src []byte, name string) (*syntax.File, error) {
-	tree, err := parseTree(src, name)
-	if err == nil {
-		return tree, nil
-	}
-	adapters := []compatibilityParser{
-		parseNestedConditionalAlternation,
-		parseAlternateIfBrace,
-		parseAssociativeSubscript,
-		parseRCExpandCaret,
-		parseReverseSubscript,
-		parseParamGlobToggle,
-		parseFdVarRedirect,
-		parseMultiNameFor,
-		parseTryAlways,
-		parseGroupedCasePattern,
-		parseANSICHeredocDelimiter,
-	}
-	for _, adapter := range adapters {
-		tree, err = adapter(src, name, err)
-		if err == nil {
-			return tree, nil
-		}
-	}
-	return nil, err
-}
-
 // Parse parses a single Zsh source read from r, using name in error
 // messages. It returns the parsed source or a parse error.
 func Parse(r io.Reader, name string) (*File, error) {
@@ -105,7 +73,7 @@ func Parse(r io.Reader, name string) (*File, error) {
 	if err != nil {
 		return nil, err
 	}
-	tree, err := parseCompatibleTree(src, name)
+	tree, err := parseWithAdapters(src, name)
 	var anonymousInvocations []AnonymousInvocation
 	if err != nil {
 		tree, anonymousInvocations, err = parseAnonymousFunctionArgs(src, name, err)

--- a/internal/parse/redirect_compat.go
+++ b/internal/parse/redirect_compat.go
@@ -16,15 +16,7 @@ func isIdentStartByte(b byte) bool {
 // feature. The retry masks the {varname} delimiter with a same-width numeric file
 // descriptor and restores the AST literal node on the resulting syntax.Redirect.
 func parseFdVarRedirect(src []byte, name string, firstErr error) (*syntax.File, error) {
-	return parseFdVarRedirectWithParser(src, name, firstErr, parseFdVarRedirects)
-}
-
-func parseFdVarRedirects(src []byte, name string) (*syntax.File, error) {
-	tree, err := parseTree(src, name)
-	if err != nil {
-		return parseFdVarRedirectWithParser(src, name, err, parseFdVarRedirects)
-	}
-	return tree, nil
+	return parseFdVarRedirectWithParser(src, name, firstErr, parseWithAdapters)
 }
 
 func parseFdVarRedirectWithParser(

--- a/internal/parse/subscript_compat.go
+++ b/internal/parse/subscript_compat.go
@@ -16,15 +16,7 @@ const (
 // mvdan/sh mistakes for arithmetic syntax. The retry masks punctuation with
 // same-width identifier bytes and restores every changed AST literal.
 func parseAssociativeSubscript(src []byte, name string, firstErr error) (*syntax.File, error) {
-	return parseAssociativeSubscriptWithParser(src, name, firstErr, parseAssociativeSubscripts)
-}
-
-func parseAssociativeSubscripts(src []byte, name string) (*syntax.File, error) {
-	tree, err := parseTree(src, name)
-	if err != nil {
-		return parseAssociativeSubscriptWithParser(src, name, err, parseAssociativeSubscripts)
-	}
-	return tree, nil
+	return parseAssociativeSubscriptWithParser(src, name, firstErr, parseWithAdapters)
 }
 
 func parseAssociativeSubscriptWithParser(

--- a/internal/parse/try_always.go
+++ b/internal/parse/try_always.go
@@ -12,7 +12,7 @@ const tryAlwaysParseError = "statements must be separated by &, ; or a newline"
 // try/always boundary. The fixed-width transformation keeps every original
 // byte offset valid for the returned syntax tree.
 func parseTryAlways(src []byte, name string, firstErr error) (*syntax.File, error) {
-	return parseTryAlwaysWithParser(src, name, firstErr, parseTree)
+	return parseTryAlwaysWithParser(src, name, firstErr, parseWithAdapters)
 }
 
 func parseTryAlwaysWithParser(


### PR DESCRIPTION
## Summary

- add a weekly, non-gating discovery survey for native-valid Zsh sources in zi, zpmod, and zunit
- replace per-adapter retry lists with one ordered compatibility chain and preserve anonymous-function invocation metadata
- document the first organization survey, adapter composition contract, and the 9 remaining parser-gap families

## Verification

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `trunk check --no-fix --ci --filter=-gitleaks`
- direct gitleaks 8.30.1 repository scan
- `git diff --check`

Supports #183 without closing its broader source-discovery design scope.
